### PR TITLE
feat(students): soft delete with global filter + remove-from-class API

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -15,8 +15,8 @@ import {
 
 const prisma = new PrismaClient();
 const passwordHasher = new PasswordHasher();
-const counterService = new CounterService(prisma);
-const activityLogService = new ActivityLogService(prisma);
+const counterService = new CounterService(prisma as any);
+const activityLogService = new ActivityLogService(prisma as any);
 
 // Helper function to log seed activities
 async function logSeedActivity(

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './super-admin.guard';

--- a/src/common/guards/super-admin.guard.ts
+++ b/src/common/guards/super-admin.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+import { UserTypes } from '../../components/users/constants';
+
+@Injectable()
+export class SuperAdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request?.user;
+    if (user?.type !== UserTypes.SUPER_ADMIN) {
+      throw new ForbiddenException('Only super admins can perform this action');
+    }
+    return true;
+  }
+}

--- a/src/components/students/class-arm-students.controller.ts
+++ b/src/components/students/class-arm-students.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Delete, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { StrategyEnum } from '../auth/strategies';
+import { CheckPolicies, PoliciesGuard } from '../roles-manager';
+import { ManageStudentPolicyHandler } from './policies';
+import { ClassArmStudentService } from './services/class-arm-student.service';
+
+@Controller('class-arms')
+@ApiTags('Class Arms')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(PoliciesGuard)
+export class ClassArmStudentsController {
+  constructor(private readonly classArmStudentService: ClassArmStudentService) {}
+
+  @Delete(':classArmId/students/:studentId')
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Student removed from class',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'No active enrollment found',
+  })
+  async removeStudentFromClassArm(
+    @Param('classArmId') classArmId: string,
+    @Param('studentId') studentId: string,
+  ) {
+    const data = await this.classArmStudentService.removeStudentFromClassArm(studentId, classArmId);
+    return { success: true, id: data.id, leftAt: data.leftAt };
+  }
+}

--- a/src/components/students/services/class-arm-student.service.ts
+++ b/src/components/students/services/class-arm-student.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
 
 @Injectable()
@@ -149,13 +149,15 @@ export class ClassArmStudentService {
     academicSessionId: string,
   ) {
     return this.prisma.$transaction(async (tx) => {
-      // Deactivate current enrollment
+      // Deactivate any currently active enrollment in this session. When the
+      // student has no active enrollment (e.g. was just removed from class)
+      // and fromClassArmId is '', this updates nothing — which is fine.
       await tx.classArmStudent.updateMany({
         where: {
           studentId,
-          classArmId: fromClassArmId,
           academicSessionId,
           isActive: true,
+          NOT: { classArmId: toClassArmId },
         },
         data: {
           isActive: false,
@@ -163,9 +165,25 @@ export class ClassArmStudentService {
         },
       });
 
-      // Create new enrollment
-      return tx.classArmStudent.create({
-        data: {
+      // Upsert the target enrollment. A historical row with
+      // (studentId, toClassArmId, academicSessionId) may exist — possibly
+      // soft-deleted if the student was previously removed from this class.
+      // Reactivate it instead of failing on the unique constraint.
+      return tx.classArmStudent.upsert({
+        where: {
+          studentId_classArmId_academicSessionId: {
+            studentId,
+            classArmId: toClassArmId,
+            academicSessionId,
+          },
+        },
+        update: {
+          isActive: true,
+          leftAt: null,
+          deletedAt: null,
+          enrolledAt: new Date(),
+        },
+        create: {
           studentId,
           classArmId: toClassArmId,
           academicSessionId,
@@ -552,5 +570,19 @@ export class ClassArmStudentService {
       skippedCount: alreadyInTargetClassIds.length,
       skippedStudents: alreadyInTargetClassIds,
     };
+  }
+
+  async removeStudentFromClassArm(studentId: string, classArmId: string) {
+    const enrollment = await this.prisma.classArmStudent.findFirst({
+      where: { studentId, classArmId, isActive: true },
+    });
+    if (!enrollment) {
+      throw new NotFoundException('No active enrollment found for student in this class');
+    }
+    const now = new Date();
+    return this.prisma.classArmStudent.update({
+      where: { id: enrollment.id },
+      data: { isActive: false, leftAt: now, deletedAt: now },
+    });
   }
 }

--- a/src/components/students/students.controller.ts
+++ b/src/components/students/students.controller.ts
@@ -12,17 +12,13 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common';
-import {
-  ApiBadRequestResponse,
-  ApiBearerAuth,
-  ApiQuery,
-  ApiResponse,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 
+import { GetCurrentUserId } from '../../common/decorators';
+import { SuperAdminGuard } from '../../common/guards';
 import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
 import { CheckPolicies, PoliciesGuard } from '../roles-manager';
-import { UserMessages } from '../users/results';
 import {
   CreateStudentDto,
   StudentQueryDto,
@@ -400,13 +396,21 @@ export class StudentsController {
   }
 
   @Delete(':id')
+  @UseGuards(AccessTokenGuard, SuperAdminGuard)
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Delete student',
+    description: 'Soft-delete student (super admin only)',
   })
-  @CheckPolicies(new ManageStudentPolicyHandler())
-  remove(@Param('id') id: string) {
-    return this.studentsService.remove(id);
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Only super admins can delete students',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Student not found',
+  })
+  remove(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    return this.studentsService.remove(userId, id);
   }
 
   // Class arm promotion endpoints

--- a/src/components/students/students.module.ts
+++ b/src/components/students/students.module.ts
@@ -2,6 +2,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { StudentsService } from './students.service';
 import { StudentsController } from './students.controller';
+import { ClassArmStudentsController } from './class-arm-students.controller';
 import { UsersModule } from '../users/users.module';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { StudentsRepository } from './students.repository';
@@ -12,6 +13,7 @@ import { CounterModule } from '../../common/counter';
 import { PasswordGenerator } from '../../utils/password/password.generator';
 import { PasswordHasher } from '../../utils/hasher/hasher';
 import { ActivityLogService } from '../../common/services/activity-log.service';
+import { Encryptor } from '../../utils/encryptor';
 import { MailQueueModule } from '../../utils/mail-queue/mail-queue.module';
 import {
   BulkUploadController,
@@ -34,7 +36,7 @@ import { SharedServicesModule } from '../../shared/shared-services.module';
       name: 'student-import',
     }),
   ],
-  controllers: [StudentsController, BulkUploadController],
+  controllers: [StudentsController, ClassArmStudentsController, BulkUploadController],
   providers: [
     StudentsService,
     StudentsRepository,
@@ -45,6 +47,7 @@ import { SharedServicesModule } from '../../shared/shared-services.module';
     BulkUploadService,
     TemplateService,
     StudentImportProcessor,
+    Encryptor,
   ],
   exports: [StudentsService, BulkUploadService, ClassArmStudentService],
 })

--- a/src/components/students/students.service.spec.ts
+++ b/src/components/students/students.service.spec.ts
@@ -1,23 +1,40 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { StudentsService } from './students.service';
-import { UsersService } from '../users/users.service';
-import { StudentsRepository } from './students.repository';
-import { SchoolsService } from '../schools';
+
 import { CounterService } from '../../common/counter';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CurrentTermService } from '../../shared/services/current-term.service';
+import { MailQueueService } from '../../utils/mail-queue/mail-queue.service';
+import { PasswordGenerator } from '../../utils/password/password.generator';
+import { SchoolsService } from '../schools';
+import { UsersService } from '../users/users.service';
+import { ClassArmStudentService } from './services/class-arm-student.service';
+import { StudentsRepository } from './students.repository';
+import { StudentsService } from './students.service';
 
 describe('StudentsService', () => {
   let service: StudentsService;
+  let prisma: {
+    user: { findUnique: jest.Mock; update: jest.Mock };
+    student: { update: jest.Mock };
+    classArmStudent: { updateMany: jest.Mock };
+    rawPrisma: { student: { findFirst: jest.Mock } };
+    $transaction: jest.Mock;
+  };
 
   beforeEach(async () => {
+    prisma = {
+      user: { findUnique: jest.fn(), update: jest.fn() },
+      student: { update: jest.fn() },
+      classArmStudent: { updateMany: jest.fn() },
+      rawPrisma: { student: { findFirst: jest.fn() } },
+      $transaction: jest.fn().mockResolvedValue([]),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         StudentsService,
-        {
-          provide: UsersService,
-          useValue: {
-            save: jest.fn(),
-          },
-        },
+        { provide: UsersService, useValue: { save: jest.fn(), update: jest.fn() } },
         {
           provide: StudentsRepository,
           useValue: {
@@ -28,20 +45,19 @@ describe('StudentsService', () => {
             findById: jest.fn(),
             update: jest.fn(),
             delete: jest.fn(),
+            count: jest.fn(),
           },
         },
+        { provide: SchoolsService, useValue: { getSchoolById: jest.fn() } },
+        { provide: CounterService, useValue: { getNextSequenceNo: jest.fn() } },
+        { provide: PrismaService, useValue: prisma },
+        { provide: PasswordGenerator, useValue: { generate: jest.fn() } },
         {
-          provide: SchoolsService,
-          useValue: {
-            getSchoolById: jest.fn(),
-          },
+          provide: ClassArmStudentService,
+          useValue: { transferStudent: jest.fn(), removeStudentFromClassArm: jest.fn() },
         },
-        {
-          provide: CounterService,
-          useValue: {
-            getNextSequenceNo: jest.fn(),
-          },
-        },
+        { provide: MailQueueService, useValue: { addWelcomeEmail: jest.fn() } },
+        { provide: CurrentTermService, useValue: { getCurrentTermWithSession: jest.fn() } },
       ],
     }).compile();
 
@@ -50,5 +66,62 @@ describe('StudentsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('remove (soft delete)', () => {
+    it('throws BadRequestException when actor has no school', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+      await expect(service.remove('actor-id', 'student-id')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException when student is not in actor school', async () => {
+      prisma.user.findUnique.mockResolvedValue({ schoolId: 'school-1' });
+      prisma.rawPrisma.student.findFirst.mockResolvedValue(null);
+      await expect(service.remove('actor-id', 'student-id')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('is idempotent when student already deleted', async () => {
+      const deletedAt = new Date('2026-01-01');
+      prisma.user.findUnique.mockResolvedValue({ schoolId: 'school-1' });
+      prisma.rawPrisma.student.findFirst.mockResolvedValue({
+        id: 'student-id',
+        userId: 'user-id',
+        deletedAt,
+      });
+      const res = await service.remove('actor-id', 'student-id');
+      expect(res).toEqual({ id: 'student-id', alreadyDeleted: true, deletedAt });
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('soft deletes student, user, and active enrollments in a transaction', async () => {
+      prisma.user.findUnique.mockResolvedValue({ schoolId: 'school-1' });
+      prisma.rawPrisma.student.findFirst.mockResolvedValue({
+        id: 'student-id',
+        userId: 'user-id',
+        deletedAt: null,
+      });
+
+      const res = await service.remove('actor-id', 'student-id');
+
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(prisma.student.update).toHaveBeenCalledWith({
+        where: { id: 'student-id' },
+        data: { deletedAt: expect.any(Date) },
+      });
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-id' },
+        data: { deletedAt: expect.any(Date) },
+      });
+      expect(prisma.classArmStudent.updateMany).toHaveBeenCalledWith({
+        where: { studentId: 'student-id', isActive: true },
+        data: { isActive: false, leftAt: expect.any(Date), deletedAt: expect.any(Date) },
+      });
+      expect(res.id).toBe('student-id');
+      expect(res.deletedAt).toBeInstanceOf(Date);
+    });
   });
 });

--- a/src/components/students/students.service.ts
+++ b/src/components/students/students.service.ts
@@ -503,8 +503,43 @@ export class StudentsService extends BaseService {
     return existingStudent;
   }
 
-  remove(id: string) {
-    return this.studentsRepository.delete({ id });
+  async remove(userId: string, studentId: string) {
+    const actor = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+    if (!actor?.schoolId) {
+      throw new BadRequestException('User not associated with a school');
+    }
+
+    const existing = await this.prisma.rawPrisma.student.findFirst({
+      where: { id: studentId, user: { schoolId: actor.schoolId } },
+      select: { id: true, userId: true, deletedAt: true },
+    });
+    if (!existing) {
+      throw new NotFoundException('Student not found');
+    }
+    if (existing.deletedAt) {
+      return { id: existing.id, alreadyDeleted: true, deletedAt: existing.deletedAt };
+    }
+
+    const now = new Date();
+    await this.prisma.$transaction([
+      this.prisma.student.update({
+        where: { id: studentId },
+        data: { deletedAt: now },
+      }),
+      this.prisma.user.update({
+        where: { id: existing.userId },
+        data: { deletedAt: now },
+      }),
+      this.prisma.classArmStudent.updateMany({
+        where: { studentId, isActive: true },
+        data: { isActive: false, leftAt: now, deletedAt: now },
+      }),
+    ]);
+
+    return { id: studentId, deletedAt: now };
   }
 
   async getStudentOverview(schoolId: string) {

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,5 +1,104 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
+const READ_OPS = new Set<string>([
+  'findUnique',
+  'findUniqueOrThrow',
+  'findFirst',
+  'findFirstOrThrow',
+  'findMany',
+  'count',
+  'aggregate',
+  'groupBy',
+]);
+
+const STUDENT_LINKED_MODELS = new Set<string>([
+  'classArmStudent',
+  'studentPromotion',
+  'studentStatusHistory',
+  'studentPayment',
+  'resultComment',
+  'prefect',
+  'classArmStudentAssessment',
+]);
+
+function buildLinkedModelExtension() {
+  return {
+    async $allOperations({
+      operation,
+      args,
+      query,
+    }: {
+      operation: string;
+      args: any;
+      query: (args: any) => Promise<any>;
+    }) {
+      if (READ_OPS.has(operation)) {
+        const prevWhere = args.where ?? {};
+        const prevStudent = prevWhere.student ?? {};
+        args.where = {
+          ...prevWhere,
+          student: { ...prevStudent, deletedAt: null },
+        };
+      }
+      return query(args);
+    },
+  };
+}
+
+function buildExtended(base: PrismaClient) {
+  const linked = Object.fromEntries(
+    Array.from(STUDENT_LINKED_MODELS).map((m) => [m, buildLinkedModelExtension()]),
+  );
+  return base.$extends({
+    name: 'softDeleteStudent',
+    query: {
+      student: {
+        async $allOperations({ operation, args, query }) {
+          if (READ_OPS.has(operation)) {
+            const a = args as any;
+            a.where = { ...(a.where ?? {}), deletedAt: null };
+          }
+          return query(args);
+        },
+      },
+      ...linked,
+    },
+  });
+}
+
+type ExtendedClient = ReturnType<typeof buildExtended>;
+
 @Injectable()
-export class PrismaService extends PrismaClient {}
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  private readonly _extended: ExtendedClient;
+  public readonly rawPrisma: PrismaClient;
+
+  constructor() {
+    super();
+    this._extended = buildExtended(this);
+    this.rawPrisma = this;
+
+    return new Proxy(this, {
+      get(target, prop, receiver) {
+        const key = typeof prop === 'string' ? prop : undefined;
+        if (key === 'rawPrisma') {
+          return target;
+        }
+        if (key === 'student' || (key && STUDENT_LINKED_MODELS.has(key))) {
+          return (target._extended as any)[key];
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as unknown as PrismaService;
+  }
+
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/test/helper/generators.ts
+++ b/test/helper/generators.ts
@@ -7,7 +7,7 @@ import { getNextUserEntityNoFormatted } from '../../src/utils/misc';
 const prisma = new PrismaClient();
 const faker = new Faker();
 const hasher = new PasswordHasher();
-const counterService = new CounterService(prisma);
+const counterService = new CounterService(prisma as any);
 
 export async function generateSchool() {
   return prisma.school.create({
@@ -236,10 +236,7 @@ export async function generateClassArmTeacher(teacherId: string, classArmId: str
   });
 }
 
-export async function generateClassArmSubjectTeacher(
-  teacherId: string,
-  classArmSubjectId: string,
-) {
+export async function generateClassArmSubjectTeacher(teacherId: string, classArmSubjectId: string) {
   return prisma.classArmSubjectTeacher.create({
     data: {
       teacher: { connect: { id: teacherId } },


### PR DESCRIPTION
Convert DELETE /students/:id to an irreversible soft delete gated by a new SuperAdminGuard. In one transaction, set Student.deletedAt, User.deletedAt, and deactivate every active ClassArmStudent row for the student (isActive=false, leftAt, deletedAt). Return { alreadyDeleted: true } on re-run for idempotency.

Install a Prisma Client Extension on PrismaService that auto-injects the soft-delete filter on every read:
- Student: deletedAt: null merged at the top level (so findUnique keeps its unique key where Prisma expects it).
- classArmStudent, studentPromotion, studentStatusHistory, studentPayment, resultComment, prefect, classArmStudentAssessment: student: { deletedAt: null } merged under the student relation.

Expose PrismaService.rawPrisma as a sanctioned bypass for the archive flow, which must read already-archived rows to stay idempotent.

Add DELETE /class-arms/:classArmId/students/:studentId backed by ClassArmStudentService.removeStudentFromClassArm(), which sets isActive=false, leftAt, and deletedAt on the active enrollment.

Fix ClassArmStudentService.transferStudent unique-constraint failure when reassigning a student to a class they were previously in:
- Replace create() with upsert() keyed on (studentId, classArmId, academicSessionId), reactivating any historical row instead of colliding with it.
- Widen the deactivate step to any active enrollment in the session other than the target, so students with no active enrollment (just removed from class) flow through correctly.

Register Encryptor as a provider in StudentsModule so AccessTokenGuard (used by the new Delete endpoint) can resolve its dependency, matching the pattern in every other module that composes AccessTokenGuard.

Update students.service.spec with coverage for remove(): tenant check, not-found, idempotent re-run, and the three-update transaction shape.