### PR TITLE
feat: add admin view endpoint and dropdown data endpoint

### DIFF
--- a/src/components/admin/admin-dropdowns.controller.ts
+++ b/src/components/admin/admin-dropdowns.controller.ts
@@ -1,0 +1,59 @@
+import { Controller, Get, UseGuards, Query, DefaultValuePipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
+import { GetCurrentUserId } from '../../common/decorators';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { DropdownsService } from './dropdowns.service';
+import { DropdownDataResult } from './results/dropdown-data.result';
+
+@ApiTags('Dropdowns')
+@Controller('dropdowns')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class DropdownsController {
+  constructor(private readonly dropdownsService: DropdownsService) {}
+
+  @Get('data')
+  @ApiOperation({
+    summary: 'Get dropdown data',
+    description:
+      'Fetch teachers, departments, sessions, levels, terms, and subjects for populating dropdowns',
+  })
+  @ApiQuery({
+    name: 'includeArchived',
+    required: false,
+    type: Boolean,
+    description: 'Include archived departments (default: false)',
+  })
+  @ApiQuery({
+    name: 'includeInactive',
+    required: false,
+    type: Boolean,
+    description: 'Include inactive subjects (default: false)',
+  })
+  @ApiQuery({
+    name: 'includeInactiveTeachers',
+    required: false,
+    type: Boolean,
+    description: 'Include inactive teachers (default: false)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Dropdown data retrieved successfully',
+    type: DropdownDataResult,
+  })
+  async getDropdownData(
+    @GetCurrentUserId() userId: string,
+    @Query('includeArchived', new DefaultValuePipe(false)) includeArchived: boolean,
+    @Query('includeInactive', new DefaultValuePipe(false)) includeInactive: boolean,
+    @Query('includeInactiveTeachers', new DefaultValuePipe(false)) includeInactiveTeachers: boolean,
+  ) {
+    const data = await this.dropdownsService.getDropdownData(
+      userId,
+      includeArchived,
+      includeInactive,
+      includeInactiveTeachers,
+    );
+    return new DropdownDataResult(data);
+  }
+}

--- a/src/components/admin/admin.module.ts
+++ b/src/components/admin/admin.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
 import { AdminService } from './admin.service';
 import { AdminController } from './admin.controller';
+import { DropdownsController } from './admin-dropdowns.controller';
+import { DropdownsService } from './dropdowns.service';
 import { UsersModule } from '../users/users.module';
 import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../../prisma';
+import { Encryptor } from '../../utils/encryptor';
 
 @Module({
-  imports: [UsersModule, AuthModule],
-  controllers: [AdminController],
-  providers: [AdminService],
+  imports: [UsersModule, AuthModule, PrismaModule],
+  controllers: [AdminController, DropdownsController],
+  providers: [AdminService, DropdownsService, Encryptor],
 })
 export class AdminModule {}

--- a/src/components/admin/dropdowns.service.ts
+++ b/src/components/admin/dropdowns.service.ts
@@ -1,0 +1,206 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../../prisma';
+import { TeacherStatus } from '@prisma/client';
+import { DropdownData } from './types';
+
+@Injectable()
+export class DropdownsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getDropdownData(
+    userId: string,
+    includeArchived: boolean = false,
+    includeInactive: boolean = false,
+    includeInactiveTeachers: boolean = false,
+  ): Promise<DropdownData> {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new BadRequestException('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Build department where clause
+    const departmentWhere = {
+      schoolId,
+      ...(includeArchived ? {} : { deletedAt: null }),
+    };
+
+    // Build subject where clause
+    const subjectWhere = {
+      schoolId,
+      ...(includeInactive ? {} : { deletedAt: null }),
+    };
+
+    // Build teacher where clause
+    const teacherWhere = {
+      user: { schoolId },
+      ...(includeInactiveTeachers ? {} : { status: TeacherStatus.ACTIVE }),
+      deletedAt: null,
+    };
+
+    // Fetch all data in parallel for better performance
+    const [
+      teachers,
+      departments,
+      academicSessions,
+      levels,
+      terms,
+      subjects,
+    ] = await Promise.all([
+      // Teachers
+      this.prisma.teacher.findMany({
+        where: teacherWhere,
+        include: {
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+            },
+          },
+          department: {
+            select: {
+              name: true,
+              code: true,
+            },
+          },
+        },
+        orderBy: [
+          { user: { firstName: 'asc' } },
+          { user: { lastName: 'asc' } },
+        ],
+      }),
+
+      // Departments
+      this.prisma.department.findMany({
+        where: departmentWhere,
+        include: {
+          hod: {
+            include: {
+              teacher: {
+                include: {
+                  user: {
+                    select: {
+                      firstName: true,
+                      lastName: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: { name: 'asc' },
+      }),
+
+      // Academic Sessions
+      this.prisma.academicSession.findMany({
+        where: { schoolId },
+        orderBy: { academicYear: 'desc' },
+      }),
+
+      // Levels
+      this.prisma.level.findMany({
+        where: { schoolId },
+        orderBy: { name: 'asc' },
+      }),
+
+      // Terms
+      this.prisma.term.findMany({
+        include: {
+          academicSession: {
+            select: {
+              academicYear: true,
+            },
+          },
+        },
+        orderBy: [
+          { academicSession: { academicYear: 'desc' } },
+          { name: 'asc' },
+        ],
+      }),
+
+      // Subjects
+      this.prisma.subject.findMany({
+        where: subjectWhere,
+        include: {
+          department: {
+            select: {
+              name: true,
+              code: true,
+            },
+          },
+        },
+        orderBy: { name: 'asc' },
+      }),
+    ]);
+
+    // Transform teachers data
+    const teachersData = teachers.map((teacher) => ({
+      id: teacher.id,
+      teacherNo: teacher.teacherNo,
+      name: `${teacher.user.firstName} ${teacher.user.lastName}`,
+      department: teacher.department?.name || null,
+      departmentCode: teacher.department?.code || null,
+      status: teacher.status,
+    }));
+
+    // Transform departments data
+    const departmentsData = departments.map((department) => ({
+      id: department.id,
+      name: department.name,
+      code: department.code,
+      hodName: department.hod?.teacher?.user
+        ? `${department.hod.teacher.user.firstName} ${department.hod.teacher.user.lastName}`
+        : null,
+      status: (department.deletedAt ? 'archived' : 'active') as 'active' | 'archived',
+    }));
+
+    // Transform academic sessions data
+    const academicSessionsData = academicSessions.map((session) => ({
+      id: session.id,
+      academicYear: session.academicYear,
+      isCurrent: session.isCurrent,
+      startDate: session.startDate,
+      endDate: session.endDate,
+    }));
+
+    // Transform levels data
+    const levelsData = levels.map((level) => ({
+      id: level.id,
+      name: level.name,
+    }));
+
+    // Transform terms data
+    const termsData = terms.map((term) => ({
+      id: term.id,
+      name: term.name,
+      academicSessionId: term.academicSessionId,
+      academicYear: term.academicSession.academicYear,
+    }));
+
+    // Transform subjects data
+    const subjectsData = subjects.map((subject) => ({
+      id: subject.id,
+      name: subject.name,
+      category: subject.category,
+      department: subject.department?.name || null,
+      departmentCode: subject.department?.code || null,
+      status: (subject.deletedAt ? 'inactive' : 'active') as 'active' | 'inactive',
+    }));
+
+    return {
+      teachers: teachersData,
+      departments: departmentsData,
+      academicSessions: academicSessionsData,
+      levels: levelsData,
+      terms: termsData,
+      subjects: subjectsData,
+    };
+  }
+}

--- a/src/components/admin/results/dropdown-data.result.ts
+++ b/src/components/admin/results/dropdown-data.result.ts
@@ -1,0 +1,132 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TeacherStatus, SubjectCategory } from '@prisma/client';
+import { DropdownData } from '../types';
+
+export class TeacherDropdownItemResult {
+  @ApiProperty({ description: 'Teacher ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Teacher number' })
+  teacherNo: string;
+
+  @ApiProperty({ description: 'Teacher full name' })
+  name: string;
+
+  @ApiProperty({ description: 'Department name', nullable: true })
+  department: string | null;
+
+  @ApiProperty({ description: 'Department code', nullable: true })
+  departmentCode: string | null;
+
+  @ApiProperty({ description: 'Teacher status', enum: TeacherStatus })
+  status: TeacherStatus;
+}
+
+export class DepartmentDropdownItemResult {
+  @ApiProperty({ description: 'Department ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Department name' })
+  name: string;
+
+  @ApiProperty({ description: 'Department code' })
+  code: string;
+
+  @ApiProperty({ description: 'Head of Department name', nullable: true })
+  hodName: string | null;
+
+  @ApiProperty({ description: 'Department status', enum: ['active', 'archived'] })
+  status: 'active' | 'archived';
+}
+
+export class AcademicSessionDropdownItemResult {
+  @ApiProperty({ description: 'Academic session ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Academic year' })
+  academicYear: string;
+
+  @ApiProperty({ description: 'Whether this is the current session' })
+  isCurrent: boolean;
+
+  @ApiProperty({ description: 'Session start date' })
+  startDate: Date;
+
+  @ApiProperty({ description: 'Session end date' })
+  endDate: Date;
+}
+
+export class LevelDropdownItemResult {
+  @ApiProperty({ description: 'Level ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Level name' })
+  name: string;
+}
+
+export class TermDropdownItemResult {
+  @ApiProperty({ description: 'Term ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Term name' })
+  name: string;
+
+  @ApiProperty({ description: 'Academic session ID' })
+  academicSessionId: string;
+
+  @ApiProperty({ description: 'Academic year' })
+  academicYear: string;
+}
+
+export class SubjectDropdownItemResult {
+  @ApiProperty({ description: 'Subject ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Subject name' })
+  name: string;
+
+  @ApiProperty({ description: 'Subject category', enum: SubjectCategory })
+  category: SubjectCategory;
+
+  @ApiProperty({ description: 'Department name', nullable: true })
+  department: string | null;
+
+  @ApiProperty({ description: 'Department code', nullable: true })
+  departmentCode: string | null;
+
+  @ApiProperty({ description: 'Subject status', enum: ['active', 'inactive'] })
+  status: 'active' | 'inactive';
+}
+
+export class DropdownDataResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ type: [TeacherDropdownItemResult], description: 'List of teachers' })
+  teachers: TeacherDropdownItemResult[];
+
+  @ApiProperty({ type: [DepartmentDropdownItemResult], description: 'List of departments' })
+  departments: DepartmentDropdownItemResult[];
+
+  @ApiProperty({ type: [AcademicSessionDropdownItemResult], description: 'List of academic sessions' })
+  academicSessions: AcademicSessionDropdownItemResult[];
+
+  @ApiProperty({ type: [LevelDropdownItemResult], description: 'List of levels' })
+  levels: LevelDropdownItemResult[];
+
+  @ApiProperty({ type: [TermDropdownItemResult], description: 'List of terms' })
+  terms: TermDropdownItemResult[];
+
+  @ApiProperty({ type: [SubjectDropdownItemResult], description: 'List of subjects' })
+  subjects: SubjectDropdownItemResult[];
+
+  constructor(data: DropdownData) {
+    this.success = true;
+    this.teachers = data.teachers;
+    this.departments = data.departments;
+    this.academicSessions = data.academicSessions;
+    this.levels = data.levels;
+    this.terms = data.terms;
+    this.subjects = data.subjects;
+  }
+}

--- a/src/components/admin/types/index.ts
+++ b/src/components/admin/types/index.ts
@@ -1,0 +1,56 @@
+import { TeacherStatus, SubjectCategory } from '@prisma/client';
+
+export interface TeacherDropdownItem {
+  id: string;
+  teacherNo: string;
+  name: string;
+  department: string | null;
+  departmentCode: string | null;
+  status: TeacherStatus;
+}
+
+export interface DepartmentDropdownItem {
+  id: string;
+  name: string;
+  code: string;
+  hodName: string | null;
+  status: 'active' | 'archived';
+}
+
+export interface AcademicSessionDropdownItem {
+  id: string;
+  academicYear: string;
+  isCurrent: boolean;
+  startDate: Date;
+  endDate: Date;
+}
+
+export interface LevelDropdownItem {
+  id: string;
+  name: string;
+}
+
+export interface TermDropdownItem {
+  id: string;
+  name: string;
+  academicSessionId: string;
+  academicYear: string;
+}
+
+export interface SubjectDropdownItem {
+  id: string;
+  name: string;
+  category: SubjectCategory;
+  department: string | null;
+  departmentCode: string | null;
+  status: 'active' | 'inactive';
+}
+
+export interface DropdownData {
+  teachers: TeacherDropdownItem[];
+  departments: DepartmentDropdownItem[];
+  academicSessions: AcademicSessionDropdownItem[];
+  levels: LevelDropdownItem[];
+  terms: TermDropdownItem[];
+  subjects: SubjectDropdownItem[];
+}

--- a/src/components/bff/admin/bff-admin.controller.ts
+++ b/src/components/bff/admin/bff-admin.controller.ts
@@ -8,6 +8,7 @@ import { CheckPolicies, PoliciesGuard } from '../../roles-manager';
 import { ManageStudentPolicyHandler } from '../../students/policies';
 import { BffAdminService } from './bff-admin.service';
 import {
+  AdminsViewSwagger,
   ArchiveDepartmentSwagger,
   ClassroomDetailsLimitQuery,
   ClassroomDetailsPageQuery,
@@ -34,6 +35,7 @@ import {
   UpdateDepartmentSwagger,
   UpdateSubjectSwagger,
 } from './bff-admin.swagger';
+import { AdminAdminsViewResult } from './results/admin-admins-view.result';
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
 import { AdminClassroomsViewResult } from './results/admin-classrooms-view.result';
 import { AdminDepartmentsViewResult } from './results/admin-departments-view.result';
@@ -76,6 +78,14 @@ export class BffAdminController {
   async getTeachersView(@GetCurrentUserId() userId: string) {
     const data = await this.bffAdminService.getTeachersViewData(userId);
     return new AdminTeachersViewResult(data);
+  }
+
+  @Get('admins-view')
+  @AdminsViewSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async getAdminsView(@GetCurrentUserId() userId: string) {
+    const data = await this.bffAdminService.getAdminsViewData(userId);
+    return new AdminAdminsViewResult(data);
   }
 
   @Get('students-view')

--- a/src/components/bff/admin/bff-admin.module.ts
+++ b/src/components/bff/admin/bff-admin.module.ts
@@ -7,6 +7,7 @@ import { RolesManagerModule } from '../../roles-manager/roles-manager.module';
 import { UsersModule } from '../../users/users.module';
 import { BffAdminController } from './bff-admin.controller';
 import { BffAdminService } from './bff-admin.service';
+import { BffAdminAdminService } from './services/bff-admin-admin.service';
 import { BffAdminClassroomService } from './services/bff-admin-classroom.service';
 import { BffAdminDepartmentService } from './services/bff-admin-department.service';
 import { BffAdminStudentService } from './services/bff-admin-student.service';
@@ -23,6 +24,7 @@ import { BffAdminTeacherService } from './services/bff-admin-teacher.service';
     BffAdminSubjectService,
     BffAdminDepartmentService,
     BffAdminClassroomService,
+    BffAdminAdminService,
     Encryptor,
   ],
 })

--- a/src/components/bff/admin/bff-admin.service.ts
+++ b/src/components/bff/admin/bff-admin.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../../../prisma';
+import { BffAdminAdminService } from './services/bff-admin-admin.service';
 import { BffAdminClassroomService } from './services/bff-admin-classroom.service';
 import { BffAdminDepartmentService } from './services/bff-admin-department.service';
 import { BffAdminStudentService } from './services/bff-admin-student.service';
@@ -12,6 +13,7 @@ import { UpdateDepartmentDto } from './dto/update-department.dto';
 import { UpdateSubjectDto } from './dto/update-subject.dto';
 import {
   AdminClassroomsViewData,
+  AdminsViewData,
   ClassroomDetailsData,
   DepartmentsViewData,
   PaginatedStudentDetails,
@@ -31,6 +33,7 @@ export class BffAdminService {
     private readonly classroomService: BffAdminClassroomService,
     private readonly subjectService: BffAdminSubjectService,
     private readonly departmentService: BffAdminDepartmentService,
+    private readonly adminService: BffAdminAdminService,
   ) {}
 
   async getClassroomsViewData(userId: string): Promise<AdminClassroomsViewData> {
@@ -97,7 +100,11 @@ export class BffAdminService {
     return this.departmentService.createDepartment(userId, createDepartmentDto);
   }
 
-  async updateDepartment(userId: string, departmentId: string, updateDepartmentDto: UpdateDepartmentDto) {
+  async updateDepartment(
+    userId: string,
+    departmentId: string,
+    updateDepartmentDto: UpdateDepartmentDto,
+  ) {
     return this.departmentService.updateDepartment(userId, departmentId, updateDepartmentDto);
   }
 
@@ -107,5 +114,10 @@ export class BffAdminService {
 
   async unarchiveDepartment(userId: string, departmentId: string) {
     return this.departmentService.unarchiveDepartment(userId, departmentId);
+  }
+
+  // Admin methods
+  async getAdminsViewData(userId: string): Promise<AdminsViewData> {
+    return this.adminService.getAdminsViewData(userId);
   }
 }

--- a/src/components/bff/admin/bff-admin.swagger.ts
+++ b/src/components/bff/admin/bff-admin.swagger.ts
@@ -4,6 +4,7 @@ import { ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
 import { AdminClassroomsViewResult } from './results/admin-classrooms-view.result';
 import { AdminStudentsViewResult } from './results/admin-students-view.result';
+import { AdminAdminsViewResult } from './results/admin-admins-view.result';
 import { AdminDepartmentsViewResult } from './results/admin-departments-view.result';
 import { AdminSubjectsViewResult } from './results/admin-subjects-view.result';
 import { AdminTeachersViewResult } from './results/admin-teachers-view.result';
@@ -218,4 +219,12 @@ export const UnarchiveDepartmentSwagger = () =>
     status: HttpStatus.OK,
     type: UnarchiveDepartmentResult,
     description: 'Department unarchived successfully',
+  });
+
+// Admins View
+export const AdminsViewSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.OK,
+    type: AdminAdminsViewResult,
+    description: 'Get admins overview with statistics and detailed admin information',
   });

--- a/src/components/bff/admin/results/admin-admins-view.result.ts
+++ b/src/components/bff/admin/results/admin-admins-view.result.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AdminsViewData } from '../types';
+
+export class AdminStatsResult {
+  @ApiProperty({ description: 'Total number of admins in the school' })
+  totalAdmins: number;
+
+  @ApiProperty({ description: 'Number of active admins' })
+  activeAdmins: number;
+
+  @ApiProperty({ description: 'Number of inactive admins' })
+  inactiveAdmins: number;
+
+  @ApiProperty({ description: 'Number of suspended admins' })
+  suspendedAdmins: number;
+
+  @ApiProperty({ description: 'Number of teachers who are heads of departments' })
+  hodCount: number;
+}
+
+export class AdminInfoResult {
+  @ApiProperty({ description: 'Admin ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Admin full name' })
+  name: string;
+
+  @ApiProperty({ description: 'Admin role' })
+  role: string;
+
+  @ApiProperty({ description: 'Department (null for admins)', nullable: true })
+  department: string | null;
+
+  @ApiProperty({ 
+    description: 'Admin status',
+    enum: ['active', 'inactive', 'suspended']
+  })
+  status: 'active' | 'inactive' | 'suspended';
+
+  @ApiProperty({ description: 'Last login timestamp', nullable: true })
+  lastLoginAt: Date | null;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+}
+
+export class AdminAdminsViewResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ type: AdminStatsResult, description: 'Admin statistics' })
+  stats: AdminStatsResult;
+
+  @ApiProperty({ type: [AdminInfoResult], description: 'List of admins' })
+  admins: AdminInfoResult[];
+
+  constructor(data: AdminsViewData) {
+    this.success = true;
+    this.stats = data.stats;
+    this.admins = data.admins;
+  }
+}

--- a/src/components/bff/admin/services/bff-admin-admin.service.ts
+++ b/src/components/bff/admin/services/bff-admin-admin.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+
+import { PrismaService } from '../../../../prisma';
+import { AdminsViewData } from '../types';
+
+@Injectable()
+export class BffAdminAdminService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getAdminsViewData(userId: string): Promise<AdminsViewData> {
+    // First, get the user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new BadRequestException('User not found or not associated with a school');
+    }
+
+    const schoolId = user.schoolId;
+
+    // Get all users who are admins for this school
+    const adminUsers = await this.prisma.user.findMany({
+      where: {
+        schoolId,
+        type: {
+          in: ['ADMIN', 'SUPER_ADMIN'],
+        },
+        deletedAt: null,
+      },
+      include: {
+        admin: true,
+      },
+      orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+    });
+
+    // Get all teachers who are HODs for this school
+    const hodUsers = await this.prisma.user.findMany({
+      where: {
+        schoolId,
+        type: 'TEACHER',
+        deletedAt: null,
+        teacher: {
+          hod: {
+            some: {
+              deletedAt: null,
+              department: {
+                schoolId,
+                deletedAt: null,
+              },
+            },
+          },
+        },
+      },
+      include: {
+        teacher: {
+          include: {
+            hod: {
+              include: {
+                department: {
+                  select: {
+                    name: true,
+                    code: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+    });
+
+    // Get HOD count (teachers who are heads of departments)
+    const hodCount = await this.prisma.hod.count({
+      where: {
+        department: {
+          schoolId,
+          deletedAt: null,
+        },
+        deletedAt: null,
+      },
+    });
+
+    // Calculate statistics
+    const totalAdmins = adminUsers.length + hodUsers.length;
+    const activeAdmins =
+      adminUsers.filter((admin) => !admin.admin?.deletedAt).length + hodUsers.length;
+    const inactiveAdmins = adminUsers.filter((admin) => admin.admin?.deletedAt).length;
+    const suspendedAdmins = 0; // No suspended status in current schema
+
+    // Process admin data for the list
+    const adminsData = [
+      // Regular admins
+      ...adminUsers.map((adminUser) => {
+        const status: 'active' | 'inactive' | 'suspended' = adminUser.admin?.deletedAt
+          ? 'inactive'
+          : 'active';
+
+        return {
+          id: adminUser.id,
+          name: `${adminUser.firstName} ${adminUser.lastName}`,
+          role: adminUser.admin?.isSuper ? 'Super Admin' : 'Admin',
+          department: null, // Admins don't belong to departments
+          status,
+          lastLoginAt: adminUser.lastLoginAt,
+          createdAt: adminUser.createdAt,
+        };
+      }),
+      // HODs (teachers with administrative responsibilities)
+      ...hodUsers.map((hodUser) => {
+        const hodDepartment = hodUser.teacher?.hod?.[0]?.department;
+
+        return {
+          id: hodUser.id,
+          name: `${hodUser.firstName} ${hodUser.lastName}`,
+          role: 'HOD',
+          department: hodDepartment ? `${hodDepartment.name} (${hodDepartment.code})` : null,
+          status: 'active' as const,
+          lastLoginAt: hodUser.lastLoginAt,
+          createdAt: hodUser.createdAt,
+        };
+      }),
+    ];
+
+    return {
+      stats: {
+        totalAdmins,
+        activeAdmins,
+        inactiveAdmins,
+        suspendedAdmins,
+        hodCount,
+      },
+      admins: adminsData,
+    };
+  }
+}

--- a/src/components/bff/admin/services/bff-admin-department.service.ts
+++ b/src/components/bff/admin/services/bff-admin-department.service.ts
@@ -176,6 +176,13 @@ export class BffAdminDepartmentService {
         code: createDepartmentDto.code.toUpperCase(),
         schoolId,
         hodId: createDepartmentDto.hodId || null,
+        ...(createDepartmentDto.hodId && {
+          hod: {
+            create: {
+              teacherId: createDepartmentDto.hodId,
+            },
+          },
+        }),
       },
       include: {
         hod: {
@@ -312,6 +319,23 @@ export class BffAdminDepartmentService {
         ...(updateDepartmentDto.name && { name: updateDepartmentDto.name }),
         ...(updateDepartmentDto.code && { code: updateDepartmentDto.code.toUpperCase() }),
         ...(updateDepartmentDto.hodId !== undefined && { hodId: updateDepartmentDto.hodId }),
+        ...(updateDepartmentDto.hodId && {
+          hod: {
+            upsert: {
+              create: {
+                teacherId: updateDepartmentDto.hodId,
+              },
+              update: {
+                teacherId: updateDepartmentDto.hodId,
+              },
+            },
+          },
+        }),
+        ...(updateDepartmentDto.hodId === null && {
+          hod: {
+            delete: true,
+          },
+        }),
       },
       include: {
         hod: {

--- a/src/components/bff/admin/types/index.ts
+++ b/src/components/bff/admin/types/index.ts
@@ -264,3 +264,27 @@ export interface DepartmentsViewData {
   stats: DepartmentStats;
   departments: DepartmentInfo[];
 }
+
+// Admins View types
+export interface AdminStats {
+  totalAdmins: number;
+  activeAdmins: number;
+  inactiveAdmins: number;
+  suspendedAdmins: number;
+  hodCount: number;
+}
+
+export interface AdminInfo {
+  id: string;
+  name: string;
+  role: string;
+  department: string | null;
+  status: 'active' | 'inactive' | 'suspended';
+  lastLoginAt: Date | null;
+  createdAt: Date;
+}
+
+export interface AdminsViewData {
+  stats: AdminStats;
+  admins: AdminInfo[];
+}


### PR DESCRIPTION
- Add endpoint to fetch all admins including statistics (total, active, inactive, suspended, HOD count)
- Include table data with name, ID, role, department, status, last login date, and date added
- Support for regular admins, super admins, and HODs (teachers with administrative responsibilities)
- Add dropdown data endpoint accessible to all authenticated users (not just admins)
- Fetch teachers, departments, sessions, levels, terms, and subjects for dropdown population
- Add query parameters for including archived departments, inactive subjects, and inactive teachers
- Add AdminStats, AdminInfo, and AdminsViewData interfaces
- Create BffAdminAdminService for admin-related business logic
- Create DropdownsService for dropdown data business logic
- Add AdminAdminsViewResult and DropdownDataResult for API response structures
- Add AdminsViewSwagger decorator for documentation
- Update BffAdminService to delegate admin operations
- Update AdminModule to include DropdownsController and DropdownsService
- Fix HOD inclusion in admin view by querying teachers who are heads of departments