### PR TITLE
fix: correct directory path in deploy workflow for staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,7 +160,7 @@ jobs:
           fi
 
           # Navigate to app directory
-          cd /home/bitnami/schos-backend
+          cd /home/bitnami/schoolos-backend
 
           # Pull latest changes from staging branch
           git pull origin staging


### PR DESCRIPTION
- Updated the directory path from /home/bitnami/schos-backend to /home/bitnami/schoolos-backend in the deploy.yml file to ensure proper navigation during deployment.