### PR TITLE
feat: add school info to student login response and enhance Swagger docs

### DIFF
--- a/src/components/auth/auth.controller.ts
+++ b/src/components/auth/auth.controller.ts
@@ -1,10 +1,11 @@
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { ApiResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
-import { AuthService } from './auth.service';
+
 import { Public } from '../../common/decorators';
+import { AuthService } from './auth.service';
+import { LoginStudentDto } from './dto/login-student.dto';
 import { LoginDto } from './dto/login.dto';
 import { AuthMessages, AuthResult } from './results';
-import { LoginStudentDto } from './dto/login-student.dto';
 
 @Controller('auth')
 @ApiTags('Auth')
@@ -41,10 +42,44 @@ export class AuthController {
   @ApiResponse({
     status: HttpStatus.OK,
     type: AuthResult,
-    description: AuthMessages.SUCCESS.AUTHENTICATED,
+    description: 'Student successfully authenticated with tokens and school information',
+    schema: {
+      example: {
+        status: 200,
+        message: 'Successfully authenticated',
+        data: {
+          student: {
+            id: 'uuid',
+            studentNo: 'STU001',
+            firstName: 'John',
+            lastName: 'Doe',
+            email: 'john.doe@school.com',
+            school: {
+              id: 'school-uuid',
+              name: 'Saint James School',
+              address: '123 School Street',
+              phone: '+1234567890',
+            },
+            classArmId: 'class-arm-uuid',
+            admissionNo: 'ADM001',
+            admissionDate: '2023-09-01T00:00:00.000Z',
+          },
+          tokens: {
+            accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+            refreshToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+          },
+        },
+      },
+    },
   })
   @ApiUnauthorizedResponse({
-    description: AuthMessages.FAILURE.ACCESS_DENIED,
+    description: 'Access denied - Invalid credentials or student must update password',
+    schema: {
+      example: {
+        status: 401,
+        message: 'Access denied',
+      },
+    },
   })
   async loginStudent(@Body() loginDto: LoginStudentDto): Promise<AuthResult> {
     const { tokens, student } = await this.authService.loginStudent(loginDto);

--- a/src/components/auth/dto/base-login.dto.ts
+++ b/src/components/auth/dto/base-login.dto.ts
@@ -1,5 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+
 import { PasswordValidator } from '../../../utils/password';
 
 export class BaseLoginDto {
@@ -11,7 +13,11 @@ export class BaseLoginDto {
   @IsString()
   @ApiProperty({
     type: String,
-    description: PasswordValidator.ValidationErrorMessage,
+    description:
+      'User password - must contain at least one lowercase, uppercase, number, and special character',
+    example: 'MySecure123!',
+    minLength: 6,
+    maxLength: 40,
   })
   password: string;
 }

--- a/src/components/auth/dto/login-student.dto.ts
+++ b/src/components/auth/dto/login-student.dto.ts
@@ -1,8 +1,16 @@
 import { IsString, MinLength } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+
 import { BaseLoginDto } from './base-login.dto';
 
 export class LoginStudentDto extends BaseLoginDto {
   @IsString()
   @MinLength(2)
+  @ApiProperty({
+    description: 'Student number/ID for authentication',
+    example: 'STU001',
+    minLength: 2,
+  })
   studentNo: string;
 }

--- a/src/components/students/students.repository.ts
+++ b/src/components/students/students.repository.ts
@@ -26,7 +26,13 @@ export class StudentsRepository extends Repository<
   findOneByStudentNo(studentNo: string): Promise<Student> {
     return this.findOne({
       where: { studentNo },
-      include: { user: true },
+      include: {
+        user: {
+          include: {
+            school: true,
+          },
+        },
+      },
     });
   }
 


### PR DESCRIPTION
- Update student repository to include school information in getStudentByStudentNo
- Enhance Swagger documentation for student login endpoint with detailed examples
- Add comprehensive API documentation for LoginStudentDto and BaseLoginDto
- Student login now returns school information similar to teacher login
- Improve developer experience with better API documentation and examples