### PR TITLE
fix: correct Paystack split bearer and pass contact info for subaccount verification

### DIFF
--- a/src/components/settings/bank-account/bank-account.service.ts
+++ b/src/components/settings/bank-account/bank-account.service.ts
@@ -86,11 +86,19 @@ export class BankAccountService extends BaseService {
         });
       } else {
         // Create new Paystack subaccount
+        const contactEmail = school.email || school.adminUser.email;
         const subaccount = await this.paystackService.createSubaccount(
           school.name,
           dto.bankCode,
           dto.accountNumber,
           0, // We use transaction_charge per payment, not percentage
+          contactEmail
+            ? {
+                email: contactEmail,
+                name: `${school.adminUser.firstName} ${school.adminUser.lastName}`,
+                phone: school.phone || school.adminUser.phone,
+              }
+            : undefined,
         );
         subaccountCode = subaccount.subaccount_code;
       }
@@ -121,11 +129,19 @@ export class BankAccountService extends BaseService {
     }
 
     // Create new account + Paystack subaccount
+    const contactEmail = school.email || school.adminUser.email;
     const subaccount = await this.paystackService.createSubaccount(
       school.name,
       dto.bankCode,
       dto.accountNumber,
       0,
+      contactEmail
+        ? {
+            email: contactEmail,
+            name: `${school.adminUser.firstName} ${school.adminUser.lastName}`,
+            phone: school.phone || school.adminUser.phone,
+          }
+        : undefined,
     );
 
     const bankAccount = await this.prisma.schoolBankAccount.create({
@@ -157,7 +173,14 @@ export class BankAccountService extends BaseService {
   private async getSchoolForUser(userId: string) {
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { schoolId: true, type: true },
+      select: {
+        schoolId: true,
+        type: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        phone: true,
+      },
     });
 
     if (!user?.schoolId) {
@@ -176,6 +199,6 @@ export class BankAccountService extends BaseService {
       throw new NotFoundException('School not found');
     }
 
-    return school;
+    return { ...school, adminUser: user };
   }
 }

--- a/src/shared/services/paystack.service.ts
+++ b/src/shared/services/paystack.service.ts
@@ -151,7 +151,7 @@ export class PaystackService {
 
       if (paymentRequest.subaccount) {
         payload.subaccount = paymentRequest.subaccount;
-        payload.bearer = 'account'; // School (subaccount) bears nothing extra; platform gets transaction_charge
+        payload.bearer = 'subaccount'; // Subaccount bears Paystack fee (already included in studentTotal); platform gets full transaction_charge
       }
 
       if (paymentRequest.transaction_charge !== undefined) {
@@ -278,14 +278,27 @@ export class PaystackService {
     bankCode: string,
     accountNumber: string,
     percentageCharge: number = 0,
+    contactInfo?: { email: string; name?: string; phone?: string },
   ): Promise<PaystackSubaccount> {
     try {
-      const response = await this.paystackClient.post('/subaccount', {
+      const payload: Record<string, any> = {
         business_name: businessName,
         settlement_bank: bankCode,
         account_number: accountNumber,
         percentage_charge: percentageCharge,
-      });
+      };
+
+      if (contactInfo?.email) {
+        payload.primary_contact_email = contactInfo.email;
+      }
+      if (contactInfo?.name) {
+        payload.primary_contact_name = contactInfo.name;
+      }
+      if (contactInfo?.phone) {
+        payload.primary_contact_phone = contactInfo.phone;
+      }
+
+      const response = await this.paystackClient.post('/subaccount', payload);
       if (!response.data.status) {
         throw new BadRequestException(response.data.message || 'Failed to create subaccount');
       }


### PR DESCRIPTION
- Change bearer from 'account' to 'subaccount' so Paystack fee is deducted from the inflated studentTotal rather than eating into platform commission, ensuring schools receive the exact fee amount
- Pass school admin contact details (email, name, phone) when creating Paystack subaccounts so they are verified automatically