### PR TITLE
feat: add teacher endpoints for admin interface

### DIFF
--- a/prisma/migrations/20250824150356_add_teacher_fields_and_user_last_login/migration.sql
+++ b/prisma/migrations/20250824150356_add_teacher_fields_and_user_last_login/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "TeacherStatus" AS ENUM ('ACTIVE', 'INACTIVE', 'ON_LEAVE');
+
+-- CreateEnum
+CREATE TYPE "EmploymentType" AS ENUM ('FULL_TIME', 'PART_TIME', 'CONTRACT');
+
+-- AlterTable
+ALTER TABLE "teachers" ADD COLUMN     "employmentType" "EmploymentType" NOT NULL DEFAULT 'FULL_TIME',
+ADD COLUMN     "joinDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "qualification" TEXT,
+ADD COLUMN     "status" "TeacherStatus" NOT NULL DEFAULT 'ACTIVE';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "lastLoginAt" TIMESTAMP(3);

--- a/prisma/migrations/20250824153757_add_department_to_teacher/migration.sql
+++ b/prisma/migrations/20250824153757_add_department_to_teacher/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "teachers" ADD COLUMN     "departmentId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "teachers" ADD CONSTRAINT "teachers_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "departments"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,18 @@ enum Gender {
   FEMALE
 }
 
+enum TeacherStatus {
+  ACTIVE
+  INACTIVE
+  ON_LEAVE
+}
+
+enum EmploymentType {
+  FULL_TIME
+  PART_TIME
+  CONTRACT
+}
+
 // --- Address Management ---
 
 /**
@@ -252,6 +264,7 @@ model Department {
   school    School     @relation(fields: [schoolId], references: [id])
   subjects  Subject[]
   classArms ClassArm[]
+  teachers  Teacher[]  // Teachers assigned to this department
 
   hod       Hod?
   createdAt DateTime  @default(now())
@@ -324,6 +337,7 @@ model User {
   address            Address?    @relation(fields: [addressId], references: [id])
   avatarUrl          String?
   dateOfBirth        DateTime?
+  lastLoginAt        DateTime?    // Track when user last logged in
   schoolId           String?
   school             School?      @relation(fields: [schoolId], references: [id])
   mustUpdatePassword Boolean     @default(false)
@@ -419,6 +433,12 @@ model Teacher {
   userId                  String                   @unique
   user                    User                     @relation(fields: [userId], references: [id])
   teacherNo               String                   @unique
+  departmentId            String?                  // Direct department assignment
+  department              Department?              @relation(fields: [departmentId], references: [id])
+  status                  TeacherStatus            @default(ACTIVE)
+  employmentType          EmploymentType           @default(FULL_TIME)
+  qualification           String?                  // Teacher's educational qualification
+  joinDate                DateTime                 @default(now())
   hod                     Hod[]
   classArmTeachers        ClassArmTeacher[]
   classArmSubjectTeachers ClassArmSubjectTeacher[]

--- a/src/components/bff/admin/bff-admin.controller.ts
+++ b/src/components/bff/admin/bff-admin.controller.ts
@@ -9,7 +9,9 @@ import { ManageStudentPolicyHandler } from '../../students/policies';
 import { BffAdminService } from './bff-admin.service';
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
 import { AdminClassroomsViewResult } from './results/admin-classrooms-view.result';
+import { AdminTeachersViewResult } from './results/admin-teachers-view.result';
 import { SingleStudentDetailsResult } from './results/single-student-details.result';
+import { SingleTeacherDetailsResult } from './results/single-teacher-details.result';
 import { StudentDetailsResult } from './results/student-details.result';
 
 @Controller('bff/admin')
@@ -28,6 +30,39 @@ export class BffAdminController {
   async getClassroomsView(@GetCurrentUserId() userId: string) {
     const data = await this.bffAdminService.getClassroomsViewData(userId);
     return new AdminClassroomsViewResult(data);
+  }
+
+  @Get('teachers-view')
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: AdminTeachersViewResult,
+    description: 'Get teachers overview with statistics and detailed teacher information',
+  })
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async getTeachersView(@GetCurrentUserId() userId: string) {
+    const data = await this.bffAdminService.getTeachersViewData(userId);
+    return new AdminTeachersViewResult(data);
+  }
+
+  @Get('teacher/:teacherId')
+  @ApiParam({
+    name: 'teacherId',
+    description: 'The ID of the teacher to get details for',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: SingleTeacherDetailsResult,
+    description:
+      'Detailed information about a specific teacher including personal info, department, subjects, classes, and performance metrics',
+  })
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async getSingleTeacherDetails(
+    @GetCurrentUserId() userId: string,
+    @Param('teacherId') teacherId: string,
+  ) {
+    const data = await this.bffAdminService.getSingleTeacherDetails(userId, teacherId);
+    return new SingleTeacherDetailsResult(data);
   }
 
   @Get('classroom/:classroomId/details')

--- a/src/components/bff/admin/bff-admin.service.ts
+++ b/src/components/bff/admin/bff-admin.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { TeacherStatus, EmploymentType } from '@prisma/client';
 
 import { PrismaService } from '../../../prisma';
 import {
@@ -7,6 +8,8 @@ import {
   PaginatedStudents,
   PaginatedStudentDetails,
   SingleStudentDetails,
+  TeachersViewData,
+  SingleTeacherDetails,
 } from './types';
 
 @Injectable()
@@ -655,6 +658,277 @@ export class BffAdminService {
       isPresent,
       attendanceRate: Math.round(attendanceRate * 100) / 100,
       avatarUrl: student.user.avatarUrl,
+    };
+  }
+
+  async getTeachersViewData(userId: string): Promise<TeachersViewData> {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Get all teachers for the school with their related data
+    const teachers = await this.prisma.teacher.findMany({
+      where: {
+        user: {
+          schoolId,
+        },
+        deletedAt: null,
+      },
+      include: {
+        user: true,
+        department: true, // Direct department relationship
+        hod: {
+          include: {
+            department: true,
+          },
+        },
+        classArmSubjectTeachers: {
+          include: {
+            subject: true,
+          },
+        },
+        classArmTeachers: {
+          include: {
+            classArm: true,
+          },
+        },
+        classArmsAsTeacher: true, // Direct class teacher assignments
+      },
+    });
+
+    // Calculate statistics using real data
+    const totalTeachers = teachers.length;
+    const activeTeachers = teachers.filter((t) => t.status === TeacherStatus.ACTIVE).length;
+    const inactiveTeachers = teachers.filter((t) => t.status === TeacherStatus.INACTIVE).length;
+    const onLeaveTeachers = teachers.filter((t) => t.status === TeacherStatus.ON_LEAVE).length;
+
+    // Process teacher data
+    const teachersData = teachers.map((teacher) => {
+      // Get department name from direct relationship
+      const department = teacher.department?.name || 'Unassigned';
+
+      // Get subjects taught
+      const subjects = teacher.classArmSubjectTeachers.map((cast) => cast.subject.name);
+
+      // Get classes assigned
+      const classesAssigned = [
+        ...teacher.classArmTeachers.map((cat) => cat.classArm.name),
+        ...teacher.classArmsAsTeacher.map((classArm) => classArm.name),
+      ];
+
+      // Calculate experience (years since join date)
+      const joinDate = teacher.joinDate;
+      const experience = Math.floor(
+        (Date.now() - new Date(joinDate).getTime()) / (365.25 * 24 * 60 * 60 * 1000),
+      );
+
+      // Map employment type from enum to string
+      const employmentTypeMap = {
+        [EmploymentType.FULL_TIME]: 'full-time' as const,
+        [EmploymentType.PART_TIME]: 'part-time' as const,
+        [EmploymentType.CONTRACT]: 'contract' as const,
+      };
+      const employment = employmentTypeMap[teacher.employmentType];
+
+      // Map status from enum to string
+      const statusMap = {
+        [TeacherStatus.ACTIVE]: 'active' as const,
+        [TeacherStatus.INACTIVE]: 'inactive' as const,
+        [TeacherStatus.ON_LEAVE]: 'on-leave' as const,
+      };
+      const status = statusMap[teacher.status];
+
+      // Get last login from user
+      const lastLogin = teacher.user.lastLoginAt?.toISOString() || null;
+
+      return {
+        id: teacher.id,
+        firstName: teacher.user.firstName,
+        lastName: teacher.user.lastName,
+        email: teacher.user.email || '',
+        phone: teacher.user.phone || '',
+        department,
+        subjects,
+        employment,
+        experience,
+        qualification: teacher.qualification || 'Not specified',
+        joinDate: joinDate.toISOString().split('T')[0], // YYYY-MM-DD format
+        lastLogin,
+        status,
+        classesAssigned,
+        avatar: teacher.user.avatarUrl,
+      };
+    });
+
+    return {
+      stats: {
+        totalTeachers,
+        activeTeachers,
+        inactiveTeachers,
+        onLeaveTeachers,
+      },
+      teachers: teachersData,
+    };
+  }
+
+  async getSingleTeacherDetails(userId: string, teacherId: string): Promise<SingleTeacherDetails> {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Get the specific teacher with all necessary data
+    const teacher = await this.prisma.teacher.findFirst({
+      where: {
+        id: teacherId,
+        user: {
+          schoolId,
+        },
+        deletedAt: null,
+      },
+      include: {
+        user: {
+          include: {
+            address: true,
+          },
+        },
+        department: true,
+        hod: {
+          include: {
+            department: true,
+          },
+        },
+        classArmSubjectTeachers: {
+          include: {
+            subject: true,
+          },
+        },
+        classArmTeachers: {
+          include: {
+            classArm: {
+              include: {
+                students: true,
+              },
+            },
+          },
+        },
+        classArmsAsTeacher: {
+          include: {
+            students: true,
+          },
+        },
+      },
+    });
+
+    if (!teacher) {
+      throw new Error('Teacher not found or not accessible');
+    }
+
+    // Get department name
+    const department = teacher.department?.name || 'Unassigned';
+
+    // Get subjects taught
+    const subjects = teacher.classArmSubjectTeachers.map((cast) => cast.subject.name);
+
+    // Get classes assigned
+    const classesAssigned = [
+      ...teacher.classArmTeachers.map((cat) => cat.classArm.name),
+      ...teacher.classArmsAsTeacher.map((classArm) => classArm.name),
+    ];
+
+    // Calculate experience (years since join date)
+    const joinDate = teacher.joinDate;
+    const experience = Math.floor(
+      (Date.now() - new Date(joinDate).getTime()) / (365.25 * 24 * 60 * 60 * 1000),
+    );
+
+    // Map employment type from enum to string
+    const employmentTypeMap = {
+      [EmploymentType.FULL_TIME]: 'full-time' as const,
+      [EmploymentType.PART_TIME]: 'part-time' as const,
+      [EmploymentType.CONTRACT]: 'contract' as const,
+    };
+    const employment = employmentTypeMap[teacher.employmentType];
+
+    // Map status from enum to string
+    const statusMap = {
+      [TeacherStatus.ACTIVE]: 'active' as const,
+      [TeacherStatus.INACTIVE]: 'inactive' as const,
+      [TeacherStatus.ON_LEAVE]: 'on-leave' as const,
+    };
+    const status = statusMap[teacher.status];
+
+    // Get last login from user
+    const lastLogin = teacher.user.lastLoginAt?.toISOString() || null;
+
+    // Check if teacher is HOD
+    const isHOD = teacher.hod.length > 0;
+    const hodDepartment = isHOD ? teacher.hod[0].department.name : null;
+
+    // Calculate total students and average class size
+    const allStudents = [
+      ...teacher.classArmTeachers.flatMap((cat) => cat.classArm.students),
+      ...teacher.classArmsAsTeacher.flatMap((classArm) => classArm.students),
+    ];
+    const totalStudents = allStudents.length;
+    const averageClassSize =
+      classesAssigned.length > 0 ? Math.round(totalStudents / classesAssigned.length) : 0;
+
+    // Format date of birth
+    const dateOfBirth = teacher.user.dateOfBirth
+      ? teacher.user.dateOfBirth.toISOString().split('T')[0]
+      : null;
+
+    // Format address
+    const address = teacher.user.address
+      ? {
+          street1: teacher.user.address.street1,
+          street2: teacher.user.address.street2,
+          city: teacher.user.address.city,
+          state: teacher.user.address.state,
+          country: teacher.user.address.country,
+        }
+      : null;
+
+    return {
+      id: teacher.id,
+      firstName: teacher.user.firstName,
+      lastName: teacher.user.lastName,
+      email: teacher.user.email || '',
+      phone: teacher.user.phone || '',
+      department,
+      subjects,
+      employment,
+      experience,
+      qualification: teacher.qualification || 'Not specified',
+      joinDate: joinDate.toISOString().split('T')[0], // YYYY-MM-DD format
+      lastLogin,
+      status,
+      classesAssigned,
+      avatar: teacher.user.avatarUrl,
+      dateOfBirth,
+      gender: teacher.user.gender === 'MALE' ? 'Male' : 'Female',
+      stateOfOrigin: teacher.user.stateOfOrigin,
+      address,
+      isHOD,
+      hodDepartment,
+      totalStudents,
+      averageClassSize,
     };
   }
 }

--- a/src/components/bff/admin/results/admin-teachers-view.result.ts
+++ b/src/components/bff/admin/results/admin-teachers-view.result.ts
@@ -1,0 +1,106 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { TeachersViewData } from '../types';
+
+export class TeacherStatsResult {
+  @ApiProperty({ description: 'Total number of teachers' })
+  totalTeachers: number;
+
+  @ApiProperty({ description: 'Number of active teachers' })
+  activeTeachers: number;
+
+  @ApiProperty({ description: 'Number of inactive teachers' })
+  inactiveTeachers: number;
+
+  @ApiProperty({ description: 'Number of teachers on leave' })
+  onLeaveTeachers: number;
+
+  constructor(data: TeachersViewData['stats']) {
+    this.totalTeachers = data.totalTeachers;
+    this.activeTeachers = data.activeTeachers;
+    this.inactiveTeachers = data.inactiveTeachers;
+    this.onLeaveTeachers = data.onLeaveTeachers;
+  }
+}
+
+export class TeacherInfoResult {
+  @ApiProperty({ description: 'Teacher ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Teacher first name' })
+  firstName: string;
+
+  @ApiProperty({ description: 'Teacher last name' })
+  lastName: string;
+
+  @ApiProperty({ description: 'Teacher email address' })
+  email: string;
+
+  @ApiProperty({ description: 'Teacher phone number' })
+  phone: string;
+
+  @ApiProperty({ description: 'Teacher department' })
+  department: string;
+
+  @ApiProperty({ description: 'Subjects taught by the teacher', type: [String] })
+  subjects: string[];
+
+  @ApiProperty({ description: 'Employment type', enum: ['full-time', 'part-time', 'contract'] })
+  employment: 'full-time' | 'part-time' | 'contract';
+
+  @ApiProperty({ description: 'Years of experience' })
+  experience: number;
+
+  @ApiProperty({ description: 'Teacher qualification' })
+  qualification: string;
+
+  @ApiProperty({ description: 'Date teacher joined (YYYY-MM-DD)' })
+  joinDate: string;
+
+  @ApiProperty({ description: 'Last login timestamp (ISO 8601) or null', nullable: true })
+  lastLogin: string | null;
+
+  @ApiProperty({ description: 'Teacher status', enum: ['active', 'inactive', 'on-leave'] })
+  status: 'active' | 'inactive' | 'on-leave';
+
+  @ApiProperty({ description: 'Classes assigned to teacher', type: [String] })
+  classesAssigned: string[];
+
+  @ApiProperty({ description: 'Teacher avatar URL', nullable: true })
+  avatar: string | null;
+
+  constructor(data: any) {
+    this.id = data.id;
+    this.firstName = data.firstName;
+    this.lastName = data.lastName;
+    this.email = data.email;
+    this.phone = data.phone;
+    this.department = data.department;
+    this.subjects = data.subjects;
+    this.employment = data.employment;
+    this.experience = data.experience;
+    this.qualification = data.qualification;
+    this.joinDate = data.joinDate;
+    this.lastLogin = data.lastLogin;
+    this.status = data.status;
+    this.classesAssigned = data.classesAssigned;
+    this.avatar = data.avatar;
+  }
+}
+
+export class AdminTeachersViewResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ type: TeacherStatsResult, description: 'Teacher statistics' })
+  stats: TeacherStatsResult;
+
+  @ApiProperty({ type: [TeacherInfoResult], description: 'List of teachers' })
+  teachers: TeacherInfoResult[];
+
+  constructor(data: TeachersViewData) {
+    this.success = true;
+    this.stats = new TeacherStatsResult(data.stats);
+    this.teachers = data.teachers.map((teacher) => new TeacherInfoResult(teacher));
+  }
+}

--- a/src/components/bff/admin/results/single-teacher-details.result.ts
+++ b/src/components/bff/admin/results/single-teacher-details.result.ts
@@ -1,0 +1,129 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { SingleTeacherDetails } from '../types';
+
+export class TeacherAddressResult {
+  @ApiProperty({ description: 'Street address line 1', nullable: true })
+  street1: string | null;
+
+  @ApiProperty({ description: 'Street address line 2', nullable: true })
+  street2: string | null;
+
+  @ApiProperty({ description: 'City', nullable: true })
+  city: string | null;
+
+  @ApiProperty({ description: 'State/Province', nullable: true })
+  state: string | null;
+
+  @ApiProperty({ description: 'Country', nullable: true })
+  country: string | null;
+
+  constructor(data: SingleTeacherDetails['address']) {
+    this.street1 = data?.street1 || null;
+    this.street2 = data?.street2 || null;
+    this.city = data?.city || null;
+    this.state = data?.state || null;
+    this.country = data?.country || null;
+  }
+}
+
+export class SingleTeacherDetailsResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Teacher ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Teacher first name' })
+  firstName: string;
+
+  @ApiProperty({ description: 'Teacher last name' })
+  lastName: string;
+
+  @ApiProperty({ description: 'Teacher email address' })
+  email: string;
+
+  @ApiProperty({ description: 'Teacher phone number' })
+  phone: string;
+
+  @ApiProperty({ description: 'Teacher department' })
+  department: string;
+
+  @ApiProperty({ description: 'Subjects taught by the teacher', type: [String] })
+  subjects: string[];
+
+  @ApiProperty({ description: 'Employment type', enum: ['full-time', 'part-time', 'contract'] })
+  employment: 'full-time' | 'part-time' | 'contract';
+
+  @ApiProperty({ description: 'Years of experience' })
+  experience: number;
+
+  @ApiProperty({ description: 'Teacher qualification' })
+  qualification: string;
+
+  @ApiProperty({ description: 'Date teacher joined (YYYY-MM-DD)' })
+  joinDate: string;
+
+  @ApiProperty({ description: 'Last login timestamp (ISO 8601) or null', nullable: true })
+  lastLogin: string | null;
+
+  @ApiProperty({ description: 'Teacher status', enum: ['active', 'inactive', 'on-leave'] })
+  status: 'active' | 'inactive' | 'on-leave';
+
+  @ApiProperty({ description: 'Classes assigned to teacher', type: [String] })
+  classesAssigned: string[];
+
+  @ApiProperty({ description: 'Teacher avatar URL', nullable: true })
+  avatar: string | null;
+
+  @ApiProperty({ description: 'Date of birth (YYYY-MM-DD)', nullable: true })
+  dateOfBirth: string | null;
+
+  @ApiProperty({ description: 'Gender' })
+  gender: string;
+
+  @ApiProperty({ description: 'State of origin', nullable: true })
+  stateOfOrigin: string | null;
+
+  @ApiProperty({ type: TeacherAddressResult, nullable: true, description: 'Teacher address' })
+  address: TeacherAddressResult | null;
+
+  @ApiProperty({ description: 'Whether teacher is Head of Department' })
+  isHOD: boolean;
+
+  @ApiProperty({ description: 'Department where teacher is HOD', nullable: true })
+  hodDepartment: string | null;
+
+  @ApiProperty({ description: 'Total number of students taught' })
+  totalStudents: number;
+
+  @ApiProperty({ description: 'Average class size' })
+  averageClassSize: number;
+
+  constructor(data: SingleTeacherDetails) {
+    this.success = true;
+    this.id = data.id;
+    this.firstName = data.firstName;
+    this.lastName = data.lastName;
+    this.email = data.email;
+    this.phone = data.phone;
+    this.department = data.department;
+    this.subjects = data.subjects;
+    this.employment = data.employment;
+    this.experience = data.experience;
+    this.qualification = data.qualification;
+    this.joinDate = data.joinDate;
+    this.lastLogin = data.lastLogin;
+    this.status = data.status;
+    this.classesAssigned = data.classesAssigned;
+    this.avatar = data.avatar;
+    this.dateOfBirth = data.dateOfBirth;
+    this.gender = data.gender;
+    this.stateOfOrigin = data.stateOfOrigin;
+    this.address = data.address ? new TeacherAddressResult(data.address) : null;
+    this.isHOD = data.isHOD;
+    this.hodDepartment = data.hodDepartment;
+    this.totalStudents = data.totalStudents;
+    this.averageClassSize = data.averageClassSize;
+  }
+}

--- a/src/components/bff/admin/types/index.ts
+++ b/src/components/bff/admin/types/index.ts
@@ -118,3 +118,67 @@ export interface PaginatedStudentDetails {
 
 // Type alias for single student details (same structure as StudentDetailInfo)
 export type SingleStudentDetails = StudentDetailInfo;
+
+// Teacher-related types
+export interface TeacherStats {
+  totalTeachers: number;
+  activeTeachers: number;
+  inactiveTeachers: number;
+  onLeaveTeachers: number;
+}
+
+export interface TeacherInfo {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  department: string;
+  subjects: string[];
+  employment: 'full-time' | 'part-time' | 'contract';
+  experience: number;
+  qualification: string;
+  joinDate: string; // YYYY-MM-DD
+  lastLogin: string | null; // ISO 8601
+  status: 'active' | 'inactive' | 'on-leave';
+  classesAssigned: string[];
+  avatar: string | null; // URL
+}
+
+export interface TeachersViewData {
+  stats: TeacherStats;
+  teachers: TeacherInfo[];
+}
+
+export interface SingleTeacherDetails {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  department: string;
+  subjects: string[];
+  employment: 'full-time' | 'part-time' | 'contract';
+  experience: number;
+  qualification: string;
+  joinDate: string; // YYYY-MM-DD
+  lastLogin: string | null; // ISO 8601
+  status: 'active' | 'inactive' | 'on-leave';
+  classesAssigned: string[];
+  avatar: string | null; // URL
+  // Additional detailed fields
+  dateOfBirth: string | null; // YYYY-MM-DD
+  gender: string;
+  stateOfOrigin: string | null;
+  address: {
+    street1: string | null;
+    street2: string | null;
+    city: string | null;
+    state: string | null;
+    country: string | null;
+  } | null;
+  isHOD: boolean;
+  hodDepartment: string | null;
+  totalStudents: number;
+  averageClassSize: number;
+}

--- a/src/components/users/results/user-result.ts
+++ b/src/components/users/results/user-result.ts
@@ -47,6 +47,9 @@ export class UserEntity implements Omit<User, 'password'> {
   dateOfBirth: Date;
 
   @ApiProperty()
+  lastLoginAt: Date | null;
+
+  @ApiProperty()
   stateOfOrigin: string | null;
 
   @ApiProperty()


### PR DESCRIPTION
- Add GET /bff/admin/teachers-view endpoint for teachers overview
- Add GET /bff/admin/teacher/:teacherId endpoint for single teacher details
- Create TeachersViewData and SingleTeacherDetails interfaces
- Add AdminTeachersViewResult and SingleTeacherDetailsResult classes
- Implement getTeachersViewData and getSingleTeacherDetails service methods
- Include comprehensive teacher data (personal, professional, metrics)
- Add proper API documentation and error handling
- Follow existing patterns from student endpoints

Teachers View Endpoint:
- Returns statistics (total, active, inactive, on-leave teachers)
- Lists all teachers with basic info (name, department, subjects, status)
- Supports admin teachers page with overview data

Single Teacher Details Endpoint:
- Returns detailed teacher information for profile pages
- Includes personal details, address, HOD status, student metrics
- Provides comprehensive data for teacher management

Both endpoints include proper authentication, authorization, and error handling.