### PR TITLE
feat: implement comprehensive subject management system

### DIFF
--- a/prisma/migrations/20250825162219_add_category_to_subject/migration.sql
+++ b/prisma/migrations/20250825162219_add_category_to_subject/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "SubjectCategory" AS ENUM ('CORE', 'GENERAL', 'VOCATIONAL');
+
+-- AlterTable
+ALTER TABLE "subjects" ADD COLUMN     "category" "SubjectCategory" NOT NULL DEFAULT 'CORE';

--- a/prisma/migrations/20250825165956_remove_is_elective_from_subject/migration.sql
+++ b/prisma/migrations/20250825165956_remove_is_elective_from_subject/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isElective` on the `subjects` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "subjects" DROP COLUMN "isElective";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,12 @@ enum EmploymentType {
   CONTRACT
 }
 
+enum SubjectCategory {
+  CORE
+  GENERAL
+  VOCATIONAL
+}
+
 // --- Address Management ---
 
 /**
@@ -511,7 +517,7 @@ model Student {
 model Subject {
   id                      String                   @id @default(uuid())
   name                    String
-  isElective              Boolean                  @default(false)
+  category                SubjectCategory          @default(CORE)
   schoolId                String
   school                  School                   @relation(fields: [schoolId], references: [id])
   departmentId            String?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -239,7 +239,7 @@ async function main() {
       const subject = await prisma.subject.create({
         data: {
           name: name.charAt(0).toUpperCase() + name.slice(1),
-          isElective: faker.datatype.boolean(),
+          category: faker.helpers.arrayElement(['CORE', 'GENERAL', 'VOCATIONAL']),
           schoolId: school.id,
           departmentId: dept.id,
         },

--- a/src/components/bff/admin/bff-admin.controller.ts
+++ b/src/components/bff/admin/bff-admin.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Post, Body, Put, Delete, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
 import { GetCurrentUserId } from '../../../common/decorators';
@@ -13,6 +13,8 @@ import {
   ClassroomDetailsParam,
   ClassroomDetailsResponse,
   ClassroomsViewSwagger,
+  CreateSubjectSwagger,
+  DeleteSubjectSwagger,
   SingleStudentDetailsParam,
   SingleStudentDetailsResponse,
   SingleTeacherDetailsParam,
@@ -23,15 +25,23 @@ import {
   StudentDetailsResponse,
   StudentDetailsSearchQuery,
   StudentsViewSwagger,
+  SubjectsViewSwagger,
   TeachersViewSwagger,
+  UpdateSubjectSwagger,
 } from './bff-admin.swagger';
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
 import { AdminClassroomsViewResult } from './results/admin-classrooms-view.result';
 import { AdminStudentsViewResult } from './results/admin-students-view.result';
+import { AdminSubjectsViewResult } from './results/admin-subjects-view.result';
 import { AdminTeachersViewResult } from './results/admin-teachers-view.result';
+import { CreateSubjectResult } from './results/create-subject.result';
+import { DeleteSubjectResult } from './results/delete-subject.result';
+import { UpdateSubjectResult } from './results/update-subject.result';
 import { SingleStudentDetailsResult } from './results/single-student-details.result';
 import { SingleTeacherDetailsResult } from './results/single-teacher-details.result';
 import { StudentDetailsResult } from './results/student-details.result';
+import { CreateSubjectDto } from './dto/create-subject.dto';
+import { UpdateSubjectDto } from './dto/update-subject.dto';
 
 @Controller('bff/admin')
 @ApiTags('BFF - Admin')
@@ -62,6 +72,45 @@ export class BffAdminController {
   async getStudentsView(@GetCurrentUserId() userId: string) {
     const data = await this.bffAdminService.getStudentsViewData(userId);
     return new AdminStudentsViewResult(data);
+  }
+
+  @Get('subjects-view')
+  @SubjectsViewSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async getSubjectsView(@GetCurrentUserId() userId: string) {
+    const data = await this.bffAdminService.getSubjectsViewData(userId);
+    return new AdminSubjectsViewResult(data);
+  }
+
+  @Post('subjects')
+  @CreateSubjectSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async createSubject(
+    @GetCurrentUserId() userId: string,
+    @Body() createSubjectDto: CreateSubjectDto,
+  ) {
+    const data = await this.bffAdminService.createSubject(userId, createSubjectDto);
+    return new CreateSubjectResult(data);
+  }
+
+  @Put('subjects/:subjectId')
+  @UpdateSubjectSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async updateSubject(
+    @GetCurrentUserId() userId: string,
+    @Param('subjectId') subjectId: string,
+    @Body() updateSubjectDto: UpdateSubjectDto,
+  ) {
+    const data = await this.bffAdminService.updateSubject(userId, subjectId, updateSubjectDto);
+    return new UpdateSubjectResult(data);
+  }
+
+  @Delete('subjects/:subjectId')
+  @DeleteSubjectSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async deleteSubject(@GetCurrentUserId() userId: string, @Param('subjectId') subjectId: string) {
+    const data = await this.bffAdminService.deleteSubject(userId, subjectId);
+    return new DeleteSubjectResult(data);
   }
 
   @Get('teacher/:teacherId')

--- a/src/components/bff/admin/bff-admin.module.ts
+++ b/src/components/bff/admin/bff-admin.module.ts
@@ -9,6 +9,7 @@ import { BffAdminController } from './bff-admin.controller';
 import { BffAdminService } from './bff-admin.service';
 import { BffAdminClassroomService } from './services/bff-admin-classroom.service';
 import { BffAdminStudentService } from './services/bff-admin-student.service';
+import { BffAdminSubjectService } from './services/bff-admin-subject.service';
 import { BffAdminTeacherService } from './services/bff-admin-teacher.service';
 
 @Module({
@@ -18,6 +19,7 @@ import { BffAdminTeacherService } from './services/bff-admin-teacher.service';
     BffAdminService,
     BffAdminTeacherService,
     BffAdminStudentService,
+    BffAdminSubjectService,
     BffAdminClassroomService,
     Encryptor,
   ],

--- a/src/components/bff/admin/bff-admin.service.ts
+++ b/src/components/bff/admin/bff-admin.service.ts
@@ -3,7 +3,10 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../prisma';
 import { BffAdminClassroomService } from './services/bff-admin-classroom.service';
 import { BffAdminStudentService } from './services/bff-admin-student.service';
+import { BffAdminSubjectService } from './services/bff-admin-subject.service';
 import { BffAdminTeacherService } from './services/bff-admin-teacher.service';
+import { CreateSubjectDto } from './dto/create-subject.dto';
+import { UpdateSubjectDto } from './dto/update-subject.dto';
 import {
   AdminClassroomsViewData,
   ClassroomDetailsData,
@@ -12,6 +15,7 @@ import {
   SingleTeacherDetails,
   TeachersViewData,
   StudentsViewData,
+  SubjectsViewData,
 } from './types';
 
 @Injectable()
@@ -21,6 +25,7 @@ export class BffAdminService {
     private readonly teacherService: BffAdminTeacherService,
     private readonly studentService: BffAdminStudentService,
     private readonly classroomService: BffAdminClassroomService,
+    private readonly subjectService: BffAdminSubjectService,
   ) {}
 
   async getClassroomsViewData(userId: string): Promise<AdminClassroomsViewData> {
@@ -60,5 +65,21 @@ export class BffAdminService {
 
   async getStudentsViewData(userId: string): Promise<StudentsViewData> {
     return this.studentService.getStudentsViewData(userId);
+  }
+
+  async getSubjectsViewData(userId: string): Promise<SubjectsViewData> {
+    return this.subjectService.getSubjectsViewData(userId);
+  }
+
+  async createSubject(userId: string, createSubjectDto: CreateSubjectDto) {
+    return this.subjectService.createSubject(userId, createSubjectDto);
+  }
+
+  async updateSubject(userId: string, subjectId: string, updateSubjectDto: UpdateSubjectDto) {
+    return this.subjectService.updateSubject(userId, subjectId, updateSubjectDto);
+  }
+
+  async deleteSubject(userId: string, subjectId: string) {
+    return this.subjectService.deleteSubject(userId, subjectId);
   }
 }

--- a/src/components/bff/admin/bff-admin.swagger.ts
+++ b/src/components/bff/admin/bff-admin.swagger.ts
@@ -4,7 +4,11 @@ import { ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
 import { AdminClassroomsViewResult } from './results/admin-classrooms-view.result';
 import { AdminStudentsViewResult } from './results/admin-students-view.result';
+import { AdminSubjectsViewResult } from './results/admin-subjects-view.result';
 import { AdminTeachersViewResult } from './results/admin-teachers-view.result';
+import { CreateSubjectResult } from './results/create-subject.result';
+import { DeleteSubjectResult } from './results/delete-subject.result';
+import { UpdateSubjectResult } from './results/update-subject.result';
 import { SingleStudentDetailsResult } from './results/single-student-details.result';
 import { SingleTeacherDetailsResult } from './results/single-teacher-details.result';
 import { StudentDetailsResult } from './results/student-details.result';
@@ -137,4 +141,36 @@ export const StudentsViewSwagger = () =>
     status: HttpStatus.OK,
     type: AdminStudentsViewResult,
     description: 'Get students overview with statistics and detailed student information',
+  });
+
+// Subjects View
+export const SubjectsViewSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.OK,
+    type: AdminSubjectsViewResult,
+    description: 'Get subjects overview with statistics and detailed subject information',
+  });
+
+// Create Subject
+export const CreateSubjectSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.CREATED,
+    type: CreateSubjectResult,
+    description: 'Subject created successfully',
+  });
+
+// Update Subject
+export const UpdateSubjectSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.OK,
+    type: UpdateSubjectResult,
+    description: 'Subject updated successfully',
+  });
+
+// Delete Subject
+export const DeleteSubjectSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.OK,
+    type: DeleteSubjectResult,
+    description: 'Subject deleted successfully',
   });

--- a/src/components/bff/admin/dto/create-subject.dto.ts
+++ b/src/components/bff/admin/dto/create-subject.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { SubjectCategory } from '@prisma/client';
+
+export class CreateSubjectDto {
+  @ApiProperty({
+    description: 'Subject name',
+    example: 'Mathematics',
+  })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    description: 'Department ID (optional)',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    nullable: true,
+  })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+
+  @ApiProperty({
+    description: 'Subject category',
+    enum: SubjectCategory,
+    example: SubjectCategory.CORE,
+    default: SubjectCategory.CORE,
+  })
+  @IsEnum(SubjectCategory)
+  @IsOptional()
+  category?: SubjectCategory;
+}

--- a/src/components/bff/admin/dto/update-subject.dto.ts
+++ b/src/components/bff/admin/dto/update-subject.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { SubjectCategory } from '@prisma/client';
+
+export class UpdateSubjectDto {
+  @ApiProperty({
+    description: 'Subject name',
+    example: 'Advanced Mathematics',
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    description: 'Department ID (optional)',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    nullable: true,
+  })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+
+  @ApiProperty({
+    description: 'Subject category',
+    enum: SubjectCategory,
+    example: SubjectCategory.CORE,
+  })
+  @IsEnum(SubjectCategory)
+  @IsOptional()
+  category?: SubjectCategory;
+}

--- a/src/components/bff/admin/results/admin-subjects-view.result.ts
+++ b/src/components/bff/admin/results/admin-subjects-view.result.ts
@@ -1,0 +1,78 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SubjectsViewData } from '../types';
+import { SubjectCategory } from '@prisma/client';
+
+export class SubjectStatsResult {
+  @ApiProperty({ description: 'Total number of subjects in the school' })
+  totalSubjects: number;
+
+  @ApiProperty({
+    description: 'Breakdown of subjects by category',
+    type: 'object',
+    properties: {
+      core: { type: 'number', description: 'Number of core subjects' },
+      general: { type: 'number', description: 'Number of general subjects' },
+      vocational: { type: 'number', description: 'Number of vocational subjects' },
+    },
+  })
+  categoryBreakdown: {
+    core: number;
+    general: number;
+    vocational: number;
+  };
+
+  @ApiProperty({
+    description: 'Breakdown of subjects by department',
+    type: 'object',
+    additionalProperties: { type: 'number' },
+  })
+  departmentBreakdown: {
+    [departmentName: string]: number;
+  };
+}
+
+export class SubjectInfoResult {
+  @ApiProperty({ description: 'Subject ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Subject name' })
+  name: string;
+
+  @ApiProperty({ description: 'Department name', nullable: true })
+  department: string | null;
+
+  @ApiProperty({ 
+    description: 'Subject category',
+    enum: SubjectCategory
+  })
+  category: SubjectCategory;
+
+  @ApiProperty({ description: 'Number of classes taking this subject' })
+  classesCount: number;
+
+  @ApiProperty({ description: 'Number of students taking this subject' })
+  studentCount: number;
+
+  @ApiProperty({ 
+    description: 'Subject status',
+    enum: ['active', 'inactive']
+  })
+  status: 'active' | 'inactive';
+}
+
+export class AdminSubjectsViewResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ type: SubjectStatsResult, description: 'Subject statistics' })
+  stats: SubjectStatsResult;
+
+  @ApiProperty({ type: [SubjectInfoResult], description: 'List of subjects' })
+  subjects: SubjectInfoResult[];
+
+  constructor(data: SubjectsViewData) {
+    this.success = true;
+    this.stats = data.stats;
+    this.subjects = data.subjects;
+  }
+}

--- a/src/components/bff/admin/results/create-subject.result.ts
+++ b/src/components/bff/admin/results/create-subject.result.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SubjectCategory } from '@prisma/client';
+
+export class CreateSubjectResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Subject ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Subject name' })
+  name: string;
+
+  @ApiProperty({ 
+    description: 'Subject category',
+    enum: SubjectCategory
+  })
+  category: SubjectCategory;
+
+  @ApiProperty({ description: 'Department name', nullable: true })
+  department: string | null;
+
+  @ApiProperty({ description: 'Department ID', nullable: true })
+  departmentId: string | null;
+
+  @ApiProperty({ description: 'School ID' })
+  schoolId: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  constructor(data: {
+    id: string;
+    name: string;
+    category: SubjectCategory;
+    department: string | null;
+    departmentId: string | null;
+    schoolId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.success = true;
+    this.id = data.id;
+    this.name = data.name;
+    this.category = data.category;
+    this.department = data.department;
+    this.departmentId = data.departmentId;
+    this.schoolId = data.schoolId;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+}

--- a/src/components/bff/admin/results/delete-subject.result.ts
+++ b/src/components/bff/admin/results/delete-subject.result.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteSubjectResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Success message' })
+  message: string;
+
+  @ApiProperty({ description: 'Deleted subject ID' })
+  id: string;
+
+  constructor(data: { success: boolean; message: string; id: string }) {
+    this.success = data.success;
+    this.message = data.message;
+    this.id = data.id;
+  }
+}

--- a/src/components/bff/admin/results/update-subject.result.ts
+++ b/src/components/bff/admin/results/update-subject.result.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SubjectCategory } from '@prisma/client';
+
+export class UpdateSubjectResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Subject ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Subject name' })
+  name: string;
+
+  @ApiProperty({ 
+    description: 'Subject category',
+    enum: SubjectCategory
+  })
+  category: SubjectCategory;
+
+  @ApiProperty({ description: 'Department name', nullable: true })
+  department: string | null;
+
+  @ApiProperty({ description: 'Department ID', nullable: true })
+  departmentId: string | null;
+
+  @ApiProperty({ description: 'School ID' })
+  schoolId: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  constructor(data: {
+    id: string;
+    name: string;
+    category: SubjectCategory;
+    department: string | null;
+    departmentId: string | null;
+    schoolId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.success = true;
+    this.id = data.id;
+    this.name = data.name;
+    this.category = data.category;
+    this.department = data.department;
+    this.departmentId = data.departmentId;
+    this.schoolId = data.schoolId;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+}

--- a/src/components/bff/admin/services/bff-admin-subject.service.ts
+++ b/src/components/bff/admin/services/bff-admin-subject.service.ts
@@ -1,0 +1,327 @@
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { PrismaService } from '../../../../prisma';
+import { CreateSubjectDto } from '../dto/create-subject.dto';
+import { UpdateSubjectDto } from '../dto/update-subject.dto';
+import { SubjectsViewData } from '../types';
+
+@Injectable()
+export class BffAdminSubjectService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getSubjectsViewData(userId: string): Promise<SubjectsViewData> {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Get all subjects for the school with their related data
+    const subjects = await this.prisma.subject.findMany({
+      where: {
+        schoolId,
+        deletedAt: null, // Only active subjects
+      },
+      include: {
+        department: true,
+        classArmSubjectTeachers: {
+          include: {
+            classArm: {
+              include: {
+                students: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Calculate statistics
+    const totalSubjects = subjects.length;
+
+    // Calculate category breakdown using the new category field
+    const coreSubjects = subjects.filter((subject) => subject.category === 'CORE').length;
+    const generalSubjects = subjects.filter((subject) => subject.category === 'GENERAL').length;
+    const vocationalSubjects = subjects.filter(
+      (subject) => subject.category === 'VOCATIONAL',
+    ).length;
+
+    const categoryBreakdown = {
+      core: coreSubjects,
+      general: generalSubjects,
+      vocational: vocationalSubjects,
+    };
+
+    // Calculate department breakdown
+    const departmentBreakdown: { [key: string]: number } = {};
+    subjects.forEach((subject) => {
+      const departmentName = subject.department?.name || 'Unassigned';
+      departmentBreakdown[departmentName] = (departmentBreakdown[departmentName] || 0) + 1;
+    });
+
+    // Process subject data for the list
+    const subjectsData = subjects.map((subject) => {
+      // Calculate classes count (unique class arms teaching this subject)
+      const uniqueClasses = new Set(subject.classArmSubjectTeachers.map((cast) => cast.classArmId));
+      const classesCount = uniqueClasses.size;
+
+      // Calculate student count (total students in all classes taking this subject)
+      const studentCount = subject.classArmSubjectTeachers.reduce(
+        (total, cast) => total + cast.classArm.students.length,
+        0,
+      );
+
+      // Determine status (active if not deleted)
+      const status: 'active' | 'inactive' = subject.deletedAt ? 'inactive' : 'active';
+
+      return {
+        id: subject.id,
+        name: subject.name,
+        department: subject.department?.name || null,
+        category: subject.category,
+        classesCount,
+        studentCount,
+        status,
+      };
+    });
+
+    return {
+      stats: {
+        totalSubjects,
+        categoryBreakdown,
+        departmentBreakdown,
+      },
+      subjects: subjectsData,
+    };
+  }
+
+  async createSubject(userId: string, createSubjectDto: CreateSubjectDto) {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new BadRequestException('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Check if subject with same name already exists in the school
+    const existingSubject = await this.prisma.subject.findFirst({
+      where: {
+        schoolId,
+        name: {
+          equals: createSubjectDto.name,
+          mode: 'insensitive', // Case-insensitive comparison
+        },
+        deletedAt: null,
+      },
+    });
+
+    if (existingSubject) {
+      throw new ConflictException(`Subject with name '${createSubjectDto.name}' already exists`);
+    }
+
+    // Validate department if provided
+    if (createSubjectDto.departmentId) {
+      const department = await this.prisma.department.findFirst({
+        where: {
+          id: createSubjectDto.departmentId,
+          schoolId,
+          deletedAt: null,
+        },
+      });
+
+      if (!department) {
+        throw new BadRequestException('Department not found or does not belong to this school');
+      }
+    }
+
+    // Create the subject
+    const subject = await this.prisma.subject.create({
+      data: {
+        name: createSubjectDto.name,
+        category: createSubjectDto.category || 'CORE',
+        schoolId,
+        departmentId: createSubjectDto.departmentId || null,
+      },
+      include: {
+        department: true,
+      },
+    });
+
+    return {
+      id: subject.id,
+      name: subject.name,
+      category: subject.category,
+      department: subject.department?.name || null,
+      departmentId: subject.departmentId,
+      schoolId: subject.schoolId,
+      createdAt: subject.createdAt,
+      updatedAt: subject.updatedAt,
+    };
+  }
+
+  async updateSubject(userId: string, subjectId: string, updateSubjectDto: UpdateSubjectDto) {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new BadRequestException('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Check if subject exists and belongs to the school
+    const existingSubject = await this.prisma.subject.findFirst({
+      where: {
+        id: subjectId,
+        schoolId,
+        deletedAt: null,
+      },
+    });
+
+    if (!existingSubject) {
+      throw new NotFoundException('Subject not found');
+    }
+
+    // Check for name conflict if name is being updated
+    if (updateSubjectDto.name && updateSubjectDto.name !== existingSubject.name) {
+      const nameConflict = await this.prisma.subject.findFirst({
+        where: {
+          schoolId,
+          name: {
+            equals: updateSubjectDto.name,
+            mode: 'insensitive',
+          },
+          id: { not: subjectId },
+          deletedAt: null,
+        },
+      });
+
+      if (nameConflict) {
+        throw new ConflictException(`Subject with name '${updateSubjectDto.name}' already exists`);
+      }
+    }
+
+    // Validate department if provided
+    if (updateSubjectDto.departmentId) {
+      const department = await this.prisma.department.findFirst({
+        where: {
+          id: updateSubjectDto.departmentId,
+          schoolId,
+          deletedAt: null,
+        },
+      });
+
+      if (!department) {
+        throw new BadRequestException('Department not found or does not belong to this school');
+      }
+    }
+
+    // Update the subject
+    const updatedSubject = await this.prisma.subject.update({
+      where: { id: subjectId },
+      data: {
+        ...(updateSubjectDto.name && { name: updateSubjectDto.name }),
+        ...(updateSubjectDto.category && { category: updateSubjectDto.category }),
+        ...(updateSubjectDto.departmentId !== undefined && {
+          departmentId: updateSubjectDto.departmentId,
+        }),
+      },
+      include: {
+        department: true,
+      },
+    });
+
+    return {
+      id: updatedSubject.id,
+      name: updatedSubject.name,
+      category: updatedSubject.category,
+      department: updatedSubject.department?.name || null,
+      departmentId: updatedSubject.departmentId,
+      schoolId: updatedSubject.schoolId,
+      createdAt: updatedSubject.createdAt,
+      updatedAt: updatedSubject.updatedAt,
+    };
+  }
+
+  async deleteSubject(userId: string, subjectId: string) {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new BadRequestException('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Check if subject exists and belongs to the school
+    const subject = await this.prisma.subject.findFirst({
+      where: {
+        id: subjectId,
+        schoolId,
+        deletedAt: null,
+      },
+      include: {
+        subjectTerms: {
+          include: {
+            subjectTermStudents: {
+              include: {
+                assessments: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!subject) {
+      throw new NotFoundException('Subject not found');
+    }
+
+    // Check if subject has any assessments
+    const hasAssessments = subject.subjectTerms.some((subjectTerm) =>
+      subjectTerm.subjectTermStudents.some((student) => student.assessments.length > 0),
+    );
+
+    if (hasAssessments) {
+      throw new BadRequestException(
+        'Cannot delete subject. It has associated assessments. Please remove all assessments first.',
+      );
+    }
+
+    // Soft delete the subject
+    await this.prisma.subject.update({
+      where: { id: subjectId },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+
+    return {
+      success: true,
+      message: 'Subject deleted successfully',
+      id: subjectId,
+    };
+  }
+}

--- a/src/components/bff/admin/types/index.ts
+++ b/src/components/bff/admin/types/index.ts
@@ -206,3 +206,33 @@ export interface StudentsViewData {
   stats: StudentStats;
   students: StudentDetailInfo[];
 }
+
+import { SubjectCategory } from '@prisma/client';
+
+// Subjects View types
+export interface SubjectStats {
+  totalSubjects: number;
+  categoryBreakdown: {
+    core: number;
+    general: number;
+    vocational: number;
+  };
+  departmentBreakdown: {
+    [departmentName: string]: number;
+  };
+}
+
+export interface SubjectInfo {
+  id: string;
+  name: string;
+  department: string | null;
+  category: SubjectCategory;
+  classesCount: number;
+  studentCount: number;
+  status: 'active' | 'inactive';
+}
+
+export interface SubjectsViewData {
+  stats: SubjectStats;
+  subjects: SubjectInfo[];
+}


### PR DESCRIPTION
- Add SubjectCategory enum (CORE, GENERAL, VOCATIONAL) to Subject model
- Remove isElective field (inappropriate for K-12 schools)
- Create complete CRUD endpoints for subjects:
  * GET /bff/admin/subjects-view - Get subjects with statistics
  * POST /bff/admin/subjects - Create new subject
  * PUT /bff/admin/subjects/:id - Update subject
  * DELETE /bff/admin/subjects/:id - Delete subject (with assessment validation)
- Add comprehensive validation and business logic:
  * School-scoped operations
  * Duplicate name prevention
  * Department validation
  * Assessment protection for deletion
- Implement proper service architecture:
  * BffAdminSubjectService for subject operations
  * Clean separation of concerns
  * Proper error handling
- Add complete Swagger documentation
- Update seed data to use new category system
- Create database migrations for schema changes

This provides a complete subject management system suitable for primary and secondary schools.