### PR TITLE
feat: implement bulk student assessment scores with upsert functionality

### DIFF
--- a/BULK_STUDENT_ASSESSMENT_SCORES_API.md
+++ b/BULK_STUDENT_ASSESSMENT_SCORES_API.md
@@ -1,0 +1,489 @@
+# Bulk Student Assessment Scores API
+
+## Overview
+
+This document describes the bulk student assessment scores functionality that allows teachers to create and update multiple student assessment scores in a single API call. This is particularly useful for entering scores for an entire class or updating multiple scores at once.
+
+## Endpoints
+
+### PUT /api/teacher/student-assessment-scores/batch (Recommended)
+
+**Description**: Create or update multiple student assessment scores in a single request. The system automatically detects existing scores and updates them instead of creating duplicates.
+
+**Authentication**: Bearer Token (JWT) required
+
+**Authorization**: Teacher role required - must be assigned to teach the specified subjects in the students' classes
+
+**Request Body:**
+```json
+{
+  "subjectName": "Mathematics",
+  "termName": "First Term",
+  "assessmentName": "Test 1",
+  "assessmentScores": [
+    {
+      "id": "existing-assessment-uuid",
+      "score": 18
+    },
+    {
+      "studentId": "new-student-uuid",
+      "score": 20
+    }
+  ]
+}
+```
+
+**Validation Rules:**
+- Maximum 100 assessment scores per request
+- Minimum 1 assessment score required
+- For **explicit updates**: Must include `id` field
+- For **smart upsert**: Must include `studentId` and provide `subjectName`, `termName`, `assessmentName` at top level
+- Score must be between 0 and 100
+- Teacher must be assigned to teach the specified subject in the student's class
+- `isExam` is optional and will be auto-determined from the assessment structure based on `assessmentName`
+
+**Smart Upsert Behavior:**
+- If no `id` is provided, the system checks if an assessment score already exists for the student/subject/term/assessment combination
+- If found, it updates the existing score instead of creating a duplicate
+- If not found, it creates a new assessment score
+- This prevents duplicate entries when teachers submit scores multiple times
+
+**Database-Level Protection:**
+- A unique constraint ensures that a student cannot have multiple assessment scores for the same assessment in the same term
+- The constraint is on `(subjectTermStudentId, name, deletedAt)` which prevents duplicates at the database level
+- If duplicate creation is attempted, the database will throw a constraint violation error
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Upsert completed. 2 successful, 0 failed.",
+  "status": 200,
+  "data": {
+    "success": [
+      {
+        "id": "existing-assessment-uuid",
+        "name": "Test 1",
+        "score": 18,
+        "isExam": false,
+        "studentId": "student-uuid-1",
+        "studentName": "Jane Smith",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "updatedAt": "2025-01-15T11:00:00Z"
+      },
+      {
+        "id": "new-assessment-uuid",
+        "name": "Test 1",
+        "score": 20,
+        "isExam": false,
+        "studentId": "new-student-uuid",
+        "studentName": "John Doe",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "createdAt": "2025-01-15T11:00:00Z"
+      }
+    ],
+    "failed": []
+  }
+}
+```
+
+### POST /api/teacher/student-assessment-scores/batch
+
+**Description**: Create multiple student assessment scores in bulk
+
+**Authentication**: Bearer Token (JWT) required
+
+**Authorization**: Teacher role required - must be assigned to teach the specified subjects in the students' classes
+
+**Request Body:**
+```json
+{
+  "assessmentScores": [
+    {
+      "studentId": "student-uuid-1",
+      "subjectName": "Mathematics",
+      "termName": "First Term",
+      "assessmentName": "Test 1",
+      "score": 18,
+      "isExam": false
+    },
+    {
+      "studentId": "student-uuid-2",
+      "subjectName": "Mathematics",
+      "termName": "First Term",
+      "assessmentName": "Test 1",
+      "score": 20,
+      "isExam": false
+    },
+    {
+      "studentId": "student-uuid-3",
+      "subjectName": "English",
+      "termName": "First Term",
+      "assessmentName": "Test 1",
+      "score": 16,
+      "isExam": false
+    }
+  ]
+}
+```
+
+**Validation Rules:**
+- Maximum 100 assessment scores per request
+- Minimum 1 assessment score required
+- Each assessment score must have valid `studentId`, `subjectName`, `termName`, `assessmentName`, and `score`
+- Score must be between 0 and 100
+- Teacher must be assigned to teach the specified subject in the student's class
+- Student must exist and be in the teacher's school
+- Subject term must exist and be active
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Bulk creation completed. 3 successful, 0 failed.",
+  "status": 201,
+  "data": {
+    "success": [
+      {
+        "id": "assessment-score-uuid-1",
+        "name": "Test 1",
+        "score": 18,
+        "isExam": false,
+        "studentId": "student-uuid-1",
+        "studentName": "Jane Smith",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "createdAt": "2025-01-15T10:00:00Z"
+      },
+      {
+        "id": "assessment-score-uuid-2",
+        "name": "Test 1",
+        "score": 20,
+        "isExam": false,
+        "studentId": "student-uuid-2",
+        "studentName": "John Doe",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "createdAt": "2025-01-15T10:00:00Z"
+      },
+      {
+        "id": "assessment-score-uuid-3",
+        "name": "Test 1",
+        "score": 16,
+        "isExam": false,
+        "studentId": "student-uuid-3",
+        "studentName": "Alice Johnson",
+        "subjectName": "English",
+        "termName": "First Term",
+        "createdAt": "2025-01-15T10:00:00Z"
+      }
+    ],
+    "failed": []
+  }
+}
+```
+
+### PATCH /api/teacher/student-assessment-scores/batch
+
+**Description**: Update multiple student assessment scores in bulk
+
+**Authentication**: Bearer Token (JWT) required
+
+**Authorization**: Teacher role required - must be assigned to teach the subjects for the assessments being updated
+
+**Request Body:**
+```json
+{
+  "assessmentScores": [
+    {
+      "id": "assessment-score-uuid-1",
+      "score": 19,
+      "assessmentName": "Test 1"
+    },
+    {
+      "id": "assessment-score-uuid-2",
+      "score": 22,
+      "assessmentName": "Test 1"
+    }
+  ]
+}
+```
+
+**Validation Rules:**
+- Maximum 100 assessment scores per request
+- Minimum 1 assessment score required
+- Each assessment score must have a valid `id`
+- Assessment score must exist and belong to the teacher's school
+- Teacher must be authorized to modify the assessment score
+- Score must be between 0 and 100 (if provided)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Bulk update completed. 2 successful, 0 failed.",
+  "status": 200,
+  "data": {
+    "success": [
+      {
+        "id": "assessment-score-uuid-1",
+        "name": "Test 1",
+        "score": 19,
+        "isExam": false,
+        "studentId": "student-uuid-1",
+        "studentName": "Jane Smith",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "updatedAt": "2025-01-15T11:00:00Z"
+      },
+      {
+        "id": "assessment-score-uuid-2",
+        "name": "Test 1",
+        "score": 22,
+        "isExam": false,
+        "studentId": "student-uuid-2",
+        "studentName": "John Doe",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "updatedAt": "2025-01-15T11:00:00Z"
+      }
+    ],
+    "failed": []
+  }
+}
+```
+
+## Error Handling
+
+### Partial Success Response
+
+When some assessment scores succeed and others fail, the API returns a response with both `success` and `failed` arrays:
+
+```json
+{
+  "success": true,
+  "message": "Bulk creation completed. 2 successful, 1 failed.",
+  "status": 201,
+  "data": {
+    "success": [
+      {
+        "id": "assessment-score-uuid-1",
+        "name": "Test 1",
+        "score": 18,
+        "isExam": false,
+        "studentId": "student-uuid-1",
+        "studentName": "Jane Smith",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "createdAt": "2025-01-15T10:00:00Z"
+      }
+    ],
+    "failed": [
+      {
+        "assessmentScore": {
+          "studentId": "invalid-student-id",
+          "subjectName": "Mathematics",
+          "termName": "First Term",
+          "assessmentName": "Test 1",
+          "score": 18
+        },
+        "error": "Student not found or not in your school"
+      }
+    ]
+  }
+}
+```
+
+### Common Error Responses
+
+- `400 Bad Request`: Invalid request data (e.g., missing required fields, score out of range)
+- `401 Unauthorized`: Invalid or missing authentication token
+- `403 Forbidden`: Teacher not authorized to manage assessment scores for the specified students/subjects
+- `404 Not Found`: Student, subject, term, or assessment score not found
+
+## Implementation Details
+
+### Files Created/Modified
+
+1. **DTOs**:
+   - `src/components/bff/teacher/dto/bulk-create-student-assessment-score.dto.ts`
+   - `src/components/bff/teacher/dto/bulk-update-student-assessment-score.dto.ts`
+
+2. **Result Classes**:
+   - `src/components/bff/teacher/results/bulk-student-assessment-score-result.ts`
+
+3. **Service**:
+   - `src/components/bff/teacher/teacher.service.ts` - Added `bulkCreateStudentAssessmentScores()` and `bulkUpdateStudentAssessmentScores()` methods
+
+4. **Controller**:
+   - `src/components/bff/teacher/teacher.controller.ts` - Added bulk endpoints
+
+5. **Index Files**:
+   - Updated DTO and result index files to export new classes
+
+### Key Features
+
+1. **Authorization**: 
+   - Verifies teacher is assigned to teach the specified subjects in the students' classes
+   - Ensures all operations are scoped to the teacher's school
+   - Validates teacher permissions for each assessment score
+
+2. **Error Handling**:
+   - Partial success support - some assessment scores can succeed while others fail
+   - Detailed error messages for failed assessment scores
+   - Continues processing even if individual assessment scores fail
+
+3. **Data Integrity**:
+   - Maintains existing validation rules from individual operations
+   - Updates total scores for subject term students
+   - Preserves referential integrity
+
+4. **Performance**:
+   - Processes assessment scores individually to maintain data consistency
+   - Limits batch size to 100 assessment scores per request
+   - Reuses existing validation and authorization logic
+
+## Usage Examples
+
+### Mixed Create and Update Operations (Recommended)
+
+```bash
+curl -X PUT /api/teacher/student-assessment-scores/batch \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "subjectName": "Mathematics",
+    "termName": "First Term",
+    "assessmentName": "Test 1",
+    "assessmentScores": [
+      {
+        "id": "existing-assessment-1",
+        "score": 19
+      },
+      {
+        "studentId": "student-2",
+        "score": 20
+      },
+      {
+        "id": "existing-assessment-3",
+        "score": 17
+      }
+    ]
+  }'
+```
+
+### Entering Scores for an Entire Class
+
+```bash
+curl -X POST /api/teacher/student-assessment-scores/batch \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assessmentScores": [
+      {
+        "studentId": "student-1",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "assessmentName": "Test 1",
+        "score": 18
+      },
+      {
+        "studentId": "student-2",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "assessmentName": "Test 1",
+        "score": 20
+      },
+      {
+        "studentId": "student-3",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "assessmentName": "Test 1",
+        "score": 16
+      }
+    ]
+  }'
+```
+
+### Updating Multiple Scores
+
+```bash
+curl -X PATCH /api/teacher/student-assessment-scores/batch \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assessmentScores": [
+      {
+        "id": "assessment-1",
+        "score": 19
+      },
+      {
+        "id": "assessment-2",
+        "score": 22
+      },
+      {
+        "id": "assessment-3",
+        "score": 17
+      }
+    ]
+  }'
+```
+
+### Mixed Subject Scores
+
+```bash
+curl -X POST /api/teacher/student-assessment-scores/batch \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assessmentScores": [
+      {
+        "studentId": "student-1",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "assessmentName": "Test 1",
+        "score": 18
+      },
+      {
+        "studentId": "student-1",
+        "subjectName": "English",
+        "termName": "First Term",
+        "assessmentName": "Test 1",
+        "score": 16
+      },
+      {
+        "studentId": "student-2",
+        "subjectName": "Mathematics",
+        "termName": "First Term",
+        "assessmentName": "Test 1",
+        "score": 20
+      }
+    ]
+  }'
+```
+
+## Security Considerations
+
+- All operations are scoped to the authenticated teacher's school
+- Authorization checks ensure only assigned teachers can manage assessment scores
+- Input validation prevents malicious data injection
+- Activity logging tracks all bulk operations for audit purposes
+- Rate limiting should be considered for bulk operations
+
+## Performance Considerations
+
+- Bulk operations are more efficient than individual API calls
+- Individual processing maintains data consistency and proper error handling
+- Total scores are automatically recalculated for each student
+- Consider implementing pagination for very large datasets
+- Monitor database performance during bulk operations
+
+## Integration with Existing Features
+
+- **Assessment Structures**: Automatically determines `isExam` based on assessment structure
+- **Grading Models**: Total scores are updated for grade calculation
+- **Activity Logging**: All bulk operations are logged for audit purposes
+- **Authorization**: Reuses existing teacher-subject-class assignment validation
+- **Data Validation**: Maintains all existing validation rules and constraints

--- a/prisma/migrations/20250914023726_add_unique_assessment_constraint/migration.sql
+++ b/prisma/migrations/20250914023726_add_unique_assessment_constraint/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[subjectTermStudentId,name,deletedAt]` on the table `subject_term_student_assessments` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "subject_term_student_assessments_subjectTermStudentId_name__key" ON "subject_term_student_assessments"("subjectTermStudentId", "name", "deletedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -781,6 +781,7 @@ model SubjectTermStudentAssessment {
   updatedAt            DateTime           @updatedAt
   deletedAt            DateTime?
 
+  @@unique([subjectTermStudentId, name, deletedAt], name: "unique_assessment_per_student_term")
   @@map("subject_term_student_assessments")
 }
 

--- a/src/components/bff/teacher/dto/bulk-create-student-assessment-score.dto.ts
+++ b/src/components/bff/teacher/dto/bulk-create-student-assessment-score.dto.ts
@@ -1,0 +1,19 @@
+import { IsArray, ValidateNested, ArrayMinSize, ArrayMaxSize } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { CreateStudentAssessmentScoreDto } from './create-student-assessment-score.dto';
+
+export class BulkCreateStudentAssessmentScoreDto {
+  @ApiProperty({
+    description: 'Array of student assessment scores to create',
+    type: [CreateStudentAssessmentScoreDto],
+    minItems: 1,
+    maxItems: 100,
+  })
+  @IsArray()
+  @ArrayMinSize(1, { message: 'At least one assessment score is required' })
+  @ArrayMaxSize(100, { message: 'Cannot create more than 100 assessment scores at once' })
+  @ValidateNested({ each: true })
+  @Type(() => CreateStudentAssessmentScoreDto)
+  assessmentScores: CreateStudentAssessmentScoreDto[];
+}

--- a/src/components/bff/teacher/dto/bulk-update-student-assessment-score.dto.ts
+++ b/src/components/bff/teacher/dto/bulk-update-student-assessment-score.dto.ts
@@ -1,0 +1,48 @@
+import { IsArray, ValidateNested, ArrayMinSize, ArrayMaxSize, IsString, IsNotEmpty, IsNumber, IsOptional, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkUpdateStudentAssessmentScoreItemDto {
+  @ApiProperty({
+    description: 'ID of the assessment score to update',
+    example: 'assessment-score-uuid',
+  })
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty({
+    description: 'Score for the assessment',
+    example: 85,
+    minimum: 0,
+    maximum: 100,
+  })
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  score: number;
+
+  @ApiProperty({
+    description: 'Name of the assessment',
+    example: 'Test 1',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  assessmentName?: string;
+}
+
+export class BulkUpdateStudentAssessmentScoreDto {
+  @ApiProperty({
+    description: 'Array of student assessment scores to update',
+    type: [BulkUpdateStudentAssessmentScoreItemDto],
+    minItems: 1,
+    maxItems: 100,
+  })
+  @IsArray()
+  @ArrayMinSize(1, { message: 'At least one assessment score is required' })
+  @ArrayMaxSize(100, { message: 'Cannot update more than 100 assessment scores at once' })
+  @ValidateNested({ each: true })
+  @Type(() => BulkUpdateStudentAssessmentScoreItemDto)
+  assessmentScores: BulkUpdateStudentAssessmentScoreItemDto[];
+}

--- a/src/components/bff/teacher/dto/index.ts
+++ b/src/components/bff/teacher/dto/index.ts
@@ -1,2 +1,5 @@
 export * from './create-student-assessment-score.dto';
 export * from './update-student-assessment-score.dto';
+export * from './bulk-create-student-assessment-score.dto';
+export * from './bulk-update-student-assessment-score.dto';
+export * from './upsert-student-assessment-score.dto';

--- a/src/components/bff/teacher/dto/upsert-student-assessment-score.dto.ts
+++ b/src/components/bff/teacher/dto/upsert-student-assessment-score.dto.ts
@@ -1,0 +1,90 @@
+import { IsArray, ValidateNested, ArrayMinSize, ArrayMaxSize, IsString, IsNotEmpty, IsNumber, IsOptional, Min, Max, IsBoolean } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpsertStudentAssessmentScoreItemDto {
+  @ApiProperty({
+    description: 'ID of the assessment score to update (optional - if not provided, will create new)',
+    example: 'assessment-score-uuid',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  id?: string;
+
+  @ApiProperty({
+    description: 'Student ID (required for new scores, ignored for updates)',
+    example: 'student-uuid',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  studentId?: string;
+
+  @ApiProperty({
+    description: 'Score for the assessment',
+    example: 85,
+    minimum: 0,
+    maximum: 100,
+  })
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  score: number;
+
+  @ApiProperty({
+    description: 'Whether this is an exam (optional - will be auto-determined from assessment structure if not provided)',
+    example: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isExam?: boolean;
+}
+
+export class UpsertStudentAssessmentScoreDto {
+  @ApiProperty({
+    description: 'Subject name (required for new scores)',
+    example: 'Mathematics',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  subjectName?: string;
+
+  @ApiProperty({
+    description: 'Term name (required for new scores)',
+    example: 'First Term',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  termName?: string;
+
+  @ApiProperty({
+    description: 'Assessment name (required for new scores)',
+    example: 'Test 1',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  assessmentName?: string;
+
+  @ApiProperty({
+    description: 'Array of student assessment scores to create or update',
+    type: [UpsertStudentAssessmentScoreItemDto],
+    minItems: 1,
+    maxItems: 100,
+  })
+  @IsArray()
+  @ArrayMinSize(1, { message: 'At least one assessment score is required' })
+  @ArrayMaxSize(100, { message: 'Cannot process more than 100 assessment scores at once' })
+  @ValidateNested({ each: true })
+  @Type(() => UpsertStudentAssessmentScoreItemDto)
+  assessmentScores: UpsertStudentAssessmentScoreItemDto[];
+}

--- a/src/components/bff/teacher/results/bulk-student-assessment-score-result.ts
+++ b/src/components/bff/teacher/results/bulk-student-assessment-score-result.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { HttpStatus } from '@nestjs/common';
+import { BaseResultWithData } from '../../../../common/results';
+
+export interface StudentAssessmentScoreData {
+  id: string;
+  name: string;
+  score: number;
+  isExam: boolean;
+  studentId: string;
+  studentName: string;
+  subjectName: string;
+  termName: string;
+  createdAt: Date;
+  updatedAt?: Date;
+}
+
+export interface BulkStudentAssessmentScoreResult {
+  success: StudentAssessmentScoreData[];
+  failed: {
+    assessmentScore: any;
+    error: string;
+  }[];
+}
+
+export class BulkStudentAssessmentScoreResultClass extends BaseResultWithData<BulkStudentAssessmentScoreResult> {
+  @ApiProperty({
+    description: 'Result of bulk operation',
+    example: {
+      success: [
+        {
+          id: 'assessment-score-1',
+          name: 'Test 1',
+          score: 18,
+          isExam: false,
+          studentId: 'student-123',
+          studentName: 'Jane Smith',
+          subjectName: 'Mathematics',
+          termName: 'First Term',
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      failed: [
+        {
+          assessmentScore: {
+            studentId: 'student-456',
+            subjectName: 'Mathematics',
+            termName: 'First Term',
+            assessmentName: 'Test 1',
+            score: 25,
+          },
+          error: 'Student not found',
+        },
+      ],
+    },
+  })
+  public data: BulkStudentAssessmentScoreResult;
+
+  public static from(
+    result: BulkStudentAssessmentScoreResult,
+    options: { message: string; status: HttpStatus },
+  ): BulkStudentAssessmentScoreResultClass {
+    return new BulkStudentAssessmentScoreResultClass(options.status, options.message, result);
+  }
+}

--- a/src/components/bff/teacher/results/index.ts
+++ b/src/components/bff/teacher/results/index.ts
@@ -7,3 +7,4 @@ export * from './teacher-profile.result';
 export * from './class-details.result';
 export * from './class-students.result';
 export * from './subject-assessment-scores.result';
+export * from './bulk-student-assessment-score-result';

--- a/src/components/bff/teacher/teacher.controller.ts
+++ b/src/components/bff/teacher/teacher.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Put,
   Query,
   UseGuards,
   UseInterceptors,
@@ -17,7 +18,13 @@ import { LogActivity } from '../../../common/decorators/log-activity.decorator';
 import { ActivityLogInterceptor } from '../../../common/interceptors/activity-log.interceptor';
 import { StrategyEnum } from '../../auth/strategies';
 import { AccessTokenGuard } from '../../auth/strategies/jwt/guards/access-token.guard';
-import { CreateStudentAssessmentScoreDto, UpdateStudentAssessmentScoreDto } from './dto';
+import { 
+  CreateStudentAssessmentScoreDto, 
+  UpdateStudentAssessmentScoreDto,
+  BulkCreateStudentAssessmentScoreDto,
+  BulkUpdateStudentAssessmentScoreDto,
+  UpsertStudentAssessmentScoreDto,
+} from './dto';
 import {
   ClassDetailsResult,
   ClassStudentsResult,
@@ -28,6 +35,7 @@ import {
   TeacherEventsResult,
   TeacherProfileResult,
   TeacherSubjectsResult,
+  BulkStudentAssessmentScoreResultClass,
 } from './results';
 import { TeacherService } from './teacher.service';
 import { TeacherDashboardSwagger } from './teacher.swagger';
@@ -329,5 +337,84 @@ export class TeacherController {
       message: result.message,
       data: result.deletedAssessment,
     };
+  }
+
+  // Bulk Student Assessment Score Management Endpoints
+  @Post('student-assessment-scores/batch')
+  @ApiOperation({ summary: 'Create multiple student assessment scores' })
+  @ApiResponse({ 
+    status: 201, 
+    description: 'Assessment scores creation completed',
+    type: BulkStudentAssessmentScoreResultClass,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request - invalid data' })
+  @ApiResponse({ status: 403, description: 'Forbidden - not authorized to teach subjects' })
+  @LogActivity({
+    action: 'BULK_CREATE_STUDENT_ASSESSMENT_SCORES',
+    entityType: 'STUDENT_ASSESSMENT_SCORES',
+    description: 'Teacher created multiple student assessment scores',
+    category: 'TEACHER',
+  })
+  async bulkCreateStudentAssessmentScores(
+    @GetCurrentUserId() userId: string,
+    @Body() bulkCreateDto: BulkCreateStudentAssessmentScoreDto,
+  ) {
+    const result = await this.teacherService.bulkCreateStudentAssessmentScores(userId, bulkCreateDto);
+    return BulkStudentAssessmentScoreResultClass.from(result, {
+      status: 201,
+      message: `Creation completed. ${result.success.length} successful, ${result.failed.length} failed.`,
+    });
+  }
+
+  @Patch('student-assessment-scores/batch')
+  @ApiOperation({ summary: 'Update multiple student assessment scores' })
+  @ApiResponse({ 
+    status: 200, 
+    description: 'Assessment scores update completed',
+    type: BulkStudentAssessmentScoreResultClass,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request - invalid data' })
+  @ApiResponse({ status: 403, description: 'Forbidden - not authorized to modify assessment scores' })
+  @LogActivity({
+    action: 'BULK_UPDATE_STUDENT_ASSESSMENT_SCORES',
+    entityType: 'STUDENT_ASSESSMENT_SCORES',
+    description: 'Teacher updated multiple student assessment scores',
+    category: 'TEACHER',
+  })
+  async bulkUpdateStudentAssessmentScores(
+    @GetCurrentUserId() userId: string,
+    @Body() bulkUpdateDto: BulkUpdateStudentAssessmentScoreDto,
+  ) {
+    const result = await this.teacherService.bulkUpdateStudentAssessmentScores(userId, bulkUpdateDto);
+    return BulkStudentAssessmentScoreResultClass.from(result, {
+      status: 200,
+      message: `Update completed. ${result.success.length} successful, ${result.failed.length} failed.`,
+    });
+  }
+
+  @Put('student-assessment-scores/batch')
+  @ApiOperation({ summary: 'Create or update multiple student assessment scores' })
+  @ApiResponse({ 
+    status: 200, 
+    description: 'Assessment scores upsert completed',
+    type: BulkStudentAssessmentScoreResultClass,
+  })
+  @ApiResponse({ status: 400, description: 'Bad request - invalid data' })
+  @ApiResponse({ status: 403, description: 'Forbidden - not authorized to manage assessment scores' })
+  @LogActivity({
+    action: 'UPSERT_STUDENT_ASSESSMENT_SCORES',
+    entityType: 'STUDENT_ASSESSMENT_SCORES',
+    description: 'Teacher created or updated multiple student assessment scores',
+    category: 'TEACHER',
+  })
+  async upsertStudentAssessmentScores(
+    @GetCurrentUserId() userId: string,
+    @Body() upsertDto: UpsertStudentAssessmentScoreDto,
+  ) {
+    const result = await this.teacherService.upsertStudentAssessmentScores(userId, upsertDto);
+    return BulkStudentAssessmentScoreResultClass.from(result, {
+      status: 200,
+      message: `Upsert completed. ${result.success.length} successful, ${result.failed.length} failed.`,
+    });
   }
 }


### PR DESCRIPTION
- Add bulk create/update DTOs for student assessment scores
- Implement unified upsert endpoint (PUT /batch) for mixed create/update operations
- Add smart upsert logic to prevent duplicate assessment scores
- Optimize request structure with common fields at top level
- Add database-level unique constraint to prevent duplicate assessments
- Include comprehensive API documentation
- Add proper error handling for constraint violations
- Support optional isExam field with auto-determination