### PR TITLE
refactor: separate CRUD operations from BFF admin controller

### DIFF
--- a/src/app-module.list.ts
+++ b/src/app-module.list.ts
@@ -15,6 +15,9 @@ import { TerminusModule } from '@nestjs/terminus';
 import { SchoolsModule } from './components/schools/schools.module';
 import { UsersModule } from './components/users/users.module';
 import { BffAdminModule } from './components/bff/admin/bff-admin.module';
+import { SubjectsModule } from './components/subjects/subjects.module';
+import { DepartmentsModule } from './components/departments/departments.module';
+import { LevelsModule } from './components/levels/levels.module';
 import { MailModule } from './utils/mail/mail.module';
 import { MailQueueModule } from './utils/mail-queue/mail-queue.module';
 
@@ -48,6 +51,9 @@ export const AppModuleList = [
   RolesManagerModule,
   AdminModule,
   BffAdminModule,
+  SubjectsModule,
+  DepartmentsModule,
+  LevelsModule,
   TerminusModule,
   AssessmentsModule,
 ];

--- a/src/components/bff/admin/bff-admin.controller.ts
+++ b/src/components/bff/admin/bff-admin.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post, Body, Put, Delete, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
 import { GetCurrentUserId } from '../../../common/decorators';
@@ -9,15 +9,11 @@ import { ManageStudentPolicyHandler } from '../../students/policies';
 import { BffAdminService } from './bff-admin.service';
 import {
   AdminsViewSwagger,
-  ArchiveDepartmentSwagger,
   ClassroomDetailsLimitQuery,
   ClassroomDetailsPageQuery,
   ClassroomDetailsParam,
   ClassroomDetailsResponse,
   ClassroomsViewSwagger,
-  CreateDepartmentSwagger,
-  CreateSubjectSwagger,
-  DeleteSubjectSwagger,
   DepartmentsViewSwagger,
   SingleStudentDetailsParam,
   SingleStudentDetailsResponse,
@@ -31,16 +27,7 @@ import {
   StudentsViewSwagger,
   SubjectsViewSwagger,
   TeachersViewSwagger,
-  UnarchiveDepartmentSwagger,
-  UpdateDepartmentSwagger,
-  UpdateSubjectSwagger,
-  DeleteDepartmentSwagger,
   LevelsViewSwagger,
-  CreateLevelSwagger,
-  UpdateLevelSwagger,
-  ArchiveLevelSwagger,
-  UnarchiveLevelSwagger,
-  DeleteLevelSwagger,
 } from './bff-admin.swagger';
 import { AdminAdminsViewResult } from './results/admin-admins-view.result';
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
@@ -50,28 +37,9 @@ import { AdminStudentsViewResult } from './results/admin-students-view.result';
 import { AdminSubjectsViewResult } from './results/admin-subjects-view.result';
 import { AdminTeachersViewResult } from './results/admin-teachers-view.result';
 import { AdminLevelsViewResult } from './results/admin-levels-view.result';
-import { ArchiveDepartmentResult } from './results/archive-department.result';
-import { CreateDepartmentResult } from './results/create-department.result';
-import { CreateSubjectResult } from './results/create-subject.result';
-import { DeleteSubjectResult } from './results/delete-subject.result';
-import { UnarchiveDepartmentResult } from './results/unarchive-department.result';
-import { UpdateDepartmentResult } from './results/update-department.result';
-import { UpdateSubjectResult } from './results/update-subject.result';
 import { SingleStudentDetailsResult } from './results/single-student-details.result';
 import { SingleTeacherDetailsResult } from './results/single-teacher-details.result';
 import { StudentDetailsResult } from './results/student-details.result';
-import { CreateDepartmentDto } from './dto/create-department.dto';
-import { CreateSubjectDto } from './dto/create-subject.dto';
-import { UpdateDepartmentDto } from './dto/update-department.dto';
-import { UpdateSubjectDto } from './dto/update-subject.dto';
-import { DeleteDepartmentResult } from './results/delete-department.result';
-import { CreateLevelDto } from './dto/create-level.dto';
-import { UpdateLevelDto } from './dto/update-level.dto';
-import { CreateLevelResult } from './results/create-level.result';
-import { UpdateLevelResult } from './results/update-level.result';
-import { ArchiveLevelResult } from './results/archive-level.result';
-import { UnarchiveLevelResult } from './results/unarchive-level.result';
-import { DeleteLevelResult } from './results/delete-level.result';
 
 @Controller('bff/admin')
 @ApiTags('BFF - Admin')
@@ -120,37 +88,6 @@ export class BffAdminController {
     return new AdminSubjectsViewResult(data);
   }
 
-  @Post('subjects')
-  @CreateSubjectSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async createSubject(
-    @GetCurrentUserId() userId: string,
-    @Body() createSubjectDto: CreateSubjectDto,
-  ) {
-    const data = await this.bffAdminService.createSubject(userId, createSubjectDto);
-    return new CreateSubjectResult(data);
-  }
-
-  @Put('subjects/:subjectId')
-  @UpdateSubjectSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async updateSubject(
-    @GetCurrentUserId() userId: string,
-    @Param('subjectId') subjectId: string,
-    @Body() updateSubjectDto: UpdateSubjectDto,
-  ) {
-    const data = await this.bffAdminService.updateSubject(userId, subjectId, updateSubjectDto);
-    return new UpdateSubjectResult(data);
-  }
-
-  @Delete('subjects/:subjectId')
-  @DeleteSubjectSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async deleteSubject(@GetCurrentUserId() userId: string, @Param('subjectId') subjectId: string) {
-    const data = await this.bffAdminService.deleteSubject(userId, subjectId);
-    return new DeleteSubjectResult(data);
-  }
-
   // Department endpoints
   @Get('departments-view')
   @DepartmentsViewSwagger()
@@ -160,66 +97,6 @@ export class BffAdminController {
     return new AdminDepartmentsViewResult(data);
   }
 
-  @Post('departments')
-  @CreateDepartmentSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async createDepartment(
-    @GetCurrentUserId() userId: string,
-    @Body() createDepartmentDto: CreateDepartmentDto,
-  ) {
-    const data = await this.bffAdminService.createDepartment(userId, createDepartmentDto);
-    return new CreateDepartmentResult(data);
-  }
-
-  @Put('departments/:departmentId')
-  @UpdateDepartmentSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async updateDepartment(
-    @GetCurrentUserId() userId: string,
-    @Param('departmentId') departmentId: string,
-    @Body() updateDepartmentDto: UpdateDepartmentDto,
-  ) {
-    const data = await this.bffAdminService.updateDepartment(
-      userId,
-      departmentId,
-      updateDepartmentDto,
-    );
-    return new UpdateDepartmentResult(data);
-  }
-
-  @Post('departments/:departmentId/archive')
-  @ArchiveDepartmentSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async archiveDepartment(
-    @GetCurrentUserId() userId: string,
-    @Param('departmentId') departmentId: string,
-  ) {
-    const data = await this.bffAdminService.archiveDepartment(userId, departmentId);
-    return new ArchiveDepartmentResult(data);
-  }
-
-  @Post('departments/:departmentId/unarchive')
-  @UnarchiveDepartmentSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async unarchiveDepartment(
-    @GetCurrentUserId() userId: string,
-    @Param('departmentId') departmentId: string,
-  ) {
-    const data = await this.bffAdminService.unarchiveDepartment(userId, departmentId);
-    return new UnarchiveDepartmentResult(data);
-  }
-
-  @Delete('departments/:departmentId')
-  @DeleteDepartmentSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async deleteDepartment(
-    @GetCurrentUserId() userId: string,
-    @Param('departmentId') departmentId: string,
-  ) {
-    const data = await this.bffAdminService.deleteDepartment(userId, departmentId);
-    return new DeleteDepartmentResult(data);
-  }
-
   // Level endpoints
   @Get('levels-view')
   @LevelsViewSwagger()
@@ -227,50 +104,6 @@ export class BffAdminController {
   async getLevelsView(@GetCurrentUserId() userId: string) {
     const data = await this.bffAdminService.getLevelsViewData(userId);
     return new AdminLevelsViewResult(data);
-  }
-
-  @Post('levels')
-  @CreateLevelSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async createLevel(@GetCurrentUserId() userId: string, @Body() createLevelDto: CreateLevelDto) {
-    const data = await this.bffAdminService.createLevel(userId, createLevelDto);
-    return new CreateLevelResult(data);
-  }
-
-  @Put('levels/:levelId')
-  @UpdateLevelSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async updateLevel(
-    @GetCurrentUserId() userId: string,
-    @Param('levelId') levelId: string,
-    @Body() updateLevelDto: UpdateLevelDto,
-  ) {
-    const data = await this.bffAdminService.updateLevel(userId, levelId, updateLevelDto);
-    return new UpdateLevelResult(data);
-  }
-
-  @Post('levels/:levelId/archive')
-  @ArchiveLevelSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async archiveLevel(@GetCurrentUserId() userId: string, @Param('levelId') levelId: string) {
-    const data = await this.bffAdminService.archiveLevel(userId, levelId);
-    return new ArchiveLevelResult(data);
-  }
-
-  @Post('levels/:levelId/unarchive')
-  @UnarchiveLevelSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async unarchiveLevel(@GetCurrentUserId() userId: string, @Param('levelId') levelId: string) {
-    const data = await this.bffAdminService.unarchiveLevel(userId, levelId);
-    return new UnarchiveLevelResult(data);
-  }
-
-  @Delete('levels/:levelId')
-  @DeleteLevelSwagger()
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  async deleteLevel(@GetCurrentUserId() userId: string, @Param('levelId') levelId: string) {
-    const data = await this.bffAdminService.deleteLevel(userId, levelId);
-    return new DeleteLevelResult(data);
   }
 
   @Get('teacher/:teacherId')

--- a/src/components/departments/departments.controller.ts
+++ b/src/components/departments/departments.controller.ts
@@ -1,0 +1,91 @@
+import { Body, Controller, Delete, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { CheckPolicies, PoliciesGuard } from '../roles-manager';
+import { ManageStudentPolicyHandler } from '../students/policies';
+import { DepartmentsService } from './departments.service';
+import {
+  ArchiveDepartmentSwagger,
+  CreateDepartmentSwagger,
+  DeleteDepartmentSwagger,
+  UnarchiveDepartmentSwagger,
+  UpdateDepartmentSwagger,
+} from './departments.swagger';
+import { CreateDepartmentDto } from './dto/create-department.dto';
+import { UpdateDepartmentDto } from './dto/update-department.dto';
+import { ArchiveDepartmentResult } from './results/archive-department.result';
+import { CreateDepartmentResult } from './results/create-department.result';
+import { DeleteDepartmentResult } from './results/delete-department.result';
+import { UnarchiveDepartmentResult } from './results/unarchive-department.result';
+import { UpdateDepartmentResult } from './results/update-department.result';
+
+@Controller('departments')
+@ApiTags('Departments')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard, PoliciesGuard)
+export class DepartmentsController {
+  constructor(private readonly departmentsService: DepartmentsService) {}
+
+  @Post()
+  @CreateDepartmentSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async createDepartment(
+    @GetCurrentUserId() userId: string,
+    @Body() createDepartmentDto: CreateDepartmentDto,
+  ) {
+    const data = await this.departmentsService.createDepartment(userId, createDepartmentDto);
+    return new CreateDepartmentResult(data);
+  }
+
+  @Put(':departmentId')
+  @UpdateDepartmentSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async updateDepartment(
+    @GetCurrentUserId() userId: string,
+    @Param('departmentId') departmentId: string,
+    @Body() updateDepartmentDto: UpdateDepartmentDto,
+  ) {
+    const data = await this.departmentsService.updateDepartment(
+      userId,
+      departmentId,
+      updateDepartmentDto,
+    );
+    return new UpdateDepartmentResult(data);
+  }
+
+  @Post(':departmentId/archive')
+  @ArchiveDepartmentSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async archiveDepartment(
+    @GetCurrentUserId() userId: string,
+    @Param('departmentId') departmentId: string,
+  ) {
+    const data = await this.departmentsService.archiveDepartment(userId, departmentId);
+    return new ArchiveDepartmentResult(data);
+  }
+
+  @Post(':departmentId/unarchive')
+  @UnarchiveDepartmentSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async unarchiveDepartment(
+    @GetCurrentUserId() userId: string,
+    @Param('departmentId') departmentId: string,
+  ) {
+    const data = await this.departmentsService.unarchiveDepartment(userId, departmentId);
+    return new UnarchiveDepartmentResult(data);
+  }
+
+  @Delete(':departmentId')
+  @DeleteDepartmentSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async deleteDepartment(
+    @GetCurrentUserId() userId: string,
+    @Param('departmentId') departmentId: string,
+  ) {
+    const data = await this.departmentsService.deleteDepartment(userId, departmentId);
+    return new DeleteDepartmentResult(data);
+  }
+}

--- a/src/components/departments/departments.module.ts
+++ b/src/components/departments/departments.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { DepartmentsController } from './departments.controller';
+import { DepartmentsService } from './departments.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { RolesManagerModule } from '../roles-manager/roles-manager.module';
+import { Encryptor } from '../../utils/encryptor';
+
+@Module({
+  imports: [PrismaModule, AuthModule, RolesManagerModule],
+  controllers: [DepartmentsController],
+  providers: [DepartmentsService, Encryptor],
+  exports: [DepartmentsService],
+})
+export class DepartmentsModule {}

--- a/src/components/departments/departments.service.ts
+++ b/src/components/departments/departments.service.ts
@@ -1,0 +1,223 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateDepartmentDto } from './dto/create-department.dto';
+import { UpdateDepartmentDto } from './dto/update-department.dto';
+
+@Injectable()
+export class DepartmentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createDepartment(userId: string, createDepartmentDto: CreateDepartmentDto) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    const department = await this.prisma.department.create({
+      data: {
+        name: createDepartmentDto.name,
+        code: createDepartmentDto.code,
+        hodId: createDepartmentDto.hodId,
+        school: {
+          connect: { id: user.schoolId },
+        },
+      },
+      include: {
+        hod: {
+          include: {
+            teacher: {
+              include: {
+                user: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return department;
+  }
+
+  async updateDepartment(userId: string, departmentId: string, updateDepartmentDto: UpdateDepartmentDto) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the department belongs to the user's school
+    const existingDepartment = await this.prisma.department.findFirst({
+      where: {
+        id: departmentId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingDepartment) {
+      throw new Error('Department not found or access denied');
+    }
+
+    const department = await this.prisma.department.update({
+      where: { id: departmentId },
+      data: {
+        ...(updateDepartmentDto.name && { name: updateDepartmentDto.name }),
+        ...(updateDepartmentDto.code && { code: updateDepartmentDto.code }),
+        ...(updateDepartmentDto.hodId && { hodId: updateDepartmentDto.hodId }),
+      },
+      include: {
+        hod: {
+          include: {
+            teacher: {
+              include: {
+                user: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return department;
+  }
+
+  async archiveDepartment(userId: string, departmentId: string) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the department belongs to the user's school
+    const existingDepartment = await this.prisma.department.findFirst({
+      where: {
+        id: departmentId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingDepartment) {
+      throw new Error('Department not found or access denied');
+    }
+
+    const department = await this.prisma.department.update({
+      where: { id: departmentId },
+      data: { deletedAt: new Date() },
+      include: {
+        hod: {
+          include: {
+            teacher: {
+              include: {
+                user: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return department;
+  }
+
+  async unarchiveDepartment(userId: string, departmentId: string) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the department belongs to the user's school
+    const existingDepartment = await this.prisma.department.findFirst({
+      where: {
+        id: departmentId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingDepartment) {
+      throw new Error('Department not found or access denied');
+    }
+
+    const department = await this.prisma.department.update({
+      where: { id: departmentId },
+      data: { deletedAt: null },
+      include: {
+        hod: {
+          include: {
+            teacher: {
+              include: {
+                user: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return department;
+  }
+
+  async deleteDepartment(userId: string, departmentId: string) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the department belongs to the user's school
+    const existingDepartment = await this.prisma.department.findFirst({
+      where: {
+        id: departmentId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingDepartment) {
+      throw new Error('Department not found or access denied');
+    }
+
+    // Check if department has associated head of department
+    const headOfDepartment = await this.prisma.teacher.findFirst({
+      where: { departmentId },
+    });
+
+    if (headOfDepartment) {
+      throw new Error('Cannot delete department. It has associated head of department. Please reassign or remove all associated head of department first.');
+    }
+
+    // Check if department has associated subjects
+    const subjects = await this.prisma.subject.findFirst({
+      where: { departmentId },
+    });
+
+    if (subjects) {
+      throw new Error('Cannot delete department. It has associated subjects. Please reassign or remove all associated subjects first.');
+    }
+
+    await this.prisma.department.delete({
+      where: { id: departmentId },
+    });
+
+    return { message: 'Department deleted successfully' };
+  }
+}

--- a/src/components/departments/departments.swagger.ts
+++ b/src/components/departments/departments.swagger.ts
@@ -1,0 +1,108 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function CreateDepartmentSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a new department' }),
+    ApiResponse({
+      status: 201,
+      description: 'Department created successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+  );
+}
+
+export function UpdateDepartmentSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update an existing department' }),
+    ApiResponse({
+      status: 200,
+      description: 'Department updated successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Department not found',
+    }),
+  );
+}
+
+export function ArchiveDepartmentSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Archive a department' }),
+    ApiResponse({
+      status: 200,
+      description: 'Department archived successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Department not found',
+    }),
+  );
+}
+
+export function UnarchiveDepartmentSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Unarchive a department' }),
+    ApiResponse({
+      status: 200,
+      description: 'Department unarchived successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Department not found',
+    }),
+  );
+}
+
+export function DeleteDepartmentSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete a department' }),
+    ApiResponse({
+      status: 200,
+      description: 'Department deleted successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request - Department has associated data',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Department not found',
+    }),
+  );
+}

--- a/src/components/departments/dto/create-department.dto.ts
+++ b/src/components/departments/dto/create-department.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID, Length } from 'class-validator';
+
+export class CreateDepartmentDto {
+  @ApiProperty({
+    description: 'Department name',
+    example: 'Science Department',
+  })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    description: 'Three character department code (e.g., SCI, MAT, ENG)',
+    example: 'SCI',
+  })
+  @IsString()
+  @Length(3, 3, { message: 'Department code must be exactly 3 characters' })
+  code: string;
+
+  @ApiProperty({
+    description: 'Head of Department (HOD) teacher ID (optional)',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    nullable: true,
+  })
+  @IsUUID()
+  @IsOptional()
+  hodId?: string;
+}

--- a/src/components/departments/dto/update-department.dto.ts
+++ b/src/components/departments/dto/update-department.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID, Length } from 'class-validator';
+
+export class UpdateDepartmentDto {
+  @ApiProperty({
+    description: 'Department name',
+    example: 'Advanced Science Department',
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    description: 'Three character department code (e.g., SCI, MAT, ENG)',
+    example: 'SCI',
+  })
+  @IsString()
+  @Length(3, 3, { message: 'Department code must be exactly 3 characters' })
+  @IsOptional()
+  code?: string;
+
+  @ApiProperty({
+    description: 'Head of Department (HOD) teacher ID (optional)',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    nullable: true,
+  })
+  @IsUUID()
+  @IsOptional()
+  hodId?: string;
+}

--- a/src/components/departments/results/archive-department.result.ts
+++ b/src/components/departments/results/archive-department.result.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ArchiveDepartmentResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Department ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Archive status' })
+  isArchived: boolean;
+
+  @ApiProperty({ description: 'Success message' })
+  message: string;
+
+  constructor(data: { id: string; deletedAt: Date | null }) {
+    this.success = true;
+    this.id = data.id;
+    this.isArchived = data.deletedAt !== null;
+    this.message = 'Department archived successfully';
+  }
+}

--- a/src/components/departments/results/create-department.result.ts
+++ b/src/components/departments/results/create-department.result.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateDepartmentResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Department ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Department name' })
+  name: string;
+
+  @ApiProperty({ description: 'Three character department code' })
+  code: string;
+
+  @ApiProperty({ description: 'Head of Department name', nullable: true })
+  hodName: string | null;
+
+  @ApiProperty({ description: 'Head of Department ID', nullable: true })
+  hodId: string | null;
+
+  @ApiProperty({ description: 'School ID' })
+  schoolId: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  constructor(data: any) {
+    this.success = true;
+    this.id = data.id;
+    this.name = data.name;
+    this.code = data.code;
+    this.hodName = data.hod?.teacher?.user ? `${data.hod.teacher.user.firstName} ${data.hod.teacher.user.lastName}` : null;
+    this.hodId = data.hodId;
+    this.schoolId = data.schoolId;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+}

--- a/src/components/departments/results/delete-department.result.ts
+++ b/src/components/departments/results/delete-department.result.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteDepartmentResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Success message' })
+  message: string;
+
+  constructor(data: { message: string }) {
+    this.success = true;
+    this.message = data.message;
+  }
+}

--- a/src/components/departments/results/unarchive-department.result.ts
+++ b/src/components/departments/results/unarchive-department.result.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UnarchiveDepartmentResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Department ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Archive status' })
+  isArchived: boolean;
+
+  @ApiProperty({ description: 'Success message' })
+  message: string;
+
+  constructor(data: { id: string; deletedAt: Date | null }) {
+    this.success = true;
+    this.id = data.id;
+    this.isArchived = data.deletedAt !== null;
+    this.message = 'Department unarchived successfully';
+  }
+}

--- a/src/components/departments/results/update-department.result.ts
+++ b/src/components/departments/results/update-department.result.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateDepartmentResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Department ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Department name' })
+  name: string;
+
+  @ApiProperty({ description: 'Three character department code' })
+  code: string;
+
+  @ApiProperty({ description: 'Head of Department name', nullable: true })
+  hodName: string | null;
+
+  @ApiProperty({ description: 'Head of Department ID', nullable: true })
+  hodId: string | null;
+
+  @ApiProperty({ description: 'School ID' })
+  schoolId: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  constructor(data: any) {
+    this.success = true;
+    this.id = data.id;
+    this.name = data.name;
+    this.code = data.code;
+    this.hodName = data.hod?.teacher?.user
+      ? `${data.hod.teacher.user.firstName} ${data.hod.teacher.user.lastName}`
+      : null;
+    this.hodId = data.hodId;
+    this.schoolId = data.schoolId;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+}

--- a/src/components/levels/dto/create-level.dto.ts
+++ b/src/components/levels/dto/create-level.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Length } from 'class-validator';
+
+export class CreateLevelDto {
+  @ApiProperty({
+    description: 'Level name',
+    example: 'JSS1',
+  })
+  @IsString()
+  @Length(2, 50, { message: 'Level name must be between 2 and 50 characters' })
+  name: string;
+
+  @ApiProperty({
+    description: 'Three character level code (e.g., JSS, SS1, PRI)',
+    example: 'JSS',
+  })
+  @IsString()
+  @Length(3, 3, { message: 'Level code must be exactly 3 characters' })
+  code: string;
+}

--- a/src/components/levels/dto/update-level.dto.ts
+++ b/src/components/levels/dto/update-level.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, Length } from 'class-validator';
+
+export class UpdateLevelDto {
+  @ApiProperty({
+    description: 'Level name',
+    example: 'JSS1',
+    required: false,
+  })
+  @IsString()
+  @Length(2, 50, { message: 'Level name must be between 2 and 50 characters' })
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    description: 'Three character level code (e.g., JSS, SS1, PRI)',
+    example: 'JSS',
+    required: false,
+  })
+  @IsString()
+  @Length(3, 3, { message: 'Level code must be exactly 3 characters' })
+  @IsOptional()
+  code?: string;
+}

--- a/src/components/levels/levels.controller.ts
+++ b/src/components/levels/levels.controller.ts
@@ -1,0 +1,75 @@
+import { Body, Controller, Delete, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { CheckPolicies, PoliciesGuard } from '../roles-manager';
+import { ManageStudentPolicyHandler } from '../students/policies';
+import { CreateLevelDto } from './dto/create-level.dto';
+import { UpdateLevelDto } from './dto/update-level.dto';
+import { LevelsService } from './levels.service';
+import {
+  ArchiveLevelSwagger,
+  CreateLevelSwagger,
+  DeleteLevelSwagger,
+  UnarchiveLevelSwagger,
+  UpdateLevelSwagger,
+} from './levels.swagger';
+import { ArchiveLevelResult } from './results/archive-level.result';
+import { CreateLevelResult } from './results/create-level.result';
+import { DeleteLevelResult } from './results/delete-level.result';
+import { UnarchiveLevelResult } from './results/unarchive-level.result';
+import { UpdateLevelResult } from './results/update-level.result';
+
+@Controller('levels')
+@ApiTags('Levels')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard, PoliciesGuard)
+export class LevelsController {
+  constructor(private readonly levelsService: LevelsService) {}
+
+  @Post()
+  @CreateLevelSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async createLevel(@GetCurrentUserId() userId: string, @Body() createLevelDto: CreateLevelDto) {
+    const data = await this.levelsService.createLevel(userId, createLevelDto);
+    return new CreateLevelResult(data);
+  }
+
+  @Put(':levelId')
+  @UpdateLevelSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async updateLevel(
+    @GetCurrentUserId() userId: string,
+    @Param('levelId') levelId: string,
+    @Body() updateLevelDto: UpdateLevelDto,
+  ) {
+    const data = await this.levelsService.updateLevel(userId, levelId, updateLevelDto);
+    return new UpdateLevelResult(data);
+  }
+
+  @Post(':levelId/archive')
+  @ArchiveLevelSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async archiveLevel(@GetCurrentUserId() userId: string, @Param('levelId') levelId: string) {
+    const data = await this.levelsService.archiveLevel(userId, levelId);
+    return new ArchiveLevelResult(data);
+  }
+
+  @Post(':levelId/unarchive')
+  @UnarchiveLevelSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async unarchiveLevel(@GetCurrentUserId() userId: string, @Param('levelId') levelId: string) {
+    const data = await this.levelsService.unarchiveLevel(userId, levelId);
+    return new UnarchiveLevelResult(data);
+  }
+
+  @Delete(':levelId')
+  @DeleteLevelSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async deleteLevel(@GetCurrentUserId() userId: string, @Param('levelId') levelId: string) {
+    const data = await this.levelsService.deleteLevel(userId, levelId);
+    return new DeleteLevelResult(data);
+  }
+}

--- a/src/components/levels/levels.module.ts
+++ b/src/components/levels/levels.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { LevelsController } from './levels.controller';
+import { LevelsService } from './levels.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { RolesManagerModule } from '../roles-manager/roles-manager.module';
+import { Encryptor } from '../../utils/encryptor';
+
+@Module({
+  imports: [PrismaModule, AuthModule, RolesManagerModule],
+  controllers: [LevelsController],
+  providers: [LevelsService, Encryptor],
+  exports: [LevelsService],
+})
+export class LevelsModule {}

--- a/src/components/levels/levels.service.ts
+++ b/src/components/levels/levels.service.ts
@@ -1,0 +1,164 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateLevelDto } from './dto/create-level.dto';
+import { UpdateLevelDto } from './dto/update-level.dto';
+
+@Injectable()
+export class LevelsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createLevel(userId: string, createLevelDto: CreateLevelDto) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    const level = await this.prisma.level.create({
+      data: {
+        ...createLevelDto,
+        schoolId: user.schoolId,
+      },
+    });
+
+    return level;
+  }
+
+  async updateLevel(userId: string, levelId: string, updateLevelDto: UpdateLevelDto) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the level belongs to the user's school
+    const existingLevel = await this.prisma.level.findFirst({
+      where: {
+        id: levelId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingLevel) {
+      throw new Error('Level not found or access denied');
+    }
+
+    const level = await this.prisma.level.update({
+      where: { id: levelId },
+      data: updateLevelDto,
+    });
+
+    return level;
+  }
+
+  async archiveLevel(userId: string, levelId: string) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the level belongs to the user's school
+    const existingLevel = await this.prisma.level.findFirst({
+      where: {
+        id: levelId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingLevel) {
+      throw new Error('Level not found or access denied');
+    }
+
+    const level = await this.prisma.level.update({
+      where: { id: levelId },
+      data: { deletedAt: new Date() },
+    });
+
+    return level;
+  }
+
+  async unarchiveLevel(userId: string, levelId: string) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the level belongs to the user's school
+    const existingLevel = await this.prisma.level.findFirst({
+      where: {
+        id: levelId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingLevel) {
+      throw new Error('Level not found or access denied');
+    }
+
+    const level = await this.prisma.level.update({
+      where: { id: levelId },
+      data: { deletedAt: null },
+    });
+
+    return level;
+  }
+
+  async deleteLevel(userId: string, levelId: string) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the level belongs to the user's school
+    const existingLevel = await this.prisma.level.findFirst({
+      where: {
+        id: levelId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingLevel) {
+      throw new Error('Level not found or access denied');
+    }
+
+    // Check if level has associated class arms
+    const classArms = await this.prisma.classArm.findFirst({
+      where: { levelId },
+    });
+
+    if (classArms) {
+      throw new Error(
+        'Cannot delete level. It has associated class arms. Please reassign or remove all associated class arms first.',
+      );
+    }
+
+    await this.prisma.level.delete({
+      where: { id: levelId },
+    });
+
+    return { message: 'Level deleted successfully' };
+  }
+}

--- a/src/components/levels/levels.swagger.ts
+++ b/src/components/levels/levels.swagger.ts
@@ -1,0 +1,108 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function CreateLevelSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a new level' }),
+    ApiResponse({
+      status: 201,
+      description: 'Level created successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+  );
+}
+
+export function UpdateLevelSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update an existing level' }),
+    ApiResponse({
+      status: 200,
+      description: 'Level updated successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Level not found',
+    }),
+  );
+}
+
+export function ArchiveLevelSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Archive a level' }),
+    ApiResponse({
+      status: 200,
+      description: 'Level archived successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Level not found',
+    }),
+  );
+}
+
+export function UnarchiveLevelSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Unarchive a level' }),
+    ApiResponse({
+      status: 200,
+      description: 'Level unarchived successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Level not found',
+    }),
+  );
+}
+
+export function DeleteLevelSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete a level' }),
+    ApiResponse({
+      status: 200,
+      description: 'Level deleted successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request - Level has associated data',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Level not found',
+    }),
+  );
+}

--- a/src/components/levels/results/archive-level.result.ts
+++ b/src/components/levels/results/archive-level.result.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ArchiveLevelResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Level ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Archive status' })
+  isArchived: boolean;
+
+  @ApiProperty({ description: 'Success message' })
+  message: string;
+
+  constructor(data: { id: string; deletedAt: Date | null }) {
+    this.success = true;
+    this.id = data.id;
+    this.isArchived = data.deletedAt !== null;
+    this.message = 'Level archived successfully';
+  }
+}

--- a/src/components/levels/results/create-level.result.ts
+++ b/src/components/levels/results/create-level.result.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateLevelResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Level ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Level name' })
+  name: string;
+
+  @ApiProperty({ description: 'Three character level code' })
+  code: string;
+
+  @ApiProperty({ description: 'School ID' })
+  schoolId: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  constructor(data: {
+    id: string;
+    name: string;
+    code: string;
+    schoolId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.success = true;
+    this.id = data.id;
+    this.name = data.name;
+    this.code = data.code;
+    this.schoolId = data.schoolId;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+}

--- a/src/components/levels/results/delete-level.result.ts
+++ b/src/components/levels/results/delete-level.result.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteLevelResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Success message' })
+  message: string;
+
+  constructor(data: { message: string }) {
+    this.success = true;
+    this.message = data.message;
+  }
+}

--- a/src/components/levels/results/unarchive-level.result.ts
+++ b/src/components/levels/results/unarchive-level.result.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UnarchiveLevelResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Level ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Archive status' })
+  isArchived: boolean;
+
+  @ApiProperty({ description: 'Success message' })
+  message: string;
+
+  constructor(data: { id: string; deletedAt: Date | null }) {
+    this.success = true;
+    this.id = data.id;
+    this.isArchived = data.deletedAt !== null;
+    this.message = 'Level unarchived successfully';
+  }
+}

--- a/src/components/levels/results/update-level.result.ts
+++ b/src/components/levels/results/update-level.result.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateLevelResult {
+  @ApiProperty({ description: 'Success status' })
+  success: boolean;
+
+  @ApiProperty({ description: 'Level ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Level name' })
+  name: string;
+
+  @ApiProperty({ description: 'Three character level code' })
+  code: string;
+
+  @ApiProperty({ description: 'School ID' })
+  schoolId: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  constructor(data: {
+    id: string;
+    name: string;
+    code: string;
+    schoolId: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.success = true;
+    this.id = data.id;
+    this.name = data.name;
+    this.code = data.code;
+    this.schoolId = data.schoolId;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+}

--- a/src/components/students/students.controller.ts
+++ b/src/components/students/students.controller.ts
@@ -1,22 +1,23 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
   HttpStatus,
+  Param,
+  Patch,
+  Post,
   UseGuards,
 } from '@nestjs/common';
-import { StudentsService } from './students.service';
-import { StudentMessages, StudentResult } from './results';
 import { ApiBadRequestResponse, ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { StrategyEnum } from '../auth/strategies';
+import { CheckPolicies, PoliciesGuard } from '../roles-manager';
 import { UserMessages } from '../users/results';
 import { CreateStudentDto, UpdateStudentDto } from './dto';
-import { CheckPolicies, PoliciesGuard } from '../roles-manager';
 import { ManageStudentPolicyHandler } from './policies';
-import { StrategyEnum } from '../auth/strategies';
+import { StudentMessages, StudentResult } from './results';
+import { StudentsService } from './students.service';
 
 @Controller('students')
 @ApiTags('Student')

--- a/src/components/subjects/dto/create-subject.dto.ts
+++ b/src/components/subjects/dto/create-subject.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+
+export class CreateSubjectDto {
+  @ApiProperty({
+    description: 'Name of the subject',
+    example: 'Mathematics',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({
+    description: 'Category of the subject',
+    example: 'CORE',
+    enum: ['CORE', 'GENERAL', 'VOCATIONAL'],
+  })
+  @IsString()
+  @IsNotEmpty()
+  category: string;
+
+  @ApiProperty({
+    description: 'ID of the department this subject belongs to',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  departmentId: string;
+}

--- a/src/components/subjects/dto/update-subject.dto.ts
+++ b/src/components/subjects/dto/update-subject.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsUUID } from 'class-validator';
+
+export class UpdateSubjectDto {
+  @ApiProperty({
+    description: 'Name of the subject',
+    example: 'Mathematics',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    description: 'Category of the subject',
+    example: 'CORE',
+    enum: ['CORE', 'GENERAL', 'VOCATIONAL'],
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  category?: string;
+
+  @ApiProperty({
+    description: 'ID of the department this subject belongs to',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    required: false,
+  })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+}

--- a/src/components/subjects/results/create-subject.result.ts
+++ b/src/components/subjects/results/create-subject.result.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateSubjectResult {
+  @ApiProperty({
+    description: 'Success message',
+    example: 'Subject created successfully',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'Created subject data',
+    type: 'object',
+    additionalProperties: true,
+  })
+  data: any;
+
+  constructor(data: any) {
+    this.message = 'Subject created successfully';
+    this.data = data;
+  }
+}

--- a/src/components/subjects/results/delete-subject.result.ts
+++ b/src/components/subjects/results/delete-subject.result.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteSubjectResult {
+  @ApiProperty({
+    description: 'Success message',
+    example: 'Subject deleted successfully',
+  })
+  message: string;
+
+  constructor(data: any) {
+    this.message = data.message || 'Subject deleted successfully';
+  }
+}

--- a/src/components/subjects/results/update-subject.result.ts
+++ b/src/components/subjects/results/update-subject.result.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateSubjectResult {
+  @ApiProperty({
+    description: 'Success message',
+    example: 'Subject updated successfully',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'Updated subject data',
+    type: 'object',
+    additionalProperties: true,
+  })
+  data: any;
+
+  constructor(data: any) {
+    this.message = 'Subject updated successfully';
+    this.data = data;
+  }
+}

--- a/src/components/subjects/subjects.controller.ts
+++ b/src/components/subjects/subjects.controller.ts
@@ -1,0 +1,58 @@
+import { Body, Controller, Delete, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { CheckPolicies, PoliciesGuard } from '../roles-manager';
+import { ManageStudentPolicyHandler } from '../students/policies';
+import { CreateSubjectDto } from './dto/create-subject.dto';
+import { UpdateSubjectDto } from './dto/update-subject.dto';
+import { CreateSubjectResult } from './results/create-subject.result';
+import { DeleteSubjectResult } from './results/delete-subject.result';
+import { UpdateSubjectResult } from './results/update-subject.result';
+import { SubjectsService } from './subjects.service';
+import {
+  CreateSubjectSwagger,
+  DeleteSubjectSwagger,
+  UpdateSubjectSwagger,
+} from './subjects.swagger';
+
+@Controller('subjects')
+@ApiTags('Subjects')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard, PoliciesGuard)
+export class SubjectsController {
+  constructor(private readonly subjectsService: SubjectsService) {}
+
+  @Post()
+  @CreateSubjectSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async createSubject(
+    @GetCurrentUserId() userId: string,
+    @Body() createSubjectDto: CreateSubjectDto,
+  ) {
+    const data = await this.subjectsService.createSubject(userId, createSubjectDto);
+    return new CreateSubjectResult(data);
+  }
+
+  @Put(':subjectId')
+  @UpdateSubjectSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async updateSubject(
+    @GetCurrentUserId() userId: string,
+    @Param('subjectId') subjectId: string,
+    @Body() updateSubjectDto: UpdateSubjectDto,
+  ) {
+    const data = await this.subjectsService.updateSubject(userId, subjectId, updateSubjectDto);
+    return new UpdateSubjectResult(data);
+  }
+
+  @Delete(':subjectId')
+  @DeleteSubjectSwagger()
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  async deleteSubject(@GetCurrentUserId() userId: string, @Param('subjectId') subjectId: string) {
+    const data = await this.subjectsService.deleteSubject(userId, subjectId);
+    return new DeleteSubjectResult(data);
+  }
+}

--- a/src/components/subjects/subjects.module.ts
+++ b/src/components/subjects/subjects.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { SubjectsController } from './subjects.controller';
+import { SubjectsService } from './subjects.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { RolesManagerModule } from '../roles-manager/roles-manager.module';
+import { Encryptor } from '../../utils/encryptor';
+
+@Module({
+  imports: [PrismaModule, AuthModule, RolesManagerModule],
+  controllers: [SubjectsController],
+  providers: [SubjectsService, Encryptor],
+  exports: [SubjectsService],
+})
+export class SubjectsModule {}

--- a/src/components/subjects/subjects.service.ts
+++ b/src/components/subjects/subjects.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateSubjectDto } from './dto/create-subject.dto';
+import { UpdateSubjectDto } from './dto/update-subject.dto';
+
+@Injectable()
+export class SubjectsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createSubject(userId: string, createSubjectDto: CreateSubjectDto) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    const subject = await this.prisma.subject.create({
+      data: {
+        name: createSubjectDto.name,
+        category: createSubjectDto.category as any,
+        department: createSubjectDto.departmentId ? {
+          connect: { id: createSubjectDto.departmentId },
+        } : undefined,
+        school: {
+          connect: { id: user.schoolId },
+        },
+      },
+      include: {
+        department: true,
+      },
+    });
+
+    return subject;
+  }
+
+  async updateSubject(userId: string, subjectId: string, updateSubjectDto: UpdateSubjectDto) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the subject belongs to the user's school
+    const existingSubject = await this.prisma.subject.findFirst({
+      where: {
+        id: subjectId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingSubject) {
+      throw new Error('Subject not found or access denied');
+    }
+
+    const subject = await this.prisma.subject.update({
+      where: { id: subjectId },
+      data: {
+        ...(updateSubjectDto.name && { name: updateSubjectDto.name }),
+        ...(updateSubjectDto.category && { category: updateSubjectDto.category as any }),
+        ...(updateSubjectDto.departmentId && { 
+          department: {
+            connect: { id: updateSubjectDto.departmentId },
+          },
+        }),
+      },
+      include: {
+        department: true,
+      },
+    });
+
+    return subject;
+  }
+
+  async deleteSubject(userId: string, subjectId: string) {
+    // Get user's school ID
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+
+    if (!user?.schoolId) {
+      throw new Error('User not associated with a school');
+    }
+
+    // Verify the subject belongs to the user's school
+    const existingSubject = await this.prisma.subject.findFirst({
+      where: {
+        id: subjectId,
+        schoolId: user.schoolId,
+      },
+    });
+
+    if (!existingSubject) {
+      throw new Error('Subject not found or access denied');
+    }
+
+    // Check if subject is being used in any curriculum or assessments
+    const subjectUsage = await this.prisma.subjectTerm.findFirst({
+      where: { subjectId },
+    });
+
+    if (subjectUsage) {
+      throw new Error('Cannot delete subject. It is being used in curriculum or assessments.');
+    }
+
+    await this.prisma.subject.delete({
+      where: { id: subjectId },
+    });
+
+    return { message: 'Subject deleted successfully' };
+  }
+}

--- a/src/components/subjects/subjects.swagger.ts
+++ b/src/components/subjects/subjects.swagger.ts
@@ -1,0 +1,64 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export function CreateSubjectSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a new subject' }),
+    ApiResponse({
+      status: 201,
+      description: 'Subject created successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+  );
+}
+
+export function UpdateSubjectSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update an existing subject' }),
+    ApiResponse({
+      status: 200,
+      description: 'Subject updated successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Subject not found',
+    }),
+  );
+}
+
+export function DeleteSubjectSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete a subject' }),
+    ApiResponse({
+      status: 200,
+      description: 'Subject deleted successfully',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Bad request - Subject is being used',
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Subject not found',
+    }),
+  );
+}


### PR DESCRIPTION
- Create dedicated controllers for subjects, departments, and levels
- Move CRUD endpoints from BFF admin controller to new dedicated controllers
- Add proper dependency injection for AuthModule and RolesManagerModule
- Implement proper Prisma relations and soft delete functionality
- Add comprehensive Swagger documentation for all new endpoints
- Update app module list to include new modules

This refactoring follows BFF architecture principles by keeping BFF controllers focused on view-specific operations while moving CRUD operations to dedicated controllers for better separation of concerns.