### PR TITLE
Feat/assessments premium beta (#129)

### DIFF
--- a/prisma/migrations/20260425210314_add_quiz_system/migration.sql
+++ b/prisma/migrations/20260425210314_add_quiz_system/migration.sql
@@ -1,0 +1,512 @@
+-- CreateEnum
+CREATE TYPE "QuestionOwnerType" AS ENUM ('SCHOS_CURATED', 'TEACHER_AUTHORED');
+
+-- CreateEnum
+CREATE TYPE "QuizOwnerType" AS ENUM ('SCHOS_CURATED', 'TEACHER_AUTHORED');
+
+-- CreateEnum
+CREATE TYPE "QuestionType" AS ENUM ('MCQ_SINGLE', 'MCQ_MULTI', 'TRUE_FALSE', 'NUMERIC', 'SHORT_ANSWER');
+
+-- CreateEnum
+CREATE TYPE "QuestionDifficulty" AS ENUM ('EASY', 'MEDIUM', 'HARD');
+
+-- CreateEnum
+CREATE TYPE "QuestionStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "QuizStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "PartialCreditMode" AS ENUM ('NONE', 'PROPORTIONAL');
+
+-- CreateEnum
+CREATE TYPE "QuizDeliveryMode" AS ENUM ('OPEN_WINDOW', 'SYNC_START');
+
+-- CreateEnum
+CREATE TYPE "QuizAssignmentStatus" AS ENUM ('SCHEDULED', 'OPEN', 'CLOSED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "QuizOverrideType" AS ENUM ('RETRY', 'EXTEND_WINDOW', 'EXTRA_TIME');
+
+-- CreateEnum
+CREATE TYPE "QuizAttemptStatus" AS ENUM ('IN_PROGRESS', 'SUBMITTED', 'GRADING', 'GRADED');
+
+-- CreateEnum
+CREATE TYPE "AggregationMethod" AS ENUM ('SUM', 'AVERAGE', 'WEIGHTED', 'BEST_OF_N');
+
+-- CreateEnum
+CREATE TYPE "MissingAttemptPolicy" AS ENUM ('TREAT_AS_ZERO', 'EXCLUDE_FROM_DENOMINATOR');
+
+-- CreateEnum
+CREATE TYPE "QuizAggregationStatus" AS ENUM ('DRAFT', 'FINALIZED');
+
+-- CreateTable
+CREATE TABLE "topics" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "parentTopicId" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "canonicalSubjectName" TEXT NOT NULL,
+    "canonicalLevelCode" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "topics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "popular_exams" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "country" TEXT,
+    "description" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "popular_exams_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "questions" (
+    "id" TEXT NOT NULL,
+    "ownerType" "QuestionOwnerType" NOT NULL,
+    "schoolId" TEXT,
+    "authorUserId" TEXT NOT NULL,
+    "subjectId" TEXT,
+    "levelId" TEXT,
+    "defaultTermId" TEXT,
+    "type" "QuestionType" NOT NULL,
+    "prompt" JSONB NOT NULL,
+    "promptPlainText" TEXT NOT NULL,
+    "mediaUrls" TEXT[],
+    "explanation" JSONB,
+    "weight" DECIMAL(10,2) NOT NULL DEFAULT 1.0,
+    "difficulty" "QuestionDifficulty",
+    "status" "QuestionStatus" NOT NULL DEFAULT 'DRAFT',
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "sourceQuestionId" TEXT,
+    "config" JSONB,
+    "partialCreditMode" "PartialCreditMode",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "questions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "question_options" (
+    "id" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "label" JSONB NOT NULL,
+    "labelPlainText" TEXT NOT NULL,
+    "isCorrect" BOOLEAN NOT NULL DEFAULT false,
+    "mediaUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "question_options_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "question_topics" (
+    "questionId" TEXT NOT NULL,
+    "topicId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "question_topics_pkey" PRIMARY KEY ("questionId","topicId")
+);
+
+-- CreateTable
+CREATE TABLE "question_popular_exams" (
+    "id" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "popularExamId" TEXT NOT NULL,
+    "examYear" INTEGER,
+    "paperReference" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "question_popular_exams_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quizzes" (
+    "id" TEXT NOT NULL,
+    "ownerType" "QuizOwnerType" NOT NULL,
+    "schoolId" TEXT,
+    "authorUserId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "instructions" TEXT,
+    "subjectId" TEXT,
+    "levelId" TEXT,
+    "defaultTermId" TEXT,
+    "status" "QuizStatus" NOT NULL DEFAULT 'DRAFT',
+    "estimatedMinutes" INTEGER,
+    "passMarkPercent" DECIMAL(5,2),
+    "difficulty" "QuestionDifficulty",
+    "defaultSettings" JSONB,
+    "sourceQuizId" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "quizzes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quiz_questions" (
+    "quizId" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "weightOverride" DECIMAL(10,2),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "quiz_questions_pkey" PRIMARY KEY ("quizId","questionId")
+);
+
+-- CreateTable
+CREATE TABLE "quiz_topics" (
+    "quizId" TEXT NOT NULL,
+    "topicId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "quiz_topics_pkey" PRIMARY KEY ("quizId","topicId")
+);
+
+-- CreateTable
+CREATE TABLE "quiz_assignments" (
+    "id" TEXT NOT NULL,
+    "quizId" TEXT NOT NULL,
+    "quizVersion" INTEGER NOT NULL,
+    "classArmSubjectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "assignedByTeacherId" TEXT NOT NULL,
+    "mode" "QuizDeliveryMode" NOT NULL,
+    "windowOpensAt" TIMESTAMP(3) NOT NULL,
+    "windowClosesAt" TIMESTAMP(3) NOT NULL,
+    "durationMinutes" INTEGER NOT NULL,
+    "syncGracePeriodSeconds" INTEGER DEFAULT 60,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 1,
+    "showResultsImmediately" BOOLEAN,
+    "showCorrectAnswers" BOOLEAN,
+    "resultsReleasedAt" TIMESTAMP(3),
+    "status" "QuizAssignmentStatus" NOT NULL DEFAULT 'SCHEDULED',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "quiz_assignments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quiz_attempt_overrides" (
+    "id" TEXT NOT NULL,
+    "quizAssignmentId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "grantedByTeacherId" TEXT NOT NULL,
+    "type" "QuizOverrideType" NOT NULL,
+    "extraAttempts" INTEGER,
+    "extraMinutes" INTEGER,
+    "newWindowClosesAt" TIMESTAMP(3),
+    "reason" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "quiz_attempt_overrides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quiz_attempts" (
+    "id" TEXT NOT NULL,
+    "quizAssignmentId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "attemptNumber" INTEGER NOT NULL DEFAULT 1,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dueAt" TIMESTAMP(3) NOT NULL,
+    "submittedAt" TIMESTAMP(3),
+    "autoSubmitted" BOOLEAN NOT NULL DEFAULT false,
+    "status" "QuizAttemptStatus" NOT NULL DEFAULT 'IN_PROGRESS',
+    "totalScore" DECIMAL(10,2),
+    "maxScore" DECIMAL(10,2) NOT NULL,
+    "percentage" DECIMAL(5,2),
+    "pageVisibilityEvents" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "quiz_attempts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "question_responses" (
+    "id" TEXT NOT NULL,
+    "attemptId" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "responseJson" JSONB,
+    "weight" DECIMAL(10,2) NOT NULL,
+    "pointsAwarded" DECIMAL(10,2),
+    "isCorrect" BOOLEAN,
+    "autoGraded" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "question_responses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quiz_score_aggregations" (
+    "id" TEXT NOT NULL,
+    "schoolId" TEXT NOT NULL,
+    "classArmSubjectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "assessmentTemplateEntryId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "aggregationMethod" "AggregationMethod" NOT NULL,
+    "bestOfN" INTEGER,
+    "rescaleToMaxScore" INTEGER NOT NULL,
+    "missingAttemptPolicy" "MissingAttemptPolicy" NOT NULL DEFAULT 'TREAT_AS_ZERO',
+    "status" "QuizAggregationStatus" NOT NULL DEFAULT 'DRAFT',
+    "finalizedAt" TIMESTAMP(3),
+    "finalizedByTeacherId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "quiz_score_aggregations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quiz_score_aggregation_items" (
+    "id" TEXT NOT NULL,
+    "aggregationId" TEXT NOT NULL,
+    "quizAssignmentId" TEXT NOT NULL,
+    "weight" DECIMAL(10,2) NOT NULL DEFAULT 1.0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "quiz_score_aggregation_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "topics_slug_key" ON "topics"("slug");
+
+-- CreateIndex
+CREATE INDEX "topics_canonicalSubjectName_canonicalLevelCode_idx" ON "topics"("canonicalSubjectName", "canonicalLevelCode");
+
+-- CreateIndex
+CREATE INDEX "topics_parentTopicId_idx" ON "topics"("parentTopicId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "popular_exams_code_key" ON "popular_exams"("code");
+
+-- CreateIndex
+CREATE INDEX "questions_schoolId_authorUserId_status_idx" ON "questions"("schoolId", "authorUserId", "status");
+
+-- CreateIndex
+CREATE INDEX "questions_subjectId_levelId_idx" ON "questions"("subjectId", "levelId");
+
+-- CreateIndex
+CREATE INDEX "questions_ownerType_status_idx" ON "questions"("ownerType", "status");
+
+-- CreateIndex
+CREATE INDEX "question_options_questionId_idx" ON "question_options"("questionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "question_options_questionId_order_key" ON "question_options"("questionId", "order");
+
+-- CreateIndex
+CREATE INDEX "question_topics_topicId_idx" ON "question_topics"("topicId");
+
+-- CreateIndex
+CREATE INDEX "question_popular_exams_popularExamId_examYear_idx" ON "question_popular_exams"("popularExamId", "examYear");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "question_popular_exams_questionId_popularExamId_examYear_key" ON "question_popular_exams"("questionId", "popularExamId", "examYear");
+
+-- CreateIndex
+CREATE INDEX "quizzes_schoolId_authorUserId_status_idx" ON "quizzes"("schoolId", "authorUserId", "status");
+
+-- CreateIndex
+CREATE INDEX "quizzes_subjectId_levelId_idx" ON "quizzes"("subjectId", "levelId");
+
+-- CreateIndex
+CREATE INDEX "quizzes_ownerType_status_idx" ON "quizzes"("ownerType", "status");
+
+-- CreateIndex
+CREATE INDEX "quiz_questions_questionId_idx" ON "quiz_questions"("questionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "quiz_questions_quizId_order_key" ON "quiz_questions"("quizId", "order");
+
+-- CreateIndex
+CREATE INDEX "quiz_topics_topicId_idx" ON "quiz_topics"("topicId");
+
+-- CreateIndex
+CREATE INDEX "quiz_assignments_classArmSubjectId_termId_status_idx" ON "quiz_assignments"("classArmSubjectId", "termId", "status");
+
+-- CreateIndex
+CREATE INDEX "quiz_assignments_windowOpensAt_windowClosesAt_idx" ON "quiz_assignments"("windowOpensAt", "windowClosesAt");
+
+-- CreateIndex
+CREATE INDEX "quiz_assignments_quizId_idx" ON "quiz_assignments"("quizId");
+
+-- CreateIndex
+CREATE INDEX "quiz_attempt_overrides_quizAssignmentId_studentId_idx" ON "quiz_attempt_overrides"("quizAssignmentId", "studentId");
+
+-- CreateIndex
+CREATE INDEX "quiz_attempt_overrides_studentId_idx" ON "quiz_attempt_overrides"("studentId");
+
+-- CreateIndex
+CREATE INDEX "quiz_attempts_quizAssignmentId_status_idx" ON "quiz_attempts"("quizAssignmentId", "status");
+
+-- CreateIndex
+CREATE INDEX "quiz_attempts_studentId_status_idx" ON "quiz_attempts"("studentId", "status");
+
+-- CreateIndex
+CREATE INDEX "quiz_attempts_dueAt_status_idx" ON "quiz_attempts"("dueAt", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "quiz_attempts_quizAssignmentId_studentId_attemptNumber_key" ON "quiz_attempts"("quizAssignmentId", "studentId", "attemptNumber");
+
+-- CreateIndex
+CREATE INDEX "question_responses_attemptId_idx" ON "question_responses"("attemptId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "question_responses_attemptId_questionId_key" ON "question_responses"("attemptId", "questionId");
+
+-- CreateIndex
+CREATE INDEX "quiz_score_aggregations_schoolId_classArmSubjectId_termId_idx" ON "quiz_score_aggregations"("schoolId", "classArmSubjectId", "termId");
+
+-- CreateIndex
+CREATE INDEX "quiz_score_aggregations_assessmentTemplateEntryId_idx" ON "quiz_score_aggregations"("assessmentTemplateEntryId");
+
+-- CreateIndex
+CREATE INDEX "quiz_score_aggregation_items_quizAssignmentId_idx" ON "quiz_score_aggregation_items"("quizAssignmentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "quiz_score_aggregation_items_aggregationId_quizAssignmentId_key" ON "quiz_score_aggregation_items"("aggregationId", "quizAssignmentId");
+
+-- AddForeignKey
+ALTER TABLE "topics" ADD CONSTRAINT "topics_parentTopicId_fkey" FOREIGN KEY ("parentTopicId") REFERENCES "topics"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "questions" ADD CONSTRAINT "questions_schoolId_fkey" FOREIGN KEY ("schoolId") REFERENCES "schools"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "questions" ADD CONSTRAINT "questions_authorUserId_fkey" FOREIGN KEY ("authorUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "questions" ADD CONSTRAINT "questions_subjectId_fkey" FOREIGN KEY ("subjectId") REFERENCES "subjects"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "questions" ADD CONSTRAINT "questions_levelId_fkey" FOREIGN KEY ("levelId") REFERENCES "levels"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "questions" ADD CONSTRAINT "questions_defaultTermId_fkey" FOREIGN KEY ("defaultTermId") REFERENCES "terms"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "questions" ADD CONSTRAINT "questions_sourceQuestionId_fkey" FOREIGN KEY ("sourceQuestionId") REFERENCES "questions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_options" ADD CONSTRAINT "question_options_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "questions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_topics" ADD CONSTRAINT "question_topics_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "questions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_topics" ADD CONSTRAINT "question_topics_topicId_fkey" FOREIGN KEY ("topicId") REFERENCES "topics"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_popular_exams" ADD CONSTRAINT "question_popular_exams_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "questions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_popular_exams" ADD CONSTRAINT "question_popular_exams_popularExamId_fkey" FOREIGN KEY ("popularExamId") REFERENCES "popular_exams"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_schoolId_fkey" FOREIGN KEY ("schoolId") REFERENCES "schools"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_authorUserId_fkey" FOREIGN KEY ("authorUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_subjectId_fkey" FOREIGN KEY ("subjectId") REFERENCES "subjects"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_levelId_fkey" FOREIGN KEY ("levelId") REFERENCES "levels"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_defaultTermId_fkey" FOREIGN KEY ("defaultTermId") REFERENCES "terms"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quizzes" ADD CONSTRAINT "quizzes_sourceQuizId_fkey" FOREIGN KEY ("sourceQuizId") REFERENCES "quizzes"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_questions" ADD CONSTRAINT "quiz_questions_quizId_fkey" FOREIGN KEY ("quizId") REFERENCES "quizzes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_questions" ADD CONSTRAINT "quiz_questions_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "questions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_topics" ADD CONSTRAINT "quiz_topics_quizId_fkey" FOREIGN KEY ("quizId") REFERENCES "quizzes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_topics" ADD CONSTRAINT "quiz_topics_topicId_fkey" FOREIGN KEY ("topicId") REFERENCES "topics"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_assignments" ADD CONSTRAINT "quiz_assignments_quizId_fkey" FOREIGN KEY ("quizId") REFERENCES "quizzes"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_assignments" ADD CONSTRAINT "quiz_assignments_classArmSubjectId_fkey" FOREIGN KEY ("classArmSubjectId") REFERENCES "class_arm_subjects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_assignments" ADD CONSTRAINT "quiz_assignments_termId_fkey" FOREIGN KEY ("termId") REFERENCES "terms"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_assignments" ADD CONSTRAINT "quiz_assignments_assignedByTeacherId_fkey" FOREIGN KEY ("assignedByTeacherId") REFERENCES "teachers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_attempt_overrides" ADD CONSTRAINT "quiz_attempt_overrides_quizAssignmentId_fkey" FOREIGN KEY ("quizAssignmentId") REFERENCES "quiz_assignments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_attempt_overrides" ADD CONSTRAINT "quiz_attempt_overrides_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_attempt_overrides" ADD CONSTRAINT "quiz_attempt_overrides_grantedByTeacherId_fkey" FOREIGN KEY ("grantedByTeacherId") REFERENCES "teachers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_attempts" ADD CONSTRAINT "quiz_attempts_quizAssignmentId_fkey" FOREIGN KEY ("quizAssignmentId") REFERENCES "quiz_assignments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_attempts" ADD CONSTRAINT "quiz_attempts_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_responses" ADD CONSTRAINT "question_responses_attemptId_fkey" FOREIGN KEY ("attemptId") REFERENCES "quiz_attempts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "question_responses" ADD CONSTRAINT "question_responses_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "questions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_score_aggregations" ADD CONSTRAINT "quiz_score_aggregations_schoolId_fkey" FOREIGN KEY ("schoolId") REFERENCES "schools"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_score_aggregations" ADD CONSTRAINT "quiz_score_aggregations_classArmSubjectId_fkey" FOREIGN KEY ("classArmSubjectId") REFERENCES "class_arm_subjects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_score_aggregations" ADD CONSTRAINT "quiz_score_aggregations_termId_fkey" FOREIGN KEY ("termId") REFERENCES "terms"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_score_aggregations" ADD CONSTRAINT "quiz_score_aggregations_finalizedByTeacherId_fkey" FOREIGN KEY ("finalizedByTeacherId") REFERENCES "teachers"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_score_aggregation_items" ADD CONSTRAINT "quiz_score_aggregation_items_aggregationId_fkey" FOREIGN KEY ("aggregationId") REFERENCES "quiz_score_aggregations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_score_aggregation_items" ADD CONSTRAINT "quiz_score_aggregation_items_quizAssignmentId_fkey" FOREIGN KEY ("quizAssignmentId") REFERENCES "quiz_assignments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260425225439_add_canonical_taxonomy_fields/migration.sql
+++ b/prisma/migrations/20260425225439_add_canonical_taxonomy_fields/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "questions" ADD COLUMN     "canonicalLevelCode" TEXT,
+ADD COLUMN     "canonicalSubjectName" TEXT,
+ADD COLUMN     "canonicalTermName" TEXT;
+
+-- AlterTable
+ALTER TABLE "quizzes" ADD COLUMN     "canonicalLevelCode" TEXT,
+ADD COLUMN     "canonicalSubjectName" TEXT,
+ADD COLUMN     "canonicalTermName" TEXT;
+
+-- CreateIndex
+CREATE INDEX "questions_canonicalSubjectName_canonicalLevelCode_idx" ON "questions"("canonicalSubjectName", "canonicalLevelCode");
+
+-- CreateIndex
+CREATE INDEX "quizzes_canonicalSubjectName_canonicalLevelCode_idx" ON "quizzes"("canonicalSubjectName", "canonicalLevelCode");

--- a/prisma/migrations/20260426021536_add_canonical_refs_and_question_number/migration.sql
+++ b/prisma/migrations/20260426021536_add_canonical_refs_and_question_number/migration.sql
@@ -1,0 +1,66 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `paperReference` on the `question_popular_exams` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "question_popular_exams" DROP COLUMN "paperReference",
+ADD COLUMN     "questionNumber" TEXT;
+
+-- CreateTable
+CREATE TABLE "canonical_subjects" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "canonical_subjects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "canonical_levels" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "group" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "canonical_levels_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "canonical_terms" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "canonical_terms_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "canonical_subjects_name_key" ON "canonical_subjects"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "canonical_subjects_slug_key" ON "canonical_subjects"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "canonical_levels_code_key" ON "canonical_levels"("code");
+
+-- CreateIndex
+CREATE INDEX "canonical_levels_group_order_idx" ON "canonical_levels"("group", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "canonical_terms_name_key" ON "canonical_terms"("name");

--- a/prisma/migrations/20260429092150_add_assessments_feature_flag_and_usage_events/migration.sql
+++ b/prisma/migrations/20260429092150_add_assessments_feature_flag_and_usage_events/migration.sql
@@ -1,0 +1,39 @@
+-- AlterTable
+ALTER TABLE "schools" ADD COLUMN     "assessmentsDisabledAt" TIMESTAMP(3),
+ADD COLUMN     "assessmentsEnabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "assessmentsEnabledAt" TIMESTAMP(3),
+ADD COLUMN     "assessmentsEnabledById" TEXT;
+
+-- CreateTable
+CREATE TABLE "quiz_usage_events" (
+    "id" TEXT NOT NULL,
+    "schoolId" TEXT NOT NULL,
+    "quizAttemptId" TEXT NOT NULL,
+    "quizAssignmentId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "durationMinutes" INTEGER NOT NULL,
+    "questionCount" INTEGER NOT NULL,
+    "chargeableUnits" DECIMAL(10,2) NOT NULL,
+    "unitRateSnapshot" DECIMAL(10,4) NOT NULL,
+    "amountKobo" INTEGER NOT NULL,
+    "isWaived" BOOLEAN NOT NULL DEFAULT false,
+    "waiverReason" TEXT,
+    "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "quiz_usage_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "quiz_usage_events_quizAttemptId_key" ON "quiz_usage_events"("quizAttemptId");
+
+-- CreateIndex
+CREATE INDEX "quiz_usage_events_schoolId_recordedAt_idx" ON "quiz_usage_events"("schoolId", "recordedAt");
+
+-- CreateIndex
+CREATE INDEX "quiz_usage_events_schoolId_isWaived_idx" ON "quiz_usage_events"("schoolId", "isWaived");
+
+-- AddForeignKey
+ALTER TABLE "quiz_usage_events" ADD CONSTRAINT "quiz_usage_events_schoolId_fkey" FOREIGN KEY ("schoolId") REFERENCES "schools"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_usage_events" ADD CONSTRAINT "quiz_usage_events_quizAttemptId_fkey" FOREIGN KEY ("quizAttemptId") REFERENCES "quiz_attempts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,10 @@ model School {
   resultTemplateId             String?                       @default("professional") @map("result_template_id")
   currentTermId                String?                       @map("current_term_id")
   currentTerm                  Term?                         @relation("SchoolCurrentTerm", fields: [currentTermId], references: [id])
+  assessmentsEnabled           Boolean                       @default(false)
+  assessmentsEnabledAt         DateTime?
+  assessmentsEnabledById       String?
+  assessmentsDisabledAt        DateTime?
   academicSessions             AcademicSession[]
   assessmentStructureTemplates AssessmentStructureTemplate[]
   bulkImportJobs               BulkImportJob[]
@@ -107,6 +111,10 @@ model School {
   /// has not yet been cancelled or executed. Used as a fast check on login.
   deletionRequestedAt          DateTime?
   deletionRequests             SchoolDeletionRequest[]
+  questions                    Question[]
+  quizzes                      Quiz[]
+  quizScoreAggregations        QuizScoreAggregation[]
+  quizUsageEvents              QuizUsageEvent[]
 
   @@map("schools")
 }
@@ -119,12 +127,12 @@ model School {
 /// * the 30-day reconsideration window the platform admin may execute it
 /// * manually — no automatic deletion takes place.
 model SchoolDeletionRequest {
-  id               String                       @id @default(uuid())
+  id               String                      @id @default(uuid())
   schoolId         String
   requestedById    String
   reason           String
-  status           SchoolDeletionRequestStatus  @default(PENDING)
-  requestedAt      DateTime                     @default(now())
+  status           SchoolDeletionRequestStatus @default(PENDING)
+  requestedAt      DateTime                    @default(now())
   /// The earliest date the platform admin may execute the request
   /// (requestedAt + 30 days). Informational — not auto-enforced server-side.
   reviewableAt     DateTime
@@ -136,13 +144,13 @@ model SchoolDeletionRequest {
   rejectedAt       DateTime?
   rejectedById     String?
   rejectionReason  String?
-  createdAt        DateTime                     @default(now())
-  updatedAt        DateTime                     @updatedAt
-  school           School                       @relation(fields: [schoolId], references: [id])
-  requestedBy      User                         @relation("SchoolDeletionRequestedBy", fields: [requestedById], references: [id])
-  cancelledBy      User?                        @relation("SchoolDeletionCancelledBy", fields: [cancelledById], references: [id])
-  executedBy       SystemAdmin?                 @relation("SchoolDeletionExecutedBy", fields: [executedById], references: [id])
-  rejectedBy       SystemAdmin?                 @relation("SchoolDeletionRejectedBy", fields: [rejectedById], references: [id])
+  createdAt        DateTime                    @default(now())
+  updatedAt        DateTime                    @updatedAt
+  school           School                      @relation(fields: [schoolId], references: [id])
+  requestedBy      User                        @relation("SchoolDeletionRequestedBy", fields: [requestedById], references: [id])
+  cancelledBy      User?                       @relation("SchoolDeletionCancelledBy", fields: [cancelledById], references: [id])
+  executedBy       SystemAdmin?                @relation("SchoolDeletionExecutedBy", fields: [executedById], references: [id])
+  rejectedBy       SystemAdmin?                @relation("SchoolDeletionRejectedBy", fields: [rejectedById], references: [id])
 
   @@index([schoolId, status])
   @@index([status])
@@ -162,16 +170,16 @@ enum SchoolDeletionRequestStatus {
 /// * Stores academic promotion settings for each school, including core subjects,
 /// * minimum requirements, and attendance criteria for student promotion.
 model AcademicPromotionSettings {
-  id                     String   @id @default(uuid())
-  schoolId               String   @unique
-  coreSubjects           String[] // Array of subject names that must be passed
-  totalSubjectsPassed    Int      // Minimum number of subjects to pass
-  totalAverage           Int      // Minimum overall average required
-  useAttendance          Boolean  @default(true) // Whether to include attendance criteria
-  minimumAttendanceRate  Int      // Minimum attendance rate (if attendance is enabled)
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
-  school                 School   @relation(fields: [schoolId], references: [id])
+  id                    String   @id @default(uuid())
+  schoolId              String   @unique
+  coreSubjects          String[] // Array of subject names that must be passed
+  totalSubjectsPassed   Int // Minimum number of subjects to pass
+  totalAverage          Int // Minimum overall average required
+  useAttendance         Boolean  @default(true) // Whether to include attendance criteria
+  minimumAttendanceRate Int // Minimum attendance rate (if attendance is enabled)
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+  school                School   @relation(fields: [schoolId], references: [id])
 
   @@map("academic_promotion_settings")
 }
@@ -251,22 +259,26 @@ model AcademicSessionCalendarItem {
 /// * Terms divide the academic session into manageable periods for teaching, assessment, and reporting.
 /// * Each term is linked to an academic session and has its own set of subjects, attendance, and assessments.
 model Term {
-  id                 String              @id @default(uuid())
-  name               String
-  academicSessionId  String
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
-  deletedAt          DateTime?
-  isLocked           Boolean             @default(false)
-  endDate            DateTime
-  startDate          DateTime
-  paymentStructures  PaymentStructure[]
-  assessments        ClassArmStudentAssessment[]
-  studentAttendances StudentAttendance[]
-  subjectAttendances SubjectAttendance[]
-  resultComments     ResultComment[]
-  academicSession    AcademicSession            @relation(fields: [academicSessionId], references: [id])
-  schoolsAsCurrent   School[]                   @relation("SchoolCurrentTerm")
+  id                    String                      @id @default(uuid())
+  name                  String
+  academicSessionId     String
+  createdAt             DateTime                    @default(now())
+  updatedAt             DateTime                    @updatedAt
+  deletedAt             DateTime?
+  isLocked              Boolean                     @default(false)
+  endDate               DateTime
+  startDate             DateTime
+  paymentStructures     PaymentStructure[]
+  assessments           ClassArmStudentAssessment[]
+  studentAttendances    StudentAttendance[]
+  subjectAttendances    SubjectAttendance[]
+  resultComments        ResultComment[]
+  academicSession       AcademicSession             @relation(fields: [academicSessionId], references: [id])
+  schoolsAsCurrent      School[]                    @relation("SchoolCurrentTerm")
+  questionsByDefault    Question[]                  @relation("QuestionDefaultTerm")
+  quizzesByDefault      Quiz[]                      @relation("QuizDefaultTerm")
+  quizAssignments       QuizAssignment[]
+  quizScoreAggregations QuizScoreAggregation[]
 
   @@map("terms")
 }
@@ -293,6 +305,8 @@ model Level {
   paymentStructures PaymentStructure[]
   promotionsFrom    StudentPromotion[] @relation("PromotionFromLevel")
   promotionsTo      StudentPromotion[] @relation("PromotionToLevel")
+  questions         Question[]
+  quizzes           Quiz[]
 
   @@unique([code, schoolId])
   @@map("levels")
@@ -332,32 +346,32 @@ model Department {
 /// * Class arms group students for teaching, attendance, and administrative purposes.
 /// * They are also linked to teachers and subjects for classroom management.
 model ClassArm {
-  id                      String                   @id @default(uuid())
-  name                    String
-  academicSessionId       String
-  levelId                 String
-  departmentId            String?
-  schoolId                String
-  createdAt               DateTime                 @default(now())
-  updatedAt               DateTime                 @updatedAt
-  deletedAt               DateTime?
-  captainId               String?                  @unique
-  classTeacherId          String?
-  location                String?
-  slug                    String
-  classArmStudents        ClassArmStudent[]
-  classArmSubjects        ClassArmSubject[]
-  classArmTeachers        ClassArmTeacher[]
-  academicSession         AcademicSession          @relation(fields: [academicSessionId], references: [id])
-  captain                 Student?                 @relation("ClassArmCaptain", fields: [captainId], references: [id])
-  classTeacher            Teacher?                 @relation("ClassArmTeacher", fields: [classTeacherId], references: [id])
-  department              Department?              @relation(fields: [departmentId], references: [id])
-  level                   Level                    @relation(fields: [levelId], references: [id])
-  school                  School                   @relation(fields: [schoolId], references: [id])
-  paymentStructures       PaymentStructure[]
-  promotionsFrom          StudentPromotion[]       @relation("PromotionFromClassArm")
-  promotionsTo            StudentPromotion[]       @relation("PromotionToClassArm")
-  resultComments          ResultComment[]
+  id                String             @id @default(uuid())
+  name              String
+  academicSessionId String
+  levelId           String
+  departmentId      String?
+  schoolId          String
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+  deletedAt         DateTime?
+  captainId         String?            @unique
+  classTeacherId    String?
+  location          String?
+  slug              String
+  classArmStudents  ClassArmStudent[]
+  classArmSubjects  ClassArmSubject[]
+  classArmTeachers  ClassArmTeacher[]
+  academicSession   AcademicSession    @relation(fields: [academicSessionId], references: [id])
+  captain           Student?           @relation("ClassArmCaptain", fields: [captainId], references: [id])
+  classTeacher      Teacher?           @relation("ClassArmTeacher", fields: [classTeacherId], references: [id])
+  department        Department?        @relation(fields: [departmentId], references: [id])
+  level             Level              @relation(fields: [levelId], references: [id])
+  school            School             @relation(fields: [schoolId], references: [id])
+  paymentStructures PaymentStructure[]
+  promotionsFrom    StudentPromotion[] @relation("PromotionFromClassArm")
+  promotionsTo      StudentPromotion[] @relation("PromotionToClassArm")
+  resultComments    ResultComment[]
 
   @@unique([slug, schoolId])
   @@unique([name, levelId, academicSessionId, schoolId], name: "unique_class_arm_per_level_session")
@@ -371,45 +385,47 @@ model ClassArm {
 /// * Stores authentication and profile information, and links to the specific role entity (student, teacher, etc.).
 /// * This model is central for access control, personalization, and communication.
 model User {
-  id                  String               @id @default(uuid())
-  type                UserType
-  email               String?
-  phone               String?
-  password            String
-  phoneVerified       Boolean              @default(false)
-  emailVerified       Boolean              @default(false)
-  firstName           String
-  lastName            String
-  addressId           String?
-  avatarUrl           String?
-  dateOfBirth         DateTime?
-  schoolId            String?
-  mustUpdatePassword  Boolean              @default(false)
-  createdAt           DateTime             @default(now())
-  updatedAt           DateTime             @updatedAt
-  deletedAt           DateTime?
-  gender              Gender
-  stateOfOrigin       String?
-  lastLoginAt         DateTime?
-  admin               Admin?
-  bulkImportJobs      BulkImportJob[]
-  colorSchemePayments ColorSchemePayment[]
-  complaintComments   ComplaintComment[]   @relation("ComplaintCommentAuthor")
-  complaintsReported  Complaint[]          @relation("ComplaintReporter")
-  guardian            Guardian?
-  student             Student?
-  systemAdmin         SystemAdmin?
-  teacher             Teacher?
-  activities              UserActivity[]
-  preferences             UserPreferences?
-  tokens                  UserToken[]
-  address                 Address?             @relation(fields: [addressId], references: [id])
-  school                  School?              @relation(fields: [schoolId], references: [id])
-  teacherResultComments   ResultComment[]      @relation("TeacherCommentBy")
-  principalResultComments ResultComment[]      @relation("PrincipalCommentBy")
-  commentTemplatesCreated CommentTemplate[]    @relation("CommentTemplateCreatedBy")
+  id                       String                  @id @default(uuid())
+  type                     UserType
+  email                    String?
+  phone                    String?
+  password                 String
+  phoneVerified            Boolean                 @default(false)
+  emailVerified            Boolean                 @default(false)
+  firstName                String
+  lastName                 String
+  addressId                String?
+  avatarUrl                String?
+  dateOfBirth              DateTime?
+  schoolId                 String?
+  mustUpdatePassword       Boolean                 @default(false)
+  createdAt                DateTime                @default(now())
+  updatedAt                DateTime                @updatedAt
+  deletedAt                DateTime?
+  gender                   Gender
+  stateOfOrigin            String?
+  lastLoginAt              DateTime?
+  admin                    Admin?
+  bulkImportJobs           BulkImportJob[]
+  colorSchemePayments      ColorSchemePayment[]
+  complaintComments        ComplaintComment[]      @relation("ComplaintCommentAuthor")
+  complaintsReported       Complaint[]             @relation("ComplaintReporter")
+  guardian                 Guardian?
+  student                  Student?
+  systemAdmin              SystemAdmin?
+  teacher                  Teacher?
+  activities               UserActivity[]
+  preferences              UserPreferences?
+  tokens                   UserToken[]
+  address                  Address?                @relation(fields: [addressId], references: [id])
+  school                   School?                 @relation(fields: [schoolId], references: [id])
+  teacherResultComments    ResultComment[]         @relation("TeacherCommentBy")
+  principalResultComments  ResultComment[]         @relation("PrincipalCommentBy")
+  commentTemplatesCreated  CommentTemplate[]       @relation("CommentTemplateCreatedBy")
   schoolDeletionsRequested SchoolDeletionRequest[] @relation("SchoolDeletionRequestedBy")
   schoolDeletionsCancelled SchoolDeletionRequest[] @relation("SchoolDeletionCancelledBy")
+  authoredQuestions        Question[]              @relation("QuestionAuthor")
+  authoredQuizzes          Quiz[]                  @relation("QuizAuthor")
 
   @@map("users")
 }
@@ -464,15 +480,15 @@ model Admin {
 /// * manage school signup requests, and oversee the entire system.
 /// * This is different from school admins who manage individual schools.
 model SystemAdmin {
-  id                 String                @id @default(uuid())
-  userId             String                @unique
+  id                 String                  @id @default(uuid())
+  userId             String                  @unique
   role               String
-  createdAt          DateTime              @default(now())
-  updatedAt          DateTime              @updatedAt
+  createdAt          DateTime                @default(now())
+  updatedAt          DateTime                @updatedAt
   deletedAt          DateTime?
-  assignedComplaints Complaint[]           @relation("ComplaintAssignee")
+  assignedComplaints Complaint[]             @relation("ComplaintAssignee")
   signupRequests     SchoolSignupRequest[]
-  user               User                  @relation(fields: [userId], references: [id])
+  user               User                    @relation(fields: [userId], references: [id])
   deletionsExecuted  SchoolDeletionRequest[] @relation("SchoolDeletionExecutedBy")
   deletionsRejected  SchoolDeletionRequest[] @relation("SchoolDeletionRejectedBy")
 
@@ -486,24 +502,27 @@ model SystemAdmin {
 /// * Stores personal and professional information, and links teachers to the subjects and class arms they teach.
 /// * Teachers may also have administrative roles (e.g., HOD, class teacher).
 model Teacher {
-  id                      String                   @id @default(uuid())
-  userId                  String                   @unique
-  teacherNo               String                   @unique
-  createdAt               DateTime                 @default(now())
-  updatedAt               DateTime                 @updatedAt
-  deletedAt               DateTime?
-  employmentType          EmploymentType           @default(FULL_TIME)
-  joinDate                DateTime                 @default(now())
-  qualification           String?
-  signatureUrl            String?
-  status                  TeacherStatus            @default(ACTIVE)
-  departmentId            String?
-  classArmSubjectTeachers ClassArmSubjectTeacher[]
-  classArmTeachers        ClassArmTeacher[]
-  classArmsAsTeacher      ClassArm[]               @relation("ClassArmTeacher")
-  hod                     Hod?
-  department              Department?              @relation(fields: [departmentId], references: [id])
-  user                    User                     @relation(fields: [userId], references: [id])
+  id                        String                   @id @default(uuid())
+  userId                    String                   @unique
+  teacherNo                 String                   @unique
+  createdAt                 DateTime                 @default(now())
+  updatedAt                 DateTime                 @updatedAt
+  deletedAt                 DateTime?
+  employmentType            EmploymentType           @default(FULL_TIME)
+  joinDate                  DateTime                 @default(now())
+  qualification             String?
+  signatureUrl              String?
+  status                    TeacherStatus            @default(ACTIVE)
+  departmentId              String?
+  classArmSubjectTeachers   ClassArmSubjectTeacher[]
+  classArmTeachers          ClassArmTeacher[]
+  classArmsAsTeacher        ClassArm[]               @relation("ClassArmTeacher")
+  hod                       Hod?
+  department                Department?              @relation(fields: [departmentId], references: [id])
+  user                      User                     @relation(fields: [userId], references: [id])
+  quizAssignments           QuizAssignment[]         @relation("QuizAssignmentAssignedBy")
+  grantedQuizOverrides      QuizAttemptOverride[]    @relation("QuizOverrideGrantedBy")
+  finalizedQuizAggregations QuizScoreAggregation[]   @relation("QuizAggregationFinalizedBy")
 
   @@map("teachers")
 }
@@ -533,33 +552,35 @@ model Guardian {
 /// * Stores personal, academic, and administrative information about each student.
 /// * Students are linked to class arms, guardians, and have records for attendance, assessments, and curriculum progress.
 model Student {
-  id                    String                 @id @default(uuid())
-  userId                String                 @unique
-  studentNo             String                 @unique
-  admissionDate         DateTime
-  admissionNo           String?                @unique
-  guardianId            String?
-  guardianFirstName     String?
-  guardianLastName      String?
-  guardianEmail         String?
-  guardianPhone         String?
-  address               Json?
-  medicalInformation    Json?
-  createdAt             DateTime               @default(now())
-  updatedAt             DateTime               @updatedAt
-  deletedAt             DateTime?
-  status                StudentStatus          @default(ACTIVE)
-  assessments           ClassArmStudentAssessment[]
-  classArmStudents      ClassArmStudent[]
-  classArmAsCaptain     ClassArm?                   @relation("ClassArmCaptain")
-  prefect               Prefect?
-  studentPayments       StudentPayment[]
-  promotedFrom          StudentPromotion[]          @relation("PromotedStudent")
-  promotions            StudentPromotion[]
-  statusHistory         StudentStatusHistory[]
-  resultComments        ResultComment[]
-  guardian              Guardian?                   @relation(fields: [guardianId], references: [id])
-  user                  User                        @relation(fields: [userId], references: [id])
+  id                   String                      @id @default(uuid())
+  userId               String                      @unique
+  studentNo            String                      @unique
+  admissionDate        DateTime
+  admissionNo          String?                     @unique
+  guardianId           String?
+  guardianFirstName    String?
+  guardianLastName     String?
+  guardianEmail        String?
+  guardianPhone        String?
+  address              Json?
+  medicalInformation   Json?
+  createdAt            DateTime                    @default(now())
+  updatedAt            DateTime                    @updatedAt
+  deletedAt            DateTime?
+  status               StudentStatus               @default(ACTIVE)
+  assessments          ClassArmStudentAssessment[]
+  classArmStudents     ClassArmStudent[]
+  classArmAsCaptain    ClassArm?                   @relation("ClassArmCaptain")
+  prefect              Prefect?
+  studentPayments      StudentPayment[]
+  promotedFrom         StudentPromotion[]          @relation("PromotedStudent")
+  promotions           StudentPromotion[]
+  statusHistory        StudentStatusHistory[]
+  resultComments       ResultComment[]
+  guardian             Guardian?                   @relation(fields: [guardianId], references: [id])
+  user                 User                        @relation(fields: [userId], references: [id])
+  quizAttempts         QuizAttempt[]
+  quizAttemptOverrides QuizAttemptOverride[]
 
   @@map("students")
 }
@@ -585,10 +606,10 @@ model ClassArmStudent {
   updatedAt          DateTime            @updatedAt
   deletedAt          DateTime?
   academicSession    AcademicSession     @relation(fields: [academicSessionId], references: [id], onDelete: Cascade)
-  classArm            ClassArm             @relation(fields: [classArmId], references: [id], onDelete: Cascade)
-  student             Student              @relation(fields: [studentId], references: [id], onDelete: Cascade)
-  studentAttendances  StudentAttendance[]
-  subjectAttendances  SubjectAttendance[]
+  classArm           ClassArm            @relation(fields: [classArmId], references: [id], onDelete: Cascade)
+  student            Student             @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  studentAttendances StudentAttendance[]
+  subjectAttendances SubjectAttendance[]
 
   @@unique([studentId, classArmId, academicSessionId])
   @@index([studentId])
@@ -629,19 +650,21 @@ model StudentStatusHistory {
 /// * Subjects are linked to departments and schools, and are taught by teachers to students in various class arms.
 /// * This entity is central to curriculum planning and academic reporting.
 model Subject {
-  id                      String                   @id @default(uuid())
-  name                    String
-  schoolId                String
-  departmentId            String?
-  createdAt               DateTime                 @default(now())
-  updatedAt               DateTime                 @updatedAt
-  deletedAt               DateTime?
-  categoryId              String?
-  classArmSubjects        ClassArmSubject[]
-  subjectAttendances      SubjectAttendance[]
-  category                Category?         @relation(fields: [categoryId], references: [id])
-  department              Department?       @relation(fields: [departmentId], references: [id])
-  school                  School            @relation(fields: [schoolId], references: [id])
+  id                 String              @id @default(uuid())
+  name               String
+  schoolId           String
+  departmentId       String?
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  deletedAt          DateTime?
+  categoryId         String?
+  classArmSubjects   ClassArmSubject[]
+  subjectAttendances SubjectAttendance[]
+  category           Category?           @relation(fields: [categoryId], references: [id])
+  department         Department?         @relation(fields: [departmentId], references: [id])
+  school             School              @relation(fields: [schoolId], references: [id])
+  questions          Question[]
+  quizzes            Quiz[]
 
   @@map("subjects")
 }
@@ -653,16 +676,18 @@ model Subject {
 /// * This is a first-class entity that exists independently of teacher assignments.
 /// * A class arm can take a subject even without a teacher assigned.
 model ClassArmSubject {
-  id          String                      @id @default(uuid())
-  classArmId  String
-  subjectId   String
-  createdAt   DateTime                    @default(now())
-  updatedAt   DateTime                    @updatedAt
-  deletedAt   DateTime?
-  classArm    ClassArm                    @relation(fields: [classArmId], references: [id])
-  subject     Subject                     @relation(fields: [subjectId], references: [id])
-  teachers    ClassArmSubjectTeacher[]
-  assessments ClassArmStudentAssessment[]
+  id                    String                      @id @default(uuid())
+  classArmId            String
+  subjectId             String
+  createdAt             DateTime                    @default(now())
+  updatedAt             DateTime                    @updatedAt
+  deletedAt             DateTime?
+  classArm              ClassArm                    @relation(fields: [classArmId], references: [id])
+  subject               Subject                     @relation(fields: [subjectId], references: [id])
+  teachers              ClassArmSubjectTeacher[]
+  assessments           ClassArmStudentAssessment[]
+  quizAssignments       QuizAssignment[]
+  quizScoreAggregations QuizScoreAggregation[]
 
   @@unique([classArmId, subjectId])
   @@map("class_arm_subjects")
@@ -700,7 +725,6 @@ model AssessmentStructureTemplate {
   @@index([isGlobalDefault])
   @@map("assessment_structure_templates")
 }
-
 
 /// *
 /// * ClassArmStudentAssessment
@@ -798,9 +822,9 @@ model SubjectAttendance {
   updatedAt         DateTime         @updatedAt
   deletedAt         DateTime?
 
-  classArmStudent   ClassArmStudent  @relation(fields: [classArmStudentId], references: [id], onDelete: Cascade)
-  term              Term             @relation(fields: [termId], references: [id])
-  subject           Subject          @relation(fields: [subjectId], references: [id])
+  classArmStudent ClassArmStudent @relation(fields: [classArmStudentId], references: [id], onDelete: Cascade)
+  term            Term            @relation(fields: [termId], references: [id])
+  subject         Subject         @relation(fields: [subjectId], references: [id])
 
   @@unique([classArmStudentId, date, subjectId])
   @@map("subject_attendances")
@@ -911,11 +935,11 @@ model Counter {
 /// * Used to generate and track unique numbers for platform-level entities (e.g., school codes).
 /// * Unlike Counter which is scoped to a school, this is for global/platform-wide sequences.
 model GlobalCounter {
-  id        String    @id @default(uuid())
-  entity    String    @unique
-  current   Int       @default(0)
-  updatedAt DateTime  @updatedAt
-  createdAt DateTime  @default(now())
+  id        String   @id @default(uuid())
+  entity    String   @unique
+  current   Int      @default(0)
+  updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
 
   @@map("global_counters")
 }
@@ -992,24 +1016,24 @@ model PaymentStructure {
 /// * Links payment structures to individual students, creating specific payment obligations.
 /// * This allows for tracking individual student payment status and history.
 model StudentPayment {
-  id                 String           @id @default(uuid())
-  studentId          String
-  paymentStructureId String
-  amount             Decimal          @db.Decimal(10, 2)
-  currency           String           @default("NGN")
-  status             PaymentStatus    @default(PENDING)
-  dueDate            DateTime
-  paidAmount         Decimal          @default(0) @db.Decimal(10, 2)
-  paidAt             DateTime?
-  notes              String?
-  waivedBy           String?
-  waivedAt           DateTime?
-  waiverReason       String?
-  createdAt          DateTime         @default(now())
-  updatedAt          DateTime         @updatedAt
-  deletedAt          DateTime?
-  paymentStructure     PaymentStructure  @relation(fields: [paymentStructureId], references: [id])
-  student              Student           @relation(fields: [studentId], references: [id])
+  id                   String                @id @default(uuid())
+  studentId            String
+  paymentStructureId   String
+  amount               Decimal               @db.Decimal(10, 2)
+  currency             String                @default("NGN")
+  status               PaymentStatus         @default(PENDING)
+  dueDate              DateTime
+  paidAmount           Decimal               @default(0) @db.Decimal(10, 2)
+  paidAt               DateTime?
+  notes                String?
+  waivedBy             String?
+  waivedAt             DateTime?
+  waiverReason         String?
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+  deletedAt            DateTime?
+  paymentStructure     PaymentStructure      @relation(fields: [paymentStructureId], references: [id])
+  student              Student               @relation(fields: [studentId], references: [id])
   platformTransactions PlatformTransaction[]
 
   @@index([studentId])
@@ -1295,7 +1319,6 @@ model LevelProgression {
   @@map("level_progressions")
 }
 
-
 /// *
 /// * SchoolBankAccount
 /// * ------------------
@@ -1566,4 +1589,644 @@ model CommentTemplate {
 
   @@index([schoolId, type])
   @@map("comment_templates")
+}
+
+// =============================================================================
+// QUIZ / ASSESSMENT SYSTEM
+// =============================================================================
+//
+// Adds a first-class question bank, reusable quizzes, live assignments to
+// classes (open-window or sync-start), per-student attempts with auto-grading,
+// and a separate quiz gradebook that can be aggregated into the existing
+// AssessmentStructureTemplate slots (Test 1, Exam, etc.).
+//
+// Topic and PopularExam are schos-managed canonical taxonomies; Question and
+// Quiz can be either SCHOS_CURATED (system-wide, no schoolId) or
+// TEACHER_AUTHORED (scoped to a school).
+
+/// *
+/// * Topic
+/// * -----
+/// * Canonical curriculum topic, schos-managed (e.g. "Newton's Laws of Motion").
+/// * Self-referential for subtopics (Mechanics > Kinematics > Projectile Motion).
+/// * Tagged by canonical subject + level so schools' subjects can match by name+code.
+model Topic {
+  id                   String    @id @default(uuid())
+  name                 String
+  slug                 String    @unique
+  description          String?
+  parentTopicId        String?
+  order                Int       @default(0)
+  canonicalSubjectName String
+  canonicalLevelCode   String
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+  deletedAt            DateTime?
+
+  parentTopic  Topic?          @relation("TopicSubtopics", fields: [parentTopicId], references: [id])
+  childTopics  Topic[]         @relation("TopicSubtopics")
+  questionTags QuestionTopic[]
+  quizTags     QuizTopic[]
+
+  @@index([canonicalSubjectName, canonicalLevelCode])
+  @@index([parentTopicId])
+  @@map("topics")
+}
+
+/// *
+/// * CanonicalSubject
+/// * ----------------
+/// * schos-managed list of subject names for cross-school discoverability.
+/// * Used for tagging curated content (Question.canonicalSubjectName,
+/// * Quiz.canonicalSubjectName, Topic.canonicalSubjectName) by name. School-
+/// * scoped Subject records map to one of these by name (case-insensitive).
+model CanonicalSubject {
+  id          String    @id @default(uuid())
+  name        String    @unique
+  slug        String    @unique
+  description String?
+  active      Boolean   @default(true)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
+
+  @@map("canonical_subjects")
+}
+
+/// *
+/// * CanonicalLevel
+/// * --------------
+/// * schos-managed list of level / grade codes (PRY1-PRY6, JSS1-SSS3, GRADE_1-12,
+/// * A_LEVEL, O_LEVEL, etc). `group` clusters them for filtered dropdowns.
+model CanonicalLevel {
+  id        String    @id @default(uuid())
+  code      String    @unique
+  name      String
+  group     String
+  order     Int
+  active    Boolean   @default(true)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime?
+
+  @@index([group, order])
+  @@map("canonical_levels")
+}
+
+/// *
+/// * CanonicalTerm
+/// * -------------
+/// * schos-managed list of term names (First Term, Second Term, Third Term).
+model CanonicalTerm {
+  id        String    @id @default(uuid())
+  name      String    @unique
+  order     Int
+  active    Boolean   @default(true)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime?
+
+  @@map("canonical_terms")
+}
+
+/// *
+/// * PopularExam
+/// * -----------
+/// * schos-managed reference list of standardized exams (WAEC, NECO, JAMB, etc.).
+/// * Teachers tick which past exams a question is sourced from, with year.
+model PopularExam {
+  id          String    @id @default(uuid())
+  code        String    @unique
+  name        String
+  country     String?
+  description String?
+  active      Boolean   @default(true)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
+
+  questionTags QuestionPopularExam[]
+
+  @@map("popular_exams")
+}
+
+/// *
+/// * Question
+/// * --------
+/// * First-class, reusable question. Owned either by a teacher (TEACHER_AUTHORED,
+/// * scoped to schoolId) or by schos (SCHOS_CURATED, schoolId is null).
+/// * Reusable across many quizzes via QuizQuestion. Edits to questions referenced
+/// * by a published quiz bump `version` (immutable history).
+model Question {
+  id                   String              @id @default(uuid())
+  ownerType            QuestionOwnerType
+  schoolId             String?
+  authorUserId         String
+  subjectId            String?
+  levelId              String?
+  defaultTermId        String?
+  canonicalSubjectName String?
+  canonicalLevelCode   String?
+  canonicalTermName    String?
+  type                 QuestionType
+  prompt               Json
+  promptPlainText      String              @db.Text
+  mediaUrls            String[]
+  explanation          Json?
+  weight               Decimal             @default(1.0) @db.Decimal(10, 2)
+  difficulty           QuestionDifficulty?
+  status               QuestionStatus      @default(DRAFT)
+  version              Int                 @default(1)
+  sourceQuestionId     String?
+  config               Json?
+  partialCreditMode    PartialCreditMode?
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
+  deletedAt            DateTime?
+
+  school         School?               @relation(fields: [schoolId], references: [id])
+  authorUser     User                  @relation("QuestionAuthor", fields: [authorUserId], references: [id])
+  subject        Subject?              @relation(fields: [subjectId], references: [id])
+  level          Level?                @relation(fields: [levelId], references: [id])
+  defaultTerm    Term?                 @relation("QuestionDefaultTerm", fields: [defaultTermId], references: [id])
+  sourceQuestion Question?             @relation("QuestionLineage", fields: [sourceQuestionId], references: [id])
+  clones         Question[]            @relation("QuestionLineage")
+  options        QuestionOption[]
+  topics         QuestionTopic[]
+  popularExams   QuestionPopularExam[]
+  quizUses       QuizQuestion[]
+  responses      QuestionResponse[]
+
+  @@index([schoolId, authorUserId, status])
+  @@index([subjectId, levelId])
+  @@index([ownerType, status])
+  @@index([canonicalSubjectName, canonicalLevelCode])
+  @@map("questions")
+}
+
+/// *
+/// * QuestionOption
+/// * --------------
+/// * Choice for MCQ_SINGLE / MCQ_MULTI questions. Label is TipTap JSON so options
+/// * can also contain math/images.
+model QuestionOption {
+  id             String    @id @default(uuid())
+  questionId     String
+  order          Int
+  label          Json
+  labelPlainText String    @db.Text
+  isCorrect      Boolean   @default(false)
+  mediaUrl       String?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  deletedAt      DateTime?
+
+  question Question @relation(fields: [questionId], references: [id], onDelete: Cascade)
+
+  @@unique([questionId, order])
+  @@index([questionId])
+  @@map("question_options")
+}
+
+/// *
+/// * QuestionTopic
+/// * -------------
+/// * Many-to-many tag from a question to one or more curriculum topics.
+model QuestionTopic {
+  questionId String
+  topicId    String
+  createdAt  DateTime @default(now())
+
+  question Question @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  topic    Topic    @relation(fields: [topicId], references: [id])
+
+  @@id([questionId, topicId])
+  @@index([topicId])
+  @@map("question_topics")
+}
+
+/// *
+/// * QuestionPopularExam
+/// * -------------------
+/// * Many-to-many tag from a question to past-exam sources, with year + reference.
+model QuestionPopularExam {
+  id             String   @id @default(uuid())
+  questionId     String
+  popularExamId  String
+  examYear       Int?
+  questionNumber String?
+  createdAt      DateTime @default(now())
+
+  question    Question    @relation(fields: [questionId], references: [id], onDelete: Cascade)
+  popularExam PopularExam @relation(fields: [popularExamId], references: [id])
+
+  @@unique([questionId, popularExamId, examYear])
+  @@index([popularExamId, examYear])
+  @@map("question_popular_exams")
+}
+
+/// *
+/// * Quiz
+/// * ----
+/// * Composition of questions with shared metadata + delivery settings.
+/// * SCHOS_CURATED quizzes (schoolId null) are visible to all schools and can be
+/// * cloned. TEACHER_AUTHORED quizzes are private to the owning school.
+/// * Edits to a published quiz bump `version`; a QuizAssignment snapshots the
+/// * version it was assigned with so historical attempts stay consistent.
+model Quiz {
+  id                   String              @id @default(uuid())
+  ownerType            QuizOwnerType
+  schoolId             String?
+  authorUserId         String
+  title                String
+  description          String?
+  instructions         String?             @db.Text
+  subjectId            String?
+  levelId              String?
+  defaultTermId        String?
+  canonicalSubjectName String?
+  canonicalLevelCode   String?
+  canonicalTermName    String?
+  status               QuizStatus          @default(DRAFT)
+  estimatedMinutes     Int?
+  passMarkPercent      Decimal?            @db.Decimal(5, 2)
+  difficulty           QuestionDifficulty?
+  defaultSettings      Json?
+  sourceQuizId         String?
+  version              Int                 @default(1)
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
+  deletedAt            DateTime?
+
+  school      School?          @relation(fields: [schoolId], references: [id])
+  authorUser  User             @relation("QuizAuthor", fields: [authorUserId], references: [id])
+  subject     Subject?         @relation(fields: [subjectId], references: [id])
+  level       Level?           @relation(fields: [levelId], references: [id])
+  defaultTerm Term?            @relation("QuizDefaultTerm", fields: [defaultTermId], references: [id])
+  sourceQuiz  Quiz?            @relation("QuizLineage", fields: [sourceQuizId], references: [id])
+  clones      Quiz[]           @relation("QuizLineage")
+  questions   QuizQuestion[]
+  topics      QuizTopic[]
+  assignments QuizAssignment[]
+
+  @@index([schoolId, authorUserId, status])
+  @@index([subjectId, levelId])
+  @@index([ownerType, status])
+  @@index([canonicalSubjectName, canonicalLevelCode])
+  @@map("quizzes")
+}
+
+/// *
+/// * QuizQuestion
+/// * ------------
+/// * Junction Quiz <-> Question with ordering and optional per-quiz weight override.
+/// * weightOverride: null means use Question.weight. The QuestionResponse snapshot
+/// * stores the resolved weight at attempt start.
+model QuizQuestion {
+  quizId         String
+  questionId     String
+  order          Int
+  weightOverride Decimal? @db.Decimal(10, 2)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  quiz     Quiz     @relation(fields: [quizId], references: [id], onDelete: Cascade)
+  question Question @relation(fields: [questionId], references: [id])
+
+  @@id([quizId, questionId])
+  @@unique([quizId, order])
+  @@index([questionId])
+  @@map("quiz_questions")
+}
+
+/// *
+/// * QuizTopic
+/// * ---------
+/// * Many-to-many tag from a quiz to one or more curriculum topics
+/// * (in addition to per-question topics).
+model QuizTopic {
+  quizId    String
+  topicId   String
+  createdAt DateTime @default(now())
+
+  quiz  Quiz  @relation(fields: [quizId], references: [id], onDelete: Cascade)
+  topic Topic @relation(fields: [topicId], references: [id])
+
+  @@id([quizId, topicId])
+  @@index([topicId])
+  @@map("quiz_topics")
+}
+
+/// *
+/// * QuizAssignment
+/// * --------------
+/// * A teacher schedules a quiz for a specific class arm subject + term.
+/// * mode: OPEN_WINDOW = students start anytime in [windowOpensAt, windowClosesAt],
+/// * each gets durationMinutes from their start. SYNC_START = everyone starts at
+/// * windowOpensAt (within syncGracePeriodSeconds); shared dueAt.
+/// * Result-visibility settings can override the quiz defaults; if
+/// * showResultsImmediately is false, teacher must call release-results.
+model QuizAssignment {
+  id                     String               @id @default(uuid())
+  quizId                 String
+  quizVersion            Int
+  classArmSubjectId      String
+  termId                 String
+  assignedByTeacherId    String
+  mode                   QuizDeliveryMode
+  windowOpensAt          DateTime
+  windowClosesAt         DateTime
+  durationMinutes        Int
+  syncGracePeriodSeconds Int?                 @default(60)
+  maxAttempts            Int                  @default(1)
+  showResultsImmediately Boolean?
+  showCorrectAnswers     Boolean?
+  resultsReleasedAt      DateTime?
+  status                 QuizAssignmentStatus @default(SCHEDULED)
+  createdAt              DateTime             @default(now())
+  updatedAt              DateTime             @updatedAt
+  deletedAt              DateTime?
+
+  quiz              Quiz                       @relation(fields: [quizId], references: [id])
+  classArmSubject   ClassArmSubject            @relation(fields: [classArmSubjectId], references: [id])
+  term              Term                       @relation(fields: [termId], references: [id])
+  assignedByTeacher Teacher                    @relation("QuizAssignmentAssignedBy", fields: [assignedByTeacherId], references: [id])
+  attempts          QuizAttempt[]
+  overrides         QuizAttemptOverride[]
+  aggregationItems  QuizScoreAggregationItem[]
+
+  @@index([classArmSubjectId, termId, status])
+  @@index([windowOpensAt, windowClosesAt])
+  @@index([quizId])
+  @@map("quiz_assignments")
+}
+
+/// *
+/// * QuizAttemptOverride
+/// * -------------------
+/// * Per-student exception: teacher grants extra attempts, extra time, or extends
+/// * the window for a specific student (e.g. due to a network outage).
+/// * Reason is required for audit.
+model QuizAttemptOverride {
+  id                 String           @id @default(uuid())
+  quizAssignmentId   String
+  studentId          String
+  grantedByTeacherId String
+  type               QuizOverrideType
+  extraAttempts      Int?
+  extraMinutes       Int?
+  newWindowClosesAt  DateTime?
+  reason             String           @db.Text
+  createdAt          DateTime         @default(now())
+
+  quizAssignment   QuizAssignment @relation(fields: [quizAssignmentId], references: [id], onDelete: Cascade)
+  student          Student        @relation(fields: [studentId], references: [id])
+  grantedByTeacher Teacher        @relation("QuizOverrideGrantedBy", fields: [grantedByTeacherId], references: [id])
+
+  @@index([quizAssignmentId, studentId])
+  @@index([studentId])
+  @@map("quiz_attempt_overrides")
+}
+
+/// *
+/// * QuizAttempt
+/// * -----------
+/// * One row per student per attempt. dueAt is computed server-side at start as
+/// * min(windowClosesAt, startedAt + durationMinutes) + any active EXTRA_TIME
+/// * overrides. status transitions: IN_PROGRESS -> SUBMITTED -> GRADING -> GRADED.
+model QuizAttempt {
+  id                   String            @id @default(uuid())
+  quizAssignmentId     String
+  studentId            String
+  attemptNumber        Int               @default(1)
+  startedAt            DateTime          @default(now())
+  dueAt                DateTime
+  submittedAt          DateTime?
+  autoSubmitted        Boolean           @default(false)
+  status               QuizAttemptStatus @default(IN_PROGRESS)
+  totalScore           Decimal?          @db.Decimal(10, 2)
+  maxScore             Decimal           @db.Decimal(10, 2)
+  percentage           Decimal?          @db.Decimal(5, 2)
+  pageVisibilityEvents Json?
+  createdAt            DateTime          @default(now())
+  updatedAt            DateTime          @updatedAt
+
+  quizAssignment QuizAssignment     @relation(fields: [quizAssignmentId], references: [id])
+  student        Student            @relation(fields: [studentId], references: [id])
+  responses      QuestionResponse[]
+  usageEvent     QuizUsageEvent?
+
+  @@unique([quizAssignmentId, studentId, attemptNumber])
+  @@index([quizAssignmentId, status])
+  @@index([studentId, status])
+  @@index([dueAt, status])
+  @@map("quiz_attempts")
+}
+
+/// *
+/// * QuizUsageEvent
+/// * --------------
+/// * One row per QuizAttempt at the moment a student starts. Captures the
+/// * nominal billable amount (rate-card price) and an `isWaived` flag with
+/// * `waiverReason` ('BETA' | 'FIRST_YEAR') when the school is in a free
+/// * period. Billing systems must skip events where `isWaived = true`.
+/// * Keyed @unique on quizAttemptId so refresh-resilient attempt-start does
+/// * not produce duplicate events.
+model QuizUsageEvent {
+  id               String      @id @default(uuid())
+  schoolId         String
+  quizAttemptId    String      @unique
+  quizAssignmentId String
+  studentId        String
+  durationMinutes  Int
+  questionCount    Int
+  chargeableUnits  Decimal     @db.Decimal(10, 2)
+  unitRateSnapshot Decimal     @db.Decimal(10, 4)
+  amountKobo       Int
+  isWaived         Boolean     @default(false)
+  waiverReason     String?
+  recordedAt       DateTime    @default(now())
+
+  school      School      @relation(fields: [schoolId], references: [id])
+  quizAttempt QuizAttempt @relation(fields: [quizAttemptId], references: [id])
+
+  @@index([schoolId, recordedAt])
+  @@index([schoolId, isWaived])
+  @@map("quiz_usage_events")
+}
+
+/// *
+/// * QuestionResponse
+/// * ----------------
+/// * One row per question per attempt. weight is snapshotted from
+/// * QuizQuestion.weightOverride ?? Question.weight at attempt start so later
+/// * edits don't affect graded scores. responseJson shape depends on type:
+/// *   MCQ_SINGLE  : { selectedOptionId: string }
+/// *   MCQ_MULTI   : { selectedOptionIds: string[] }
+/// *   TRUE_FALSE  : { value: boolean }
+/// *   NUMERIC     : { value: number, unit?: string }
+/// *   SHORT_ANSWER: { text: string }
+model QuestionResponse {
+  id            String   @id @default(uuid())
+  attemptId     String
+  questionId    String
+  responseJson  Json?
+  weight        Decimal  @db.Decimal(10, 2)
+  pointsAwarded Decimal? @db.Decimal(10, 2)
+  isCorrect     Boolean?
+  autoGraded    Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  attempt  QuizAttempt @relation(fields: [attemptId], references: [id], onDelete: Cascade)
+  question Question    @relation(fields: [questionId], references: [id])
+
+  @@unique([attemptId, questionId])
+  @@index([attemptId])
+  @@map("question_responses")
+}
+
+/// *
+/// * QuizScoreAggregation
+/// * --------------------
+/// * Maps N quiz assignments to one slot in AssessmentStructureTemplate.
+/// * Example: Quiz 1 + Quiz 2 + Quiz 3 -> "Test 1" via AVERAGE rescaled to /15.
+/// * On finalize, a job upserts ClassArmStudentAssessment rows so the score flows
+/// * through to existing results & broadsheet UIs unchanged.
+/// * missingAttemptPolicy decides how to treat students who didn't submit:
+/// * TREAT_AS_ZERO (default) or EXCLUDE_FROM_DENOMINATOR.
+model QuizScoreAggregation {
+  id                        String                @id @default(uuid())
+  schoolId                  String
+  classArmSubjectId         String
+  termId                    String
+  assessmentTemplateEntryId String
+  name                      String
+  aggregationMethod         AggregationMethod
+  bestOfN                   Int?
+  rescaleToMaxScore         Int
+  missingAttemptPolicy      MissingAttemptPolicy  @default(TREAT_AS_ZERO)
+  status                    QuizAggregationStatus @default(DRAFT)
+  finalizedAt               DateTime?
+  finalizedByTeacherId      String?
+  createdAt                 DateTime              @default(now())
+  updatedAt                 DateTime              @updatedAt
+  deletedAt                 DateTime?
+
+  school             School                     @relation(fields: [schoolId], references: [id])
+  classArmSubject    ClassArmSubject            @relation(fields: [classArmSubjectId], references: [id])
+  term               Term                       @relation(fields: [termId], references: [id])
+  finalizedByTeacher Teacher?                   @relation("QuizAggregationFinalizedBy", fields: [finalizedByTeacherId], references: [id])
+  items              QuizScoreAggregationItem[]
+
+  @@index([schoolId, classArmSubjectId, termId])
+  @@index([assessmentTemplateEntryId])
+  @@map("quiz_score_aggregations")
+}
+
+/// *
+/// * QuizScoreAggregationItem
+/// * ------------------------
+/// * Junction QuizScoreAggregation <-> QuizAssignment with optional weight
+/// * (used by AggregationMethod = WEIGHTED).
+model QuizScoreAggregationItem {
+  id               String   @id @default(uuid())
+  aggregationId    String
+  quizAssignmentId String
+  weight           Decimal  @default(1.0) @db.Decimal(10, 2)
+  createdAt        DateTime @default(now())
+
+  aggregation    QuizScoreAggregation @relation(fields: [aggregationId], references: [id], onDelete: Cascade)
+  quizAssignment QuizAssignment       @relation(fields: [quizAssignmentId], references: [id])
+
+  @@unique([aggregationId, quizAssignmentId])
+  @@index([quizAssignmentId])
+  @@map("quiz_score_aggregation_items")
+}
+
+// -----------------------------------------------------------------------------
+// Quiz / Assessment enums
+// -----------------------------------------------------------------------------
+
+enum QuestionOwnerType {
+  SCHOS_CURATED
+  TEACHER_AUTHORED
+}
+
+enum QuizOwnerType {
+  SCHOS_CURATED
+  TEACHER_AUTHORED
+}
+
+enum QuestionType {
+  MCQ_SINGLE
+  MCQ_MULTI
+  TRUE_FALSE
+  NUMERIC
+  SHORT_ANSWER
+}
+
+enum QuestionDifficulty {
+  EASY
+  MEDIUM
+  HARD
+}
+
+enum QuestionStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+enum QuizStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+enum PartialCreditMode {
+  NONE
+  PROPORTIONAL
+}
+
+enum QuizDeliveryMode {
+  OPEN_WINDOW
+  SYNC_START
+}
+
+enum QuizAssignmentStatus {
+  SCHEDULED
+  OPEN
+  CLOSED
+  ARCHIVED
+}
+
+enum QuizOverrideType {
+  RETRY
+  EXTEND_WINDOW
+  EXTRA_TIME
+}
+
+enum QuizAttemptStatus {
+  IN_PROGRESS
+  SUBMITTED
+  GRADING
+  GRADED
+}
+
+enum AggregationMethod {
+  SUM
+  AVERAGE
+  WEIGHTED
+  BEST_OF_N
+}
+
+enum MissingAttemptPolicy {
+  TREAT_AS_ZERO
+  EXCLUDE_FROM_DENOMINATOR
+}
+
+enum QuizAggregationStatus {
+  DRAFT
+  FINALIZED
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1052,7 +1052,180 @@ async function main() {
 
   console.log(`✅ Created ${paymentStructures.length} payment structures`);
   console.log(`✅ Generated ${studentPayments.length} student payments`);
+
+  await seedPopularExams();
+  await seedCanonicalSubjects();
+  await seedCanonicalLevels();
+  await seedCanonicalTerms();
+
   console.log('✅ School seed data generated successfully!');
+}
+
+const POPULAR_EXAMS: ReadonlyArray<{
+  code: string;
+  name: string;
+  country: string;
+  description: string;
+}> = [
+  { code: 'WAEC', name: 'West African Examinations Council', country: 'NG', description: 'Senior School Certificate Examination administered across West Africa.' },
+  { code: 'NECO', name: 'National Examinations Council', country: 'NG', description: 'Nigerian senior secondary certificate examination.' },
+  { code: 'JAMB', name: 'Joint Admissions and Matriculation Board', country: 'NG', description: 'Nigerian university matriculation examination (UTME).' },
+  { code: 'NABTEB', name: 'National Business and Technical Examinations Board', country: 'NG', description: 'Nigerian technical and business education certificate.' },
+  { code: 'BECE', name: 'Basic Education Certificate Examination', country: 'NG', description: 'Junior secondary school exit examination in Nigeria.' },
+  { code: 'COMMON_ENTRANCE', name: 'National Common Entrance Examination', country: 'NG', description: 'Entry examination for federal unity colleges.' },
+  { code: 'IGCSE', name: 'International General Certificate of Secondary Education', country: 'INTL', description: 'Cambridge international secondary qualification.' },
+  { code: 'CHECKPOINT', name: 'Cambridge Lower Secondary Checkpoint', country: 'INTL', description: 'Cambridge end-of-stage assessment for lower secondary.' },
+  { code: 'A_LEVELS', name: 'GCE Advanced Level', country: 'INTL', description: 'Cambridge / Edexcel pre-university qualification.' },
+  { code: 'O_LEVELS', name: 'GCE Ordinary Level', country: 'INTL', description: 'Cambridge / Edexcel ordinary-level qualification.' },
+  { code: 'SAT', name: 'Scholastic Assessment Test', country: 'INTL', description: 'College Board standardized university admissions test.' },
+  { code: 'TOEFL', name: 'Test of English as a Foreign Language', country: 'INTL', description: 'English-language proficiency test for non-native speakers.' },
+  { code: 'IELTS', name: 'International English Language Testing System', country: 'INTL', description: 'English-language proficiency test for study, work, migration.' },
+];
+
+const CANONICAL_SUBJECTS: ReadonlyArray<{ name: string; slug: string; description?: string }> = [
+  { name: 'Mathematics', slug: 'mathematics' },
+  { name: 'Further Mathematics', slug: 'further-mathematics' },
+  { name: 'English Language', slug: 'english-language' },
+  { name: 'Literature in English', slug: 'literature-in-english' },
+  { name: 'Physics', slug: 'physics' },
+  { name: 'Chemistry', slug: 'chemistry' },
+  { name: 'Biology', slug: 'biology' },
+  { name: 'Agricultural Science', slug: 'agricultural-science' },
+  { name: 'Geography', slug: 'geography' },
+  { name: 'Economics', slug: 'economics' },
+  { name: 'Government', slug: 'government' },
+  { name: 'History', slug: 'history' },
+  { name: 'Civic Education', slug: 'civic-education' },
+  { name: 'Christian Religious Studies', slug: 'christian-religious-studies' },
+  { name: 'Islamic Religious Studies', slug: 'islamic-religious-studies' },
+  { name: 'Commerce', slug: 'commerce' },
+  { name: 'Financial Accounting', slug: 'financial-accounting' },
+  { name: 'Business Studies', slug: 'business-studies' },
+  { name: 'Office Practice', slug: 'office-practice' },
+  { name: 'Marketing', slug: 'marketing' },
+  { name: 'Computer Science', slug: 'computer-science' },
+  { name: 'Information Communication Technology', slug: 'ict' },
+  { name: 'Basic Science', slug: 'basic-science' },
+  { name: 'Basic Technology', slug: 'basic-technology' },
+  { name: 'Social Studies', slug: 'social-studies' },
+  { name: 'Cultural and Creative Arts', slug: 'cultural-and-creative-arts' },
+  { name: 'Visual Arts', slug: 'visual-arts' },
+  { name: 'Music', slug: 'music' },
+  { name: 'Home Economics', slug: 'home-economics' },
+  { name: 'Food and Nutrition', slug: 'food-and-nutrition' },
+  { name: 'Physical and Health Education', slug: 'physical-and-health-education' },
+  { name: 'French', slug: 'french' },
+  { name: 'Yoruba', slug: 'yoruba' },
+  { name: 'Igbo', slug: 'igbo' },
+  { name: 'Hausa', slug: 'hausa' },
+  { name: 'Verbal Reasoning', slug: 'verbal-reasoning' },
+  { name: 'Quantitative Reasoning', slug: 'quantitative-reasoning' },
+];
+
+const CANONICAL_LEVELS: ReadonlyArray<{
+  code: string;
+  name: string;
+  group: string;
+  order: number;
+}> = [
+  // Nigerian primary
+  { code: 'PRY1', name: 'Primary 1', group: 'PRIMARY', order: 1 },
+  { code: 'PRY2', name: 'Primary 2', group: 'PRIMARY', order: 2 },
+  { code: 'PRY3', name: 'Primary 3', group: 'PRIMARY', order: 3 },
+  { code: 'PRY4', name: 'Primary 4', group: 'PRIMARY', order: 4 },
+  { code: 'PRY5', name: 'Primary 5', group: 'PRIMARY', order: 5 },
+  { code: 'PRY6', name: 'Primary 6', group: 'PRIMARY', order: 6 },
+  // Nigerian junior secondary
+  { code: 'JSS1', name: 'Junior Secondary 1', group: 'JUNIOR_SECONDARY', order: 7 },
+  { code: 'JSS2', name: 'Junior Secondary 2', group: 'JUNIOR_SECONDARY', order: 8 },
+  { code: 'JSS3', name: 'Junior Secondary 3', group: 'JUNIOR_SECONDARY', order: 9 },
+  // Nigerian senior secondary
+  { code: 'SSS1', name: 'Senior Secondary 1', group: 'SENIOR_SECONDARY', order: 10 },
+  { code: 'SSS2', name: 'Senior Secondary 2', group: 'SENIOR_SECONDARY', order: 11 },
+  { code: 'SSS3', name: 'Senior Secondary 3', group: 'SENIOR_SECONDARY', order: 12 },
+  // International grade system (US/IB)
+  { code: 'GRADE_1', name: 'Grade 1', group: 'INTL_GRADE', order: 1 },
+  { code: 'GRADE_2', name: 'Grade 2', group: 'INTL_GRADE', order: 2 },
+  { code: 'GRADE_3', name: 'Grade 3', group: 'INTL_GRADE', order: 3 },
+  { code: 'GRADE_4', name: 'Grade 4', group: 'INTL_GRADE', order: 4 },
+  { code: 'GRADE_5', name: 'Grade 5', group: 'INTL_GRADE', order: 5 },
+  { code: 'GRADE_6', name: 'Grade 6', group: 'INTL_GRADE', order: 6 },
+  { code: 'GRADE_7', name: 'Grade 7', group: 'INTL_GRADE', order: 7 },
+  { code: 'GRADE_8', name: 'Grade 8', group: 'INTL_GRADE', order: 8 },
+  { code: 'GRADE_9', name: 'Grade 9', group: 'INTL_GRADE', order: 9 },
+  { code: 'GRADE_10', name: 'Grade 10', group: 'INTL_GRADE', order: 10 },
+  { code: 'GRADE_11', name: 'Grade 11', group: 'INTL_GRADE', order: 11 },
+  { code: 'GRADE_12', name: 'Grade 12', group: 'INTL_GRADE', order: 12 },
+  // British / Cambridge pre-university
+  { code: 'O_LEVEL', name: 'O Level', group: 'BRITISH', order: 1 },
+  { code: 'A_LEVEL', name: 'A Level', group: 'BRITISH', order: 2 },
+];
+
+const CANONICAL_TERMS: ReadonlyArray<{ name: string; order: number }> = [
+  { name: 'First Term', order: 1 },
+  { name: 'Second Term', order: 2 },
+  { name: 'Third Term', order: 3 },
+];
+
+async function seedCanonicalSubjects() {
+  console.log('Seeding canonical subjects...');
+  for (const s of CANONICAL_SUBJECTS) {
+    await prisma.canonicalSubject.upsert({
+      where: { slug: s.slug },
+      update: { name: s.name, description: s.description },
+      create: { name: s.name, slug: s.slug, description: s.description, active: true },
+    });
+  }
+  console.log(`✅ Seeded ${CANONICAL_SUBJECTS.length} canonical subjects`);
+}
+
+async function seedCanonicalLevels() {
+  console.log('Seeding canonical levels...');
+  for (const l of CANONICAL_LEVELS) {
+    await prisma.canonicalLevel.upsert({
+      where: { code: l.code },
+      update: { name: l.name, group: l.group, order: l.order },
+      create: { code: l.code, name: l.name, group: l.group, order: l.order, active: true },
+    });
+  }
+  console.log(`✅ Seeded ${CANONICAL_LEVELS.length} canonical levels`);
+}
+
+async function seedCanonicalTerms() {
+  console.log('Seeding canonical terms...');
+  for (const t of CANONICAL_TERMS) {
+    await prisma.canonicalTerm.upsert({
+      where: { name: t.name },
+      update: { order: t.order },
+      create: { name: t.name, order: t.order, active: true },
+    });
+  }
+  console.log(`✅ Seeded ${CANONICAL_TERMS.length} canonical terms`);
+}
+
+/**
+ * Idempotent: upserts the canonical PopularExam reference list. Safe to re-run.
+ */
+async function seedPopularExams() {
+  console.log('Seeding popular exams...');
+  for (const exam of POPULAR_EXAMS) {
+    await prisma.popularExam.upsert({
+      where: { code: exam.code },
+      update: {
+        name: exam.name,
+        country: exam.country,
+        description: exam.description,
+      },
+      create: {
+        code: exam.code,
+        name: exam.name,
+        country: exam.country,
+        description: exam.description,
+        active: true,
+      },
+    });
+  }
+  console.log(`✅ Seeded ${POPULAR_EXAMS.length} popular exams`);
 }
 
 main()

--- a/src/app-module.list.ts
+++ b/src/app-module.list.ts
@@ -13,11 +13,18 @@ import { AuthModule } from './components/auth/auth.module';
 import { BffAdminModule } from './components/bff/admin/bff-admin.module';
 import { StudentModule } from './components/bff/student/student.module';
 import { TeacherModule } from './components/bff/teacher/teacher.module';
+import { CanonicalReferencesModule } from './components/canonical-references/canonical-references.module';
 import { CategoriesModule } from './components/categories/categories.module';
 import { DepartmentsModule } from './components/departments/departments.module';
 import { LevelsModule } from './components/levels/levels.module';
 import { PaymentsModule } from './components/payments/payments.module';
 import { PlatformModule } from './components/platform/platform.module';
+import { PopularExamsModule } from './components/popular-exams/popular-exams.module';
+import { QuestionsModule } from './components/questions/questions.module';
+import { QuizAggregationsModule } from './components/quiz-aggregations/quiz-aggregations.module';
+import { QuizAssignmentsModule } from './components/quiz-assignments/quiz-assignments.module';
+import { QuizAttemptsModule } from './components/quiz-attempts/quiz-attempts.module';
+import { QuizzesModule } from './components/quizzes/quizzes.module';
 import { ResultCommentsModule } from './components/result-comments/result-comments.module';
 import { StorageModule } from './components/storage/storage.module';
 import { RolesManagerModule } from './components/roles-manager';
@@ -25,6 +32,7 @@ import { SchoolsModule } from './components/schools/schools.module';
 import { SettingsModule } from './components/settings/settings.module';
 import { StudentsModule } from './components/students/students.module';
 import { SubjectsModule } from './components/subjects/subjects.module';
+import { TopicsModule } from './components/topics/topics.module';
 import { UsersModule } from './components/users/users.module';
 import getConfiguration from './config/configuration';
 import { getEnvFileName } from './config/get-env';
@@ -67,6 +75,7 @@ export const AppModuleList = [
   BffAdminModule,
   TeacherModule,
   StudentModule,
+  CanonicalReferencesModule,
   CategoriesModule,
   SubjectsModule,
   DepartmentsModule,
@@ -76,6 +85,13 @@ export const AppModuleList = [
   AssessmentStructuresModule,
   PaymentsModule,
   PlatformModule,
+  PopularExamsModule,
+  QuestionsModule,
+  QuizAggregationsModule,
+  QuizAssignmentsModule,
+  QuizAttemptsModule,
+  QuizzesModule,
   ResultCommentsModule,
   StorageModule,
+  TopicsModule,
 ];

--- a/src/common/guards/assessments-feature.guard.ts
+++ b/src/common/guards/assessments-feature.guard.ts
@@ -1,0 +1,30 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable()
+export class AssessmentsFeatureGuard implements CanActivate {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const schoolId: string | undefined = request?.user?.schoolId;
+    if (!schoolId) {
+      throw new ForbiddenException({
+        code: 'ASSESSMENTS_DISABLED',
+        message: 'Your school has not enabled Assessments.',
+      });
+    }
+    const school = await this.prisma.school.findUnique({
+      where: { id: schoolId },
+      select: { assessmentsEnabled: true },
+    });
+    if (!school?.assessmentsEnabled) {
+      throw new ForbiddenException({
+        code: 'ASSESSMENTS_DISABLED',
+        message: 'Your school has not enabled Assessments.',
+      });
+    }
+    return true;
+  }
+}

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -1,1 +1,3 @@
 export * from './super-admin.guard';
+export * from './system-admin.guard';
+export * from './assessments-feature.guard';

--- a/src/common/guards/system-admin.guard.ts
+++ b/src/common/guards/system-admin.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+import { UserTypes } from '../../components/users/constants';
+
+/**
+ * Allows any user whose `User.type` is `SYSTEM_ADMIN` — that includes
+ * PLATFORM_ADMIN and any future `SystemAdmin.role` (e.g. SUPPORT_ADMIN,
+ * CONTENT_MODERATOR). PLATFORM_ADMIN is the highest-privilege internal role
+ * and must satisfy every gate that any system admin satisfies; do NOT tighten
+ * this guard to inspect `SystemAdmin.role`. Use a separate guard for
+ * role-specific restrictions.
+ */
+@Injectable()
+export class SystemAdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request?.user;
+    if (user?.type !== UserTypes.SYSTEM_ADMIN) {
+      throw new ForbiddenException('Only system admins can perform this action');
+    }
+    return true;
+  }
+}

--- a/src/components/bff/admin/bff-admin.controller.ts
+++ b/src/components/bff/admin/bff-admin.controller.ts
@@ -26,6 +26,10 @@ import { CheckPolicies, PoliciesGuard } from '../../roles-manager';
 import { ManageStudentPolicyHandler } from '../../students/policies';
 import { BffAdminService } from './bff-admin.service';
 import { ResultCommentsService } from '../../result-comments/result-comments.service';
+import { QuizBillingService } from '../../quiz-billing/quiz-billing.service';
+import { ToggleAssessmentsDto } from './dto/toggle-assessments.dto';
+import { AssessmentsSettingsResult } from './results/assessments-settings.result';
+import { AssessmentsUsageResult } from './results/assessments-usage.result';
 import {
   UpsertResultCommentDto,
   BulkUpsertResultCommentDto,
@@ -38,12 +42,17 @@ import { CreateSubjectDto } from './dto/create-subject.dto';
 import { UpdateSubjectDto } from './dto/update-subject.dto';
 import {
   AdminsViewSwagger,
+  AssessmentsUsageMonthQuery,
   ClassroomDetailsLimitQuery,
   ClassroomDetailsPageQuery,
   ClassroomDetailsParam,
   ClassroomDetailsResponse,
   ClassroomsViewSwagger,
   DepartmentsViewSwagger,
+  GetAssessmentsSettingsOperation,
+  GetAssessmentsSettingsSwagger,
+  GetAssessmentsUsageOperation,
+  GetAssessmentsUsageSwagger,
   SingleStudentDetailsParam,
   SingleStudentDetailsResponse,
   SingleTeacherDetailsParam,
@@ -58,6 +67,8 @@ import {
   TeachersViewSwagger,
   LevelsViewSwagger,
   DashboardSummarySwagger,
+  ToggleAssessmentsSettingsOperation,
+  ToggleAssessmentsSettingsSwagger,
 } from './bff-admin.swagger';
 import { AdminAdminsViewResult } from './results/admin-admins-view.result';
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
@@ -81,7 +92,42 @@ export class BffAdminController {
   constructor(
     private readonly bffAdminService: BffAdminService,
     private readonly resultCommentsService: ResultCommentsService,
+    private readonly quizBillingService: QuizBillingService,
   ) {}
+
+  @Get('assessments-settings')
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  @GetAssessmentsSettingsOperation()
+  @GetAssessmentsSettingsSwagger()
+  async getAssessmentsSettings(@GetCurrentUserId() userId: string) {
+    const data = await this.quizBillingService.getSettings(userId);
+    return new AssessmentsSettingsResult(data);
+  }
+
+  @Patch('assessments-settings')
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  @ToggleAssessmentsSettingsOperation()
+  @ToggleAssessmentsSettingsSwagger()
+  async toggleAssessmentsSettings(
+    @GetCurrentUserId() userId: string,
+    @Body() dto: ToggleAssessmentsDto,
+  ) {
+    const data = await this.quizBillingService.toggleSettings(userId, dto.enabled);
+    return new AssessmentsSettingsResult(data);
+  }
+
+  @Get('assessments-usage')
+  @CheckPolicies(new ManageStudentPolicyHandler())
+  @GetAssessmentsUsageOperation()
+  @AssessmentsUsageMonthQuery()
+  @GetAssessmentsUsageSwagger()
+  async getAssessmentsUsage(
+    @GetCurrentUserId() userId: string,
+    @Query('month') month?: string,
+  ) {
+    const data = await this.quizBillingService.getUsage(userId, month);
+    return new AssessmentsUsageResult(data);
+  }
 
   @Get('dashboard-summary')
   @DashboardSummarySwagger()

--- a/src/components/bff/admin/bff-admin.module.ts
+++ b/src/components/bff/admin/bff-admin.module.ts
@@ -19,6 +19,7 @@ import { AssessmentStructureTemplateService } from '../../assessment-structures/
 import { ClassroomBroadsheetBuilder } from '../../../utils/classroom-broadsheet.util';
 import { SharedServicesModule } from '../../../shared/shared-services.module';
 import { ResultCommentsModule } from '../../result-comments/result-comments.module';
+import { QuizBillingService } from '../../quiz-billing/quiz-billing.service';
 
 @Module({
   imports: [PrismaModule, ActivityLogModule, UsersModule, RolesManagerModule, JwtAuthModule, SharedServicesModule, ResultCommentsModule],
@@ -35,6 +36,7 @@ import { ResultCommentsModule } from '../../result-comments/result-comments.modu
     AssessmentStructureTemplateService,
     ClassroomBroadsheetBuilder,
     Encryptor,
+    QuizBillingService,
   ],
 })
 export class BffAdminModule {}

--- a/src/components/bff/admin/bff-admin.swagger.ts
+++ b/src/components/bff/admin/bff-admin.swagger.ts
@@ -1,5 +1,8 @@
 import { HttpStatus } from '@nestjs/common';
-import { ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+
+import { AssessmentsSettingsResult } from './results/assessments-settings.result';
+import { AssessmentsUsageResult } from './results/assessments-usage.result';
 
 import { AdminClassroomDetailsResult } from './results/admin-classroom-details.result';
 import { AdminClassroomsViewResult } from './results/admin-classrooms-view.result';
@@ -301,3 +304,49 @@ export const DashboardSummarySwagger = () =>
     description:
       'Get comprehensive dashboard summary with aggregated statistics for all major resources including students, teachers, classrooms, subjects, departments, levels, admins, attendance, payments, and recent activities',
   });
+
+// Assessments Settings — read
+export const GetAssessmentsSettingsSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.OK,
+    type: AssessmentsSettingsResult,
+    description:
+      "Read the school's Assessments enable state, audit fields, and the active free-period end date / reason",
+  });
+
+// Assessments Settings — toggle
+export const ToggleAssessmentsSettingsSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.OK,
+    type: AssessmentsSettingsResult,
+    description:
+      'Enable or disable Assessments for the calling admin\'s school. Sets enabledAt/enabledById on enable, disabledAt on disable.',
+  });
+
+// Assessments Usage — month aggregate
+export const AssessmentsUsageMonthQuery = () =>
+  ApiQuery({
+    name: 'month',
+    required: false,
+    type: String,
+    example: '2026-04',
+    description: 'Month to aggregate, in YYYY-MM. Defaults to current UTC month if omitted.',
+  });
+
+export const GetAssessmentsUsageSwagger = () =>
+  ApiResponse({
+    status: HttpStatus.OK,
+    type: AssessmentsUsageResult,
+    description:
+      'Aggregated quiz_usage_events for the school for the given month. Returns nominal, waived, and chargeable totals plus per-assignment breakdown.',
+  });
+
+// Assessments operation summaries (used alongside the response decorators)
+export const GetAssessmentsSettingsOperation = () =>
+  ApiOperation({ summary: "Read the school's Assessments feature settings" });
+
+export const ToggleAssessmentsSettingsOperation = () =>
+  ApiOperation({ summary: 'Enable or disable Assessments for the school' });
+
+export const GetAssessmentsUsageOperation = () =>
+  ApiOperation({ summary: 'Get aggregated Assessments usage for a month' });

--- a/src/components/bff/admin/dto/toggle-assessments.dto.ts
+++ b/src/components/bff/admin/dto/toggle-assessments.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class ToggleAssessmentsDto {
+  @IsBoolean()
+  enabled!: boolean;
+}

--- a/src/components/bff/admin/results/assessments-settings.result.ts
+++ b/src/components/bff/admin/results/assessments-settings.result.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import type { AssessmentsSettingsView } from '../../../quiz-billing/quiz-billing.service';
+
+export class AssessmentsSettingsResult implements AssessmentsSettingsView {
+  @ApiProperty({ description: 'Whether Assessments is currently enabled for this school' })
+  assessmentsEnabled!: boolean;
+
+  @ApiPropertyOptional({ type: String, format: 'date-time', nullable: true })
+  assessmentsEnabledAt!: Date | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Display name of the admin who enabled it' })
+  assessmentsEnabledByName!: string | null;
+
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    description:
+      'Date until which usage is waived (max of global Beta cutoff and school.createdAt + 365d)',
+  })
+  freeUntil!: Date;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    enum: ['BETA', 'FIRST_YEAR'],
+    description: 'Reason for the active waiver, or null if no waiver currently applies',
+  })
+  freeUntilReason!: 'BETA' | 'FIRST_YEAR' | null;
+
+  @ApiProperty({ description: 'Rate per chargeable unit, in naira' })
+  unitRateNaira!: number;
+
+  constructor(data: AssessmentsSettingsView) {
+    Object.assign(this, data);
+  }
+}

--- a/src/components/bff/admin/results/assessments-usage.result.ts
+++ b/src/components/bff/admin/results/assessments-usage.result.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import type { AssessmentsUsageView } from '../../../quiz-billing/quiz-billing.service';
+
+export class AssessmentsUsageByAssignmentResult {
+  @ApiProperty()
+  quizAssignmentId!: string;
+
+  @ApiProperty()
+  attempts!: number;
+
+  @ApiProperty()
+  units!: number;
+
+  @ApiProperty({ description: 'Nominal cost in kobo at full rate' })
+  nominalAmountKobo!: number;
+}
+
+export class AssessmentsUsageResult implements AssessmentsUsageView {
+  @ApiProperty({ example: '2026-04', description: 'Month aggregated, in YYYY-MM' })
+  month!: string;
+
+  @ApiProperty()
+  totalAttempts!: number;
+
+  @ApiProperty()
+  totalUnits!: number;
+
+  @ApiProperty({ description: 'Sum of nominal cost in kobo (full rate)' })
+  nominalAmountKobo!: number;
+
+  @ApiProperty({
+    description: 'Portion of the nominal that is waived this month (Beta or first-year free)',
+  })
+  waivedAmountKobo!: number;
+
+  @ApiProperty({ description: 'Portion of the nominal actually billable for this month' })
+  chargeableAmountKobo!: number;
+
+  @ApiProperty({ type: [AssessmentsUsageByAssignmentResult] })
+  byAssignment!: AssessmentsUsageByAssignmentResult[];
+
+  constructor(data: AssessmentsUsageView) {
+    Object.assign(this, data);
+  }
+}

--- a/src/components/bff/teacher/results/teacher-classes.result.ts
+++ b/src/components/bff/teacher/results/teacher-classes.result.ts
@@ -3,6 +3,7 @@ import { TeacherClassInfo } from '../types';
 export class TeacherClassesResult {
   classes: {
     id: string;
+    classArmSubjectId?: string;
     name: string;
     level: string;
     subject: string;

--- a/src/components/bff/teacher/teacher.controller.ts
+++ b/src/components/bff/teacher/teacher.controller.ts
@@ -79,6 +79,15 @@ export class TeacherController {
     return new TeacherClassesResult(classes);
   }
 
+  @Get('curriculum')
+  @ApiOperation({
+    summary:
+      "Returns the teacher's school's curriculum metadata (subjects, levels, terms with IDs) for authoring dropdowns.",
+  })
+  async getTeacherCurriculum(@GetCurrentUserId() userId: string) {
+    return this.teacherService.getTeacherCurriculum(userId);
+  }
+
   @Get('subject-assignments')
   @ApiQuery({
     name: 'limit',

--- a/src/components/bff/teacher/teacher.service.ts
+++ b/src/components/bff/teacher/teacher.service.ts
@@ -156,6 +156,68 @@ export class TeacherService {
     }));
   }
 
+  /**
+   * Returns the teacher's school's curriculum metadata for authoring dropdowns:
+   * subjects + levels + the current-session's terms. All scoped to the teacher's
+   * own school. Used by question / quiz authoring forms.
+   */
+  async getTeacherCurriculum(userId: string): Promise<{
+    subjects: { id: string; name: string }[];
+    levels: { id: string; code: string; name: string }[];
+    terms: { id: string; name: string }[];
+    currentTermId: string | null;
+    currentAcademicSessionId: string | null;
+  }> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+    if (!user?.schoolId)
+      return {
+        subjects: [],
+        levels: [],
+        terms: [],
+        currentTermId: null,
+        currentAcademicSessionId: null,
+      };
+
+    const schoolId = user.schoolId;
+    const current = await this.currentTermService.getCurrentTermWithSession(schoolId);
+    const sessionId = current?.session.id ?? null;
+
+    const [subjects, levels, terms, school] = await Promise.all([
+      this.prisma.subject.findMany({
+        where: { schoolId, deletedAt: null },
+        select: { id: true, name: true },
+        orderBy: { name: 'asc' },
+      }),
+      this.prisma.level.findMany({
+        where: { schoolId, deletedAt: null },
+        select: { id: true, code: true, name: true },
+        orderBy: { order: 'asc' },
+      }),
+      sessionId
+        ? this.prisma.term.findMany({
+            where: { academicSessionId: sessionId, deletedAt: null },
+            select: { id: true, name: true, startDate: true },
+            orderBy: { startDate: 'asc' },
+          })
+        : Promise.resolve([]),
+      this.prisma.school.findUnique({
+        where: { id: schoolId },
+        select: { currentTermId: true },
+      }),
+    ]);
+
+    return {
+      subjects,
+      levels,
+      terms: terms.map(({ id, name }) => ({ id, name })),
+      currentTermId: school?.currentTermId ?? null,
+      currentAcademicSessionId: sessionId,
+    };
+  }
+
   // Get teacher's subject assignments (classes where teacher teaches specific subjects)
   async getTeacherSubjectAssignments(userId: string): Promise<TeacherClassInfo[]> {
     const teacher = await this.getTeacherWithRelations(userId);
@@ -163,6 +225,7 @@ export class TeacherService {
     // Return classes where the teacher teaches specific subjects
     return teacher.classArmSubjectTeachers.map((cast) => ({
       id: cast.classArmSubject.classArm.id,
+      classArmSubjectId: cast.classArmSubject.id,
       name: cast.classArmSubject.classArm.name,
       level: cast.classArmSubject.classArm.level.name,
       subject: cast.classArmSubject.subject.name,

--- a/src/components/bff/teacher/types/index.ts
+++ b/src/components/bff/teacher/types/index.ts
@@ -46,6 +46,9 @@ export interface TeacherProfile {
 // Class information
 export interface TeacherClassInfo {
   id: string;
+  /** classArmSubject.id — the FK target for QuizAssignment.classArmSubjectId.
+   *  Only set on subject-assignment results; null on whole-class entries. */
+  classArmSubjectId?: string;
   name: string;
   level: string;
   subject: string;

--- a/src/components/canonical-references/canonical-references.controller.ts
+++ b/src/components/canonical-references/canonical-references.controller.ts
@@ -1,0 +1,163 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { SystemAdminGuard } from '../../common/guards';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { CanonicalReferencesService } from './canonical-references.service';
+import {
+  CreateCanonicalLevelDto,
+  CreateCanonicalSubjectDto,
+  CreateCanonicalTermDto,
+  UpdateCanonicalLevelDto,
+  UpdateCanonicalSubjectDto,
+  UpdateCanonicalTermDto,
+} from './dto/canonical.dto';
+import {
+  CanonicalLevelResult,
+  CanonicalLevelsListResult,
+  CanonicalSubjectResult,
+  CanonicalSubjectsListResult,
+  CanonicalTermResult,
+  CanonicalTermsListResult,
+} from './results/canonical.result';
+
+@Controller('canonical-references')
+@ApiTags('Canonical References')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class CanonicalReferencesController {
+  constructor(private readonly service: CanonicalReferencesService) {}
+
+  // ---------- Subjects ----------
+
+  @Get('subjects')
+  @ApiOperation({
+    summary:
+      'List schos-managed canonical subjects. Used to populate dropdowns when curating SCHOS_CURATED content. By default returns active only — pass ?includeInactive=true to see all.',
+  })
+  @ApiResponse({ status: 200, type: CanonicalSubjectsListResult })
+  async listSubjects(@Query('includeInactive') includeInactive?: string) {
+    const subjects = await this.service.listSubjects(includeInactive !== 'true');
+    return new CanonicalSubjectsListResult(subjects.map((s) => new CanonicalSubjectResult(s)));
+  }
+
+  @Post('subjects')
+  @UseGuards(SystemAdminGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a canonical subject (platform admin only).' })
+  @ApiResponse({ status: 201, type: CanonicalSubjectResult })
+  async createSubject(@Body() dto: CreateCanonicalSubjectDto) {
+    const s = await this.service.createSubject(dto);
+    return new CanonicalSubjectResult(s);
+  }
+
+  @Patch('subjects/:id')
+  @UseGuards(SystemAdminGuard)
+  @ApiOperation({ summary: 'Update a canonical subject (platform admin only).' })
+  @ApiResponse({ status: 200, type: CanonicalSubjectResult })
+  async updateSubject(@Param('id') id: string, @Body() dto: UpdateCanonicalSubjectDto) {
+    const s = await this.service.updateSubject(id, dto);
+    return new CanonicalSubjectResult(s);
+  }
+
+  @Delete('subjects/:id')
+  @UseGuards(SystemAdminGuard)
+  @ApiOperation({ summary: 'Soft-delete a canonical subject (platform admin only).' })
+  async deleteSubject(@Param('id') id: string) {
+    await this.service.deleteSubject(id);
+    return { success: true, message: 'Canonical subject deleted' };
+  }
+
+  // ---------- Levels ----------
+
+  @Get('levels')
+  @ApiOperation({
+    summary:
+      'List schos-managed canonical levels (PRY1-SSS3, GRADE_1-12, A_LEVEL, etc). Optional ?group= filter, ?includeInactive=true.',
+  })
+  @ApiResponse({ status: 200, type: CanonicalLevelsListResult })
+  async listLevels(
+    @Query('group') group?: string,
+    @Query('includeInactive') includeInactive?: string,
+  ) {
+    const levels = await this.service.listLevels(includeInactive !== 'true', group);
+    return new CanonicalLevelsListResult(levels.map((l) => new CanonicalLevelResult(l)));
+  }
+
+  @Post('levels')
+  @UseGuards(SystemAdminGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a canonical level (platform admin only).' })
+  @ApiResponse({ status: 201, type: CanonicalLevelResult })
+  async createLevel(@Body() dto: CreateCanonicalLevelDto) {
+    const l = await this.service.createLevel(dto);
+    return new CanonicalLevelResult(l);
+  }
+
+  @Patch('levels/:id')
+  @UseGuards(SystemAdminGuard)
+  @ApiOperation({ summary: 'Update a canonical level (platform admin only).' })
+  @ApiResponse({ status: 200, type: CanonicalLevelResult })
+  async updateLevel(@Param('id') id: string, @Body() dto: UpdateCanonicalLevelDto) {
+    const l = await this.service.updateLevel(id, dto);
+    return new CanonicalLevelResult(l);
+  }
+
+  @Delete('levels/:id')
+  @UseGuards(SystemAdminGuard)
+  @ApiOperation({ summary: 'Soft-delete a canonical level (platform admin only).' })
+  async deleteLevel(@Param('id') id: string) {
+    await this.service.deleteLevel(id);
+    return { success: true, message: 'Canonical level deleted' };
+  }
+
+  // ---------- Terms ----------
+
+  @Get('terms')
+  @ApiOperation({ summary: 'List schos-managed canonical terms. ?includeInactive=true for all.' })
+  @ApiResponse({ status: 200, type: CanonicalTermsListResult })
+  async listTerms(@Query('includeInactive') includeInactive?: string) {
+    const terms = await this.service.listTerms(includeInactive !== 'true');
+    return new CanonicalTermsListResult(terms.map((t) => new CanonicalTermResult(t)));
+  }
+
+  @Post('terms')
+  @UseGuards(SystemAdminGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a canonical term (platform admin only).' })
+  @ApiResponse({ status: 201, type: CanonicalTermResult })
+  async createTerm(@Body() dto: CreateCanonicalTermDto) {
+    const t = await this.service.createTerm(dto);
+    return new CanonicalTermResult(t);
+  }
+
+  @Patch('terms/:id')
+  @UseGuards(SystemAdminGuard)
+  @ApiOperation({ summary: 'Update a canonical term (platform admin only).' })
+  @ApiResponse({ status: 200, type: CanonicalTermResult })
+  async updateTerm(@Param('id') id: string, @Body() dto: UpdateCanonicalTermDto) {
+    const t = await this.service.updateTerm(id, dto);
+    return new CanonicalTermResult(t);
+  }
+
+  @Delete('terms/:id')
+  @UseGuards(SystemAdminGuard)
+  @ApiOperation({ summary: 'Soft-delete a canonical term (platform admin only).' })
+  async deleteTerm(@Param('id') id: string) {
+    await this.service.deleteTerm(id);
+    return { success: true, message: 'Canonical term deleted' };
+  }
+}

--- a/src/components/canonical-references/canonical-references.module.ts
+++ b/src/components/canonical-references/canonical-references.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { CanonicalReferencesController } from './canonical-references.controller';
+import { CanonicalReferencesService } from './canonical-references.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [CanonicalReferencesController],
+  providers: [CanonicalReferencesService, Encryptor],
+  exports: [CanonicalReferencesService],
+})
+export class CanonicalReferencesModule {}

--- a/src/components/canonical-references/canonical-references.service.ts
+++ b/src/components/canonical-references/canonical-references.service.ts
@@ -1,0 +1,239 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { PrismaService } from '../../prisma/prisma.service';
+
+interface SubjectInput {
+  name: string;
+  slug?: string;
+  description?: string | null;
+  active?: boolean;
+}
+
+interface LevelInput {
+  code: string;
+  name: string;
+  group: string;
+  order: number;
+  active?: boolean;
+}
+
+interface TermInput {
+  name: string;
+  order: number;
+  active?: boolean;
+}
+
+@Injectable()
+export class CanonicalReferencesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ---------- Subjects ----------
+
+  listSubjects(activeOnly = true) {
+    return this.prisma.canonicalSubject.findMany({
+      where: {
+        deletedAt: null,
+        ...(activeOnly && { active: true }),
+      },
+      orderBy: [{ name: 'asc' }],
+    });
+  }
+
+  async createSubject(dto: SubjectInput) {
+    if (!dto.name?.trim()) throw new BadRequestException('name is required');
+    const slug = (dto.slug ?? this.slugify(dto.name)).trim();
+    if (!slug) throw new BadRequestException('slug is required');
+    if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(slug)) {
+      throw new BadRequestException('slug must be lowercase alphanumeric with hyphens');
+    }
+    try {
+      return await this.prisma.canonicalSubject.create({
+        data: {
+          name: dto.name.trim(),
+          slug,
+          description: dto.description ?? null,
+          active: dto.active ?? true,
+        },
+      });
+    } catch (err) {
+      throw this.translateUniqueViolation(err, 'subject');
+    }
+  }
+
+  async updateSubject(id: string, dto: Partial<SubjectInput>) {
+    await this.findSubjectOrThrow(id);
+    try {
+      return await this.prisma.canonicalSubject.update({
+        where: { id },
+        data: {
+          ...(dto.name !== undefined && { name: dto.name.trim() }),
+          ...(dto.slug !== undefined && { slug: dto.slug.trim() }),
+          ...(dto.description !== undefined && { description: dto.description }),
+          ...(dto.active !== undefined && { active: dto.active }),
+        },
+      });
+    } catch (err) {
+      throw this.translateUniqueViolation(err, 'subject');
+    }
+  }
+
+  async deleteSubject(id: string) {
+    await this.findSubjectOrThrow(id);
+    return this.prisma.canonicalSubject.update({
+      where: { id },
+      data: { deletedAt: new Date(), active: false },
+    });
+  }
+
+  private async findSubjectOrThrow(id: string) {
+    const s = await this.prisma.canonicalSubject.findFirst({ where: { id, deletedAt: null } });
+    if (!s) throw new NotFoundException('Canonical subject not found');
+    return s;
+  }
+
+  // ---------- Levels ----------
+
+  listLevels(activeOnly = true, group?: string) {
+    return this.prisma.canonicalLevel.findMany({
+      where: {
+        deletedAt: null,
+        ...(activeOnly && { active: true }),
+        ...(group && { group }),
+      },
+      orderBy: [{ group: 'asc' }, { order: 'asc' }],
+    });
+  }
+
+  async createLevel(dto: LevelInput) {
+    const code = dto.code?.trim().toUpperCase();
+    if (!code) throw new BadRequestException('code is required');
+    if (!dto.name?.trim()) throw new BadRequestException('name is required');
+    if (!dto.group?.trim()) throw new BadRequestException('group is required');
+    try {
+      return await this.prisma.canonicalLevel.create({
+        data: {
+          code,
+          name: dto.name.trim(),
+          group: dto.group.trim().toUpperCase(),
+          order: dto.order,
+          active: dto.active ?? true,
+        },
+      });
+    } catch (err) {
+      throw this.translateUniqueViolation(err, 'level');
+    }
+  }
+
+  async updateLevel(id: string, dto: Partial<LevelInput>) {
+    await this.findLevelOrThrow(id);
+    try {
+      return await this.prisma.canonicalLevel.update({
+        where: { id },
+        data: {
+          ...(dto.code !== undefined && { code: dto.code.trim().toUpperCase() }),
+          ...(dto.name !== undefined && { name: dto.name.trim() }),
+          ...(dto.group !== undefined && { group: dto.group.trim().toUpperCase() }),
+          ...(dto.order !== undefined && { order: dto.order }),
+          ...(dto.active !== undefined && { active: dto.active }),
+        },
+      });
+    } catch (err) {
+      throw this.translateUniqueViolation(err, 'level');
+    }
+  }
+
+  async deleteLevel(id: string) {
+    await this.findLevelOrThrow(id);
+    return this.prisma.canonicalLevel.update({
+      where: { id },
+      data: { deletedAt: new Date(), active: false },
+    });
+  }
+
+  private async findLevelOrThrow(id: string) {
+    const l = await this.prisma.canonicalLevel.findFirst({ where: { id, deletedAt: null } });
+    if (!l) throw new NotFoundException('Canonical level not found');
+    return l;
+  }
+
+  // ---------- Terms ----------
+
+  listTerms(activeOnly = true) {
+    return this.prisma.canonicalTerm.findMany({
+      where: {
+        deletedAt: null,
+        ...(activeOnly && { active: true }),
+      },
+      orderBy: [{ order: 'asc' }],
+    });
+  }
+
+  async createTerm(dto: TermInput) {
+    if (!dto.name?.trim()) throw new BadRequestException('name is required');
+    try {
+      return await this.prisma.canonicalTerm.create({
+        data: {
+          name: dto.name.trim(),
+          order: dto.order,
+          active: dto.active ?? true,
+        },
+      });
+    } catch (err) {
+      throw this.translateUniqueViolation(err, 'term');
+    }
+  }
+
+  async updateTerm(id: string, dto: Partial<TermInput>) {
+    await this.findTermOrThrow(id);
+    try {
+      return await this.prisma.canonicalTerm.update({
+        where: { id },
+        data: {
+          ...(dto.name !== undefined && { name: dto.name.trim() }),
+          ...(dto.order !== undefined && { order: dto.order }),
+          ...(dto.active !== undefined && { active: dto.active }),
+        },
+      });
+    } catch (err) {
+      throw this.translateUniqueViolation(err, 'term');
+    }
+  }
+
+  async deleteTerm(id: string) {
+    await this.findTermOrThrow(id);
+    return this.prisma.canonicalTerm.update({
+      where: { id },
+      data: { deletedAt: new Date(), active: false },
+    });
+  }
+
+  private async findTermOrThrow(id: string) {
+    const t = await this.prisma.canonicalTerm.findFirst({ where: { id, deletedAt: null } });
+    if (!t) throw new NotFoundException('Canonical term not found');
+    return t;
+  }
+
+  // ---------- helpers ----------
+
+  private slugify(s: string) {
+    return s
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  private translateUniqueViolation(err: unknown, label: string): Error {
+    const e = err as { code?: string; meta?: { target?: string[] } };
+    if (e?.code === 'P2002') {
+      const field = e.meta?.target?.join(', ') ?? 'name/slug/code';
+      return new ConflictException(`A ${label} with this ${field} already exists`);
+    }
+    return err as Error;
+  }
+}

--- a/src/components/canonical-references/dto/canonical.dto.ts
+++ b/src/components/canonical-references/dto/canonical.dto.ts
@@ -1,0 +1,167 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+export class CreateCanonicalSubjectDto {
+  @ApiProperty({ example: 'Astronomy' })
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    required: false,
+    example: 'astronomy',
+    description: 'URL slug. Lowercase alphanumeric with hyphens. Auto-generated from name if omitted.',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z0-9]+(-[a-z0-9]+)*$/, {
+    message: 'slug must be lowercase alphanumeric with hyphens (e.g. my-subject-name)',
+  })
+  @MaxLength(100)
+  slug?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false, default: true })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}
+
+export class UpdateCanonicalSubjectDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z0-9]+(-[a-z0-9]+)*$/, {
+    message: 'slug must be lowercase alphanumeric with hyphens',
+  })
+  @MaxLength(100)
+  slug?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}
+
+export class CreateCanonicalLevelDto {
+  @ApiProperty({
+    example: 'GRADE_13',
+    description: 'Stable code, UPPER_SNAKE_CASE. Cannot collide with an existing level.',
+  })
+  @IsString()
+  @MaxLength(40)
+  code: string;
+
+  @ApiProperty({ example: 'Grade 13' })
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    example: 'INTL_GRADE',
+    description: 'Group bucket: PRIMARY | JUNIOR_SECONDARY | SENIOR_SECONDARY | INTL_GRADE | BRITISH | (custom)',
+  })
+  @IsString()
+  @MaxLength(40)
+  group: string;
+
+  @ApiProperty({ example: 13, description: 'Display order within the group' })
+  @IsInt()
+  @Min(0)
+  order: number;
+
+  @ApiProperty({ required: false, default: true })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}
+
+export class UpdateCanonicalLevelDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(40)
+  code?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(40)
+  group?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}
+
+export class CreateCanonicalTermDto {
+  @ApiProperty({ example: 'Fourth Term' })
+  @IsString()
+  @MaxLength(60)
+  name: string;
+
+  @ApiProperty({ example: 4 })
+  @IsInt()
+  @Min(0)
+  order: number;
+
+  @ApiProperty({ required: false, default: true })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}
+
+export class UpdateCanonicalTermDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(60)
+  name?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/components/canonical-references/results/canonical.result.ts
+++ b/src/components/canonical-references/results/canonical.result.ts
@@ -1,0 +1,80 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CanonicalLevel, CanonicalSubject, CanonicalTerm } from '@prisma/client';
+
+export class CanonicalSubjectResult {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() slug: string;
+  @ApiProperty({ required: false, nullable: true }) description: string | null;
+  @ApiProperty() active: boolean;
+
+  constructor(s: CanonicalSubject) {
+    this.id = s.id;
+    this.name = s.name;
+    this.slug = s.slug;
+    this.description = s.description;
+    this.active = s.active;
+  }
+}
+
+export class CanonicalSubjectsListResult {
+  @ApiProperty({ type: [CanonicalSubjectResult] })
+  subjects: CanonicalSubjectResult[];
+
+  constructor(subjects: CanonicalSubjectResult[]) {
+    this.subjects = subjects;
+  }
+}
+
+export class CanonicalLevelResult {
+  @ApiProperty() id: string;
+  @ApiProperty() code: string;
+  @ApiProperty() name: string;
+  @ApiProperty({
+    description: 'Cluster (PRIMARY, JUNIOR_SECONDARY, SENIOR_SECONDARY, INTL_GRADE, BRITISH, etc.)',
+  })
+  group: string;
+  @ApiProperty() order: number;
+  @ApiProperty() active: boolean;
+
+  constructor(l: CanonicalLevel) {
+    this.id = l.id;
+    this.code = l.code;
+    this.name = l.name;
+    this.group = l.group;
+    this.order = l.order;
+    this.active = l.active;
+  }
+}
+
+export class CanonicalLevelsListResult {
+  @ApiProperty({ type: [CanonicalLevelResult] })
+  levels: CanonicalLevelResult[];
+
+  constructor(levels: CanonicalLevelResult[]) {
+    this.levels = levels;
+  }
+}
+
+export class CanonicalTermResult {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() order: number;
+  @ApiProperty() active: boolean;
+
+  constructor(t: CanonicalTerm) {
+    this.id = t.id;
+    this.name = t.name;
+    this.order = t.order;
+    this.active = t.active;
+  }
+}
+
+export class CanonicalTermsListResult {
+  @ApiProperty({ type: [CanonicalTermResult] })
+  terms: CanonicalTermResult[];
+
+  constructor(terms: CanonicalTermResult[]) {
+    this.terms = terms;
+  }
+}

--- a/src/components/canonical-references/results/index.ts
+++ b/src/components/canonical-references/results/index.ts
@@ -1,0 +1,1 @@
+export * from './canonical.result';

--- a/src/components/popular-exams/dto/create-popular-exam.dto.ts
+++ b/src/components/popular-exams/dto/create-popular-exam.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+
+export class CreatePopularExamDto {
+  @ApiProperty({
+    description: 'Stable machine code for the exam (uppercase, used in tagging). Cannot be changed after creation.',
+    example: 'WAEC',
+  })
+  @IsString()
+  @Matches(/^[A-Z][A-Z0-9_]*$/, {
+    message: 'code must be UPPER_SNAKE_CASE starting with a letter',
+  })
+  @MaxLength(40)
+  code: string;
+
+  @ApiProperty({
+    description: 'Full display name of the exam',
+    example: 'West African Examinations Council',
+  })
+  @IsString()
+  @MaxLength(200)
+  name: string;
+
+  @ApiProperty({
+    description: 'ISO country code or region (e.g. NG, INTL)',
+    example: 'NG',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(10)
+  country?: string;
+
+  @ApiProperty({
+    description: 'Free-text description',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({
+    description: 'Whether this exam is selectable by teachers (defaults to true)',
+    required: false,
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/components/popular-exams/dto/index.ts
+++ b/src/components/popular-exams/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './create-popular-exam.dto';
+export * from './update-popular-exam.dto';
+export * from './popular-exam-query.dto';

--- a/src/components/popular-exams/dto/popular-exam-query.dto.ts
+++ b/src/components/popular-exams/dto/popular-exam-query.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class PopularExamQueryDto {
+  @ApiProperty({
+    description: 'Filter by active status. Omit to return all (active and inactive).',
+    required: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  active?: boolean;
+
+  @ApiProperty({
+    description: 'Filter by country code (e.g. NG, INTL)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  country?: string;
+}

--- a/src/components/popular-exams/dto/update-popular-exam.dto.ts
+++ b/src/components/popular-exams/dto/update-popular-exam.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+/**
+ * `code` is intentionally omitted — once an exam is referenced by tagged
+ * questions, its code is its identity. To rename, deactivate the old and
+ * create a new one.
+ */
+export class UpdatePopularExamDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  name?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(10)
+  country?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/components/popular-exams/popular-exams.controller.ts
+++ b/src/components/popular-exams/popular-exams.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { SystemAdminGuard } from '../../common/guards';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import {
+  CreatePopularExamDto,
+  PopularExamQueryDto,
+  UpdatePopularExamDto,
+} from './dto';
+import { PopularExamsService } from './popular-exams.service';
+import {
+  CreatePopularExamSwagger,
+  DeletePopularExamSwagger,
+  ListPopularExamsSwagger,
+  UpdatePopularExamSwagger,
+} from './popular-exams.swagger';
+import {
+  CreatePopularExamResult,
+  DeletePopularExamResult,
+  PopularExamResult,
+  PopularExamsListResult,
+  UpdatePopularExamResult,
+} from './results/popular-exam.result';
+
+@Controller('popular-exams')
+@ApiTags('Popular Exams')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class PopularExamsController {
+  constructor(private readonly popularExamsService: PopularExamsService) {}
+
+  @Get()
+  @ListPopularExamsSwagger()
+  async list(@Query() query: PopularExamQueryDto) {
+    const exams = await this.popularExamsService.list(query);
+    return new PopularExamsListResult(exams.map((e) => new PopularExamResult(e)));
+  }
+
+  @Post()
+  @UseGuards(SystemAdminGuard)
+  @CreatePopularExamSwagger()
+  async create(@Body() dto: CreatePopularExamDto) {
+    const exam = await this.popularExamsService.create(dto);
+    return new CreatePopularExamResult(new PopularExamResult(exam));
+  }
+
+  @Patch(':id')
+  @UseGuards(SystemAdminGuard)
+  @UpdatePopularExamSwagger()
+  async update(@Param('id') id: string, @Body() dto: UpdatePopularExamDto) {
+    const exam = await this.popularExamsService.update(id, dto);
+    return new UpdatePopularExamResult(new PopularExamResult(exam));
+  }
+
+  @Delete(':id')
+  @UseGuards(SystemAdminGuard)
+  @DeletePopularExamSwagger()
+  async delete(@Param('id') id: string) {
+    await this.popularExamsService.softDelete(id);
+    return new DeletePopularExamResult();
+  }
+}

--- a/src/components/popular-exams/popular-exams.module.ts
+++ b/src/components/popular-exams/popular-exams.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { PopularExamsController } from './popular-exams.controller';
+import { PopularExamsService } from './popular-exams.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [PopularExamsController],
+  providers: [PopularExamsService, Encryptor],
+  exports: [PopularExamsService],
+})
+export class PopularExamsModule {}

--- a/src/components/popular-exams/popular-exams.service.ts
+++ b/src/components/popular-exams/popular-exams.service.ts
@@ -1,0 +1,90 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  CreatePopularExamDto,
+  PopularExamQueryDto,
+  UpdatePopularExamDto,
+} from './dto';
+
+@Injectable()
+export class PopularExamsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(query: PopularExamQueryDto) {
+    const where: Prisma.PopularExamWhereInput = { deletedAt: null };
+    if (query.active !== undefined) where.active = query.active;
+    if (query.country) where.country = query.country;
+
+    return this.prisma.popularExam.findMany({
+      where,
+      orderBy: [{ active: 'desc' }, { code: 'asc' }],
+    });
+  }
+
+  async findById(id: string) {
+    const exam = await this.prisma.popularExam.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!exam) throw new NotFoundException('Popular exam not found');
+    return exam;
+  }
+
+  async create(dto: CreatePopularExamDto) {
+    const existing = await this.prisma.popularExam.findFirst({
+      where: { code: dto.code },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `Popular exam with code '${dto.code}' already exists`,
+      );
+    }
+
+    return this.prisma.popularExam.create({
+      data: {
+        code: dto.code,
+        name: dto.name,
+        country: dto.country,
+        description: dto.description,
+        active: dto.active ?? true,
+      },
+    });
+  }
+
+  async update(id: string, dto: UpdatePopularExamDto) {
+    await this.findById(id);
+
+    return this.prisma.popularExam.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.country !== undefined && { country: dto.country }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.active !== undefined && { active: dto.active }),
+      },
+    });
+  }
+
+  async softDelete(id: string) {
+    await this.findById(id);
+
+    const tagged = await this.prisma.questionPopularExam.count({
+      where: { popularExamId: id },
+    });
+    if (tagged > 0) {
+      throw new ConflictException(
+        `Cannot delete: ${tagged} question(s) reference this exam. Deactivate it instead.`,
+      );
+    }
+
+    await this.prisma.popularExam.update({
+      where: { id },
+      data: { deletedAt: new Date(), active: false },
+    });
+  }
+}

--- a/src/components/popular-exams/popular-exams.swagger.ts
+++ b/src/components/popular-exams/popular-exams.swagger.ts
@@ -1,0 +1,48 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+import { CreatePopularExamDto, UpdatePopularExamDto } from './dto';
+import {
+  CreatePopularExamResult,
+  DeletePopularExamResult,
+  PopularExamsListResult,
+  UpdatePopularExamResult,
+} from './results/popular-exam.result';
+
+export function ListPopularExamsSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'List popular exams (filterable by active / country)' }),
+    ApiResponse({ status: 200, type: PopularExamsListResult }),
+  );
+}
+
+export function CreatePopularExamSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a popular exam (system admin only)' }),
+    ApiBody({ type: CreatePopularExamDto }),
+    ApiResponse({ status: 201, type: CreatePopularExamResult }),
+    ApiResponse({ status: 409, description: 'Code already in use' }),
+  );
+}
+
+export function UpdatePopularExamSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update a popular exam (system admin only)' }),
+    ApiParam({ name: 'id', description: 'Popular exam id' }),
+    ApiBody({ type: UpdatePopularExamDto }),
+    ApiResponse({ status: 200, type: UpdatePopularExamResult }),
+    ApiResponse({ status: 404, description: 'Not found' }),
+  );
+}
+
+export function DeletePopularExamSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Soft-delete a popular exam (system admin only). Rejects if any question references it.',
+    }),
+    ApiParam({ name: 'id', description: 'Popular exam id' }),
+    ApiResponse({ status: 200, type: DeletePopularExamResult }),
+    ApiResponse({ status: 404, description: 'Not found' }),
+    ApiResponse({ status: 409, description: 'Exam is referenced by questions; deactivate instead' }),
+  );
+}

--- a/src/components/popular-exams/results/index.ts
+++ b/src/components/popular-exams/results/index.ts
@@ -1,0 +1,1 @@
+export * from './popular-exam.result';

--- a/src/components/popular-exams/results/popular-exam.result.ts
+++ b/src/components/popular-exams/results/popular-exam.result.ts
@@ -1,0 +1,103 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PopularExamResult {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @ApiProperty({ example: 'WAEC' })
+  code: string;
+
+  @ApiProperty({ example: 'West African Examinations Council' })
+  name: string;
+
+  @ApiProperty({ example: 'NG', nullable: true })
+  country: string | null;
+
+  @ApiProperty({ nullable: true })
+  description: string | null;
+
+  @ApiProperty({ example: true })
+  active: boolean;
+
+  @ApiProperty({ example: '2026-04-25T00:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2026-04-25T00:00:00.000Z' })
+  updatedAt: Date;
+
+  constructor(exam: {
+    id: string;
+    code: string;
+    name: string;
+    country: string | null;
+    description: string | null;
+    active: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = exam.id;
+    this.code = exam.code;
+    this.name = exam.name;
+    this.country = exam.country;
+    this.description = exam.description;
+    this.active = exam.active;
+    this.createdAt = exam.createdAt;
+    this.updatedAt = exam.updatedAt;
+  }
+}
+
+export class PopularExamsListResult {
+  @ApiProperty({ type: [PopularExamResult] })
+  popularExams: PopularExamResult[];
+
+  constructor(exams: PopularExamResult[]) {
+    this.popularExams = exams;
+  }
+}
+
+export class CreatePopularExamResult {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Popular exam created successfully' })
+  message: string;
+
+  @ApiProperty({ type: PopularExamResult })
+  popularExam: PopularExamResult;
+
+  constructor(exam: PopularExamResult) {
+    this.success = true;
+    this.message = 'Popular exam created successfully';
+    this.popularExam = exam;
+  }
+}
+
+export class UpdatePopularExamResult {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Popular exam updated successfully' })
+  message: string;
+
+  @ApiProperty({ type: PopularExamResult })
+  popularExam: PopularExamResult;
+
+  constructor(exam: PopularExamResult) {
+    this.success = true;
+    this.message = 'Popular exam updated successfully';
+    this.popularExam = exam;
+  }
+}
+
+export class DeletePopularExamResult {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Popular exam deleted successfully' })
+  message: string;
+
+  constructor() {
+    this.success = true;
+    this.message = 'Popular exam deleted successfully';
+  }
+}

--- a/src/components/questions/dto/create-question.dto.ts
+++ b/src/components/questions/dto/create-question.dto.ts
@@ -1,0 +1,177 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsEnum,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+import {
+  PartialCreditMode,
+  QuestionDifficulty,
+  QuestionStatus,
+  QuestionType,
+} from '@prisma/client';
+
+import { QuestionOptionDto } from './question-option.dto';
+import { QuestionPopularExamTagDto } from './question-popular-exam-tag.dto';
+
+export class CreateQuestionDto {
+  @ApiProperty({ enum: QuestionType })
+  @IsEnum(QuestionType)
+  type: QuestionType;
+
+  @ApiProperty({
+    description: 'Question prompt as TipTap JSON document (supports inline LaTeX math).',
+  })
+  @IsObject()
+  prompt: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Plain-text rendering of prompt, used for search/preview' })
+  @IsString()
+  promptPlainText: string;
+
+  @ApiProperty({ required: false, type: [String], description: 'S3 keys for prompt media' })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mediaUrls?: string[];
+
+  @ApiProperty({
+    required: false,
+    description: 'Explanation shown after grading (TipTap JSON)',
+  })
+  @IsOptional()
+  @IsObject()
+  explanation?: Record<string, unknown>;
+
+  @ApiProperty({
+    required: false,
+    description: 'Base weight (default 1.0). Overridable per quiz via QuizQuestion.weightOverride.',
+    default: 1,
+  })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Max(99999.99)
+  weight?: number;
+
+  @ApiProperty({ required: false, enum: QuestionDifficulty })
+  @IsOptional()
+  @IsEnum(QuestionDifficulty)
+  difficulty?: QuestionDifficulty;
+
+  @ApiProperty({ required: false, enum: QuestionStatus, default: QuestionStatus.DRAFT })
+  @IsOptional()
+  @IsEnum(QuestionStatus)
+  status?: QuestionStatus;
+
+  @ApiProperty({
+    required: false,
+    description: 'School-scoped subject id. Required for TEACHER_AUTHORED, must be null for SCHOS_CURATED.',
+  })
+  @IsOptional()
+  @IsUUID()
+  subjectId?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'School-scoped level id. Required for TEACHER_AUTHORED, must be null for SCHOS_CURATED.',
+  })
+  @IsOptional()
+  @IsUUID()
+  levelId?: string;
+
+  @ApiProperty({ required: false, description: 'Default term id (school-scoped)' })
+  @IsOptional()
+  @IsUUID()
+  defaultTermId?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Canonical subject name (e.g. "Mathematics"). Required for SCHOS_CURATED. Auto-derived from subject.name on create for TEACHER_AUTHORED if not provided.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  canonicalSubjectName?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Canonical level code (e.g. "SS2"). Required for SCHOS_CURATED. Auto-derived from level.code on create for TEACHER_AUTHORED if not provided.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  canonicalLevelCode?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Canonical term name (e.g. "First Term"). Optional. Auto-derived from term.name on create for TEACHER_AUTHORED if not provided.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  canonicalTermName?: string;
+
+  @ApiProperty({
+    required: false,
+    type: [String],
+    description: 'Topic ids to tag this question with',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  topicIds?: string[];
+
+  @ApiProperty({
+    required: false,
+    type: [QuestionPopularExamTagDto],
+    description: 'Past-exam sources (one entry per exam+year)',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => QuestionPopularExamTagDto)
+  popularExams?: QuestionPopularExamTagDto[];
+
+  @ApiProperty({
+    required: false,
+    type: [QuestionOptionDto],
+    description: 'Options (required for MCQ_SINGLE / MCQ_MULTI; ignored for other types)',
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(2)
+  @ArrayMaxSize(10)
+  @ValidateNested({ each: true })
+  @Type(() => QuestionOptionDto)
+  options?: QuestionOptionDto[];
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Type-specific config. NUMERIC: { correctAnswer, tolerance, unit?, toleranceMode }. SHORT_ANSWER: { acceptedAnswers, caseSensitive, normalizeWhitespace }. TRUE_FALSE: { correctAnswer }.',
+  })
+  @IsOptional()
+  @IsObject()
+  config?: Record<string, unknown>;
+
+  @ApiProperty({ required: false, enum: PartialCreditMode })
+  @IsOptional()
+  @IsEnum(PartialCreditMode)
+  partialCreditMode?: PartialCreditMode;
+}

--- a/src/components/questions/dto/index.ts
+++ b/src/components/questions/dto/index.ts
@@ -1,0 +1,5 @@
+export * from './create-question.dto';
+export * from './update-question.dto';
+export * from './question-query.dto';
+export * from './question-option.dto';
+export * from './question-popular-exam-tag.dto';

--- a/src/components/questions/dto/question-option.dto.ts
+++ b/src/components/questions/dto/question-option.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsObject, IsOptional, IsString, Min } from 'class-validator';
+
+export class QuestionOptionDto {
+  @ApiProperty({ description: 'Display order (0-based) among options' })
+  @IsInt()
+  @Min(0)
+  order: number;
+
+  @ApiProperty({
+    description: 'Option label as TipTap JSON (supports inline math + images)',
+  })
+  @IsObject()
+  label: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Plain-text rendering of label, used for search/preview' })
+  @IsString()
+  labelPlainText: string;
+
+  @ApiProperty({ description: 'Whether selecting this option counts as correct' })
+  @IsBoolean()
+  isCorrect: boolean;
+
+  @ApiProperty({ required: false, description: 'Optional S3 key for an option image' })
+  @IsOptional()
+  @IsString()
+  mediaUrl?: string;
+}

--- a/src/components/questions/dto/question-popular-exam-tag.dto.ts
+++ b/src/components/questions/dto/question-popular-exam-tag.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+
+export class QuestionPopularExamTagDto {
+  @ApiProperty({ description: 'PopularExam id (resolved from /popular-exams)' })
+  @IsUUID()
+  popularExamId: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Year the question was drawn from (e.g. 2019)',
+    minimum: 1900,
+    maximum: 2100,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1900)
+  @Max(2100)
+  examYear?: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'Question number from the source paper (e.g. "14", "Q14a", "P2-Q14")',
+  })
+  @IsOptional()
+  @IsString()
+  questionNumber?: string;
+}

--- a/src/components/questions/dto/question-query.dto.ts
+++ b/src/components/questions/dto/question-query.dto.ts
@@ -1,0 +1,87 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsEnum, IsInt, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+
+import { QuestionDifficulty, QuestionStatus, QuestionType } from '@prisma/client';
+
+export class QuestionQueryDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  subjectId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  levelId?: string;
+
+  @ApiProperty({ required: false, description: 'Filter by canonical subject name (case-insensitive exact match)' })
+  @IsOptional()
+  @IsString()
+  canonicalSubjectName?: string;
+
+  @ApiProperty({ required: false, description: 'Filter by canonical level code (case-insensitive exact match)' })
+  @IsOptional()
+  @IsString()
+  canonicalLevelCode?: string;
+
+  @ApiProperty({ required: false, description: 'Filter by canonical term name (case-insensitive exact match)' })
+  @IsOptional()
+  @IsString()
+  canonicalTermName?: string;
+
+  @ApiProperty({ required: false, type: [String], description: 'Filter to questions tagged with ANY of these topic ids' })
+  @IsOptional()
+  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
+  @IsArray()
+  @IsUUID('4', { each: true })
+  topicIds?: string[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  popularExamId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1900)
+  @Max(2100)
+  examYear?: number;
+
+  @ApiProperty({ required: false, enum: QuestionType })
+  @IsOptional()
+  @IsEnum(QuestionType)
+  type?: QuestionType;
+
+  @ApiProperty({ required: false, enum: QuestionDifficulty })
+  @IsOptional()
+  @IsEnum(QuestionDifficulty)
+  difficulty?: QuestionDifficulty;
+
+  @ApiProperty({ required: false, enum: QuestionStatus })
+  @IsOptional()
+  @IsEnum(QuestionStatus)
+  status?: QuestionStatus;
+
+  @ApiProperty({ required: false, description: 'Free-text search on promptPlainText (case-insensitive contains)' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({ required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ required: false, default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/components/questions/dto/update-question.dto.ts
+++ b/src/components/questions/dto/update-question.dto.ts
@@ -1,0 +1,12 @@
+import { PartialType } from '@nestjs/swagger';
+
+import { CreateQuestionDto } from './create-question.dto';
+
+/**
+ * All fields optional. When provided, replaces the corresponding collection
+ * (options / topicIds / popularExams) wholesale rather than merging.
+ *
+ * Edits to a question that is referenced by any PUBLISHED quiz are rejected;
+ * the API guides the caller to clone the question instead.
+ */
+export class UpdateQuestionDto extends PartialType(CreateQuestionDto) {}

--- a/src/components/questions/questions.controller.ts
+++ b/src/components/questions/questions.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { CreateQuestionDto, QuestionQueryDto, UpdateQuestionDto } from './dto';
+import { QuestionsService } from './questions.service';
+import {
+  CloneQuestionSwagger,
+  CreateQuestionSwagger,
+  DeleteQuestionSwagger,
+  GetQuestionSwagger,
+  ListLibraryQuestionsSwagger,
+  ListMyQuestionsSwagger,
+  UpdateQuestionSwagger,
+} from './questions.swagger';
+import {
+  CloneQuestionResult,
+  CreateQuestionResult,
+  DeleteQuestionResult,
+  QuestionResult,
+  QuestionsListResult,
+  UpdateQuestionResult,
+} from './results/question.result';
+
+@Controller('questions')
+@ApiTags('Questions')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class QuestionsController {
+  constructor(private readonly questionsService: QuestionsService) {}
+
+  @Post()
+  @CreateQuestionSwagger()
+  async create(@GetCurrentUserId() userId: string, @Body() dto: CreateQuestionDto) {
+    const question = await this.questionsService.create(userId, dto);
+    return new CreateQuestionResult(new QuestionResult(question));
+  }
+
+  @Get('mine')
+  @ListMyQuestionsSwagger()
+  async listMine(@GetCurrentUserId() userId: string, @Query() query: QuestionQueryDto) {
+    const { items, total, page, limit } = await this.questionsService.list(userId, 'mine', query);
+    return new QuestionsListResult(items.map((q) => new QuestionResult(q)), total, page, limit);
+  }
+
+  @Get('library')
+  @ListLibraryQuestionsSwagger()
+  async listLibrary(@GetCurrentUserId() userId: string, @Query() query: QuestionQueryDto) {
+    const { items, total, page, limit } = await this.questionsService.list(userId, 'library', query);
+    return new QuestionsListResult(items.map((q) => new QuestionResult(q)), total, page, limit);
+  }
+
+  @Get(':id')
+  @GetQuestionSwagger()
+  async findById(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const question = await this.questionsService.findById(userId, id);
+    return new QuestionResult(question);
+  }
+
+  @Patch(':id')
+  @UpdateQuestionSwagger()
+  async update(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: UpdateQuestionDto,
+  ) {
+    const question = await this.questionsService.update(userId, id, dto);
+    return new UpdateQuestionResult(new QuestionResult(question));
+  }
+
+  @Delete(':id')
+  @DeleteQuestionSwagger()
+  async delete(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    await this.questionsService.softDelete(userId, id);
+    return new DeleteQuestionResult();
+  }
+
+  @Post(':id/clone')
+  @HttpCode(HttpStatus.CREATED)
+  @CloneQuestionSwagger()
+  async clone(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const question = await this.questionsService.clone(userId, id);
+    return new CloneQuestionResult(new QuestionResult(question));
+  }
+}

--- a/src/components/questions/questions.module.ts
+++ b/src/components/questions/questions.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { QuestionsController } from './questions.controller';
+import { QuestionsService } from './questions.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [QuestionsController],
+  providers: [QuestionsService, Encryptor],
+  exports: [QuestionsService],
+})
+export class QuestionsModule {}

--- a/src/components/questions/questions.service.ts
+++ b/src/components/questions/questions.service.ts
@@ -1,0 +1,625 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  Prisma,
+  QuestionOwnerType,
+  QuestionStatus,
+  QuestionType,
+  QuizStatus,
+} from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { UserTypes } from '../users/constants';
+import {
+  CreateQuestionDto,
+  QuestionOptionDto,
+  QuestionPopularExamTagDto,
+  QuestionQueryDto,
+  UpdateQuestionDto,
+} from './dto';
+
+const QUESTION_INCLUDE = {
+  options: true,
+  topics: { include: { topic: true } },
+  popularExams: { include: { popularExam: true } },
+  _count: { select: { quizUses: true } },
+} as const;
+
+interface CallerContext {
+  userId: string;
+  type: string;
+  schoolId: string | null;
+}
+
+@Injectable()
+export class QuestionsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(callerUserId: string, scope: 'mine' | 'library', query: QuestionQueryDto) {
+    const caller = await this.getCallerContext(callerUserId);
+
+    const where: Prisma.QuestionWhereInput = { deletedAt: null };
+
+    if (scope === 'mine') {
+      if (caller.type !== UserTypes.TEACHER) {
+        return { items: [], total: 0, page: query.page ?? 1, limit: query.limit ?? 20 };
+      }
+      where.ownerType = QuestionOwnerType.TEACHER_AUTHORED;
+      where.schoolId = caller.schoolId;
+      where.authorUserId = callerUserId;
+    } else {
+      where.ownerType = QuestionOwnerType.SCHOS_CURATED;
+    }
+
+    if (query.subjectId) where.subjectId = query.subjectId;
+    if (query.levelId) where.levelId = query.levelId;
+    if (query.canonicalSubjectName) {
+      where.canonicalSubjectName = { equals: query.canonicalSubjectName, mode: 'insensitive' };
+    }
+    if (query.canonicalLevelCode) {
+      where.canonicalLevelCode = { equals: query.canonicalLevelCode, mode: 'insensitive' };
+    }
+    if (query.canonicalTermName) {
+      where.canonicalTermName = { equals: query.canonicalTermName, mode: 'insensitive' };
+    }
+    if (query.type) where.type = query.type;
+    if (query.difficulty) where.difficulty = query.difficulty;
+    if (query.status) where.status = query.status;
+    if (query.search) {
+      where.promptPlainText = { contains: query.search, mode: 'insensitive' };
+    }
+    if (query.topicIds?.length) {
+      where.topics = { some: { topicId: { in: query.topicIds } } };
+    }
+    if (query.popularExamId || query.examYear !== undefined) {
+      const examWhere: Prisma.QuestionPopularExamWhereInput = {};
+      if (query.popularExamId) examWhere.popularExamId = query.popularExamId;
+      if (query.examYear !== undefined) examWhere.examYear = query.examYear;
+      where.popularExams = { some: examWhere };
+    }
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+
+    const [items, total] = await Promise.all([
+      this.prisma.question.findMany({
+        where,
+        include: QUESTION_INCLUDE,
+        orderBy: [{ updatedAt: 'desc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.question.count({ where }),
+    ]);
+
+    return { items, total, page, limit };
+  }
+
+  async findById(callerUserId: string, id: string) {
+    const caller = await this.getCallerContext(callerUserId);
+    const question = await this.prisma.question.findFirst({
+      where: { id, deletedAt: null },
+      include: QUESTION_INCLUDE,
+    });
+    if (!question) throw new NotFoundException('Question not found');
+
+    const isCurated = question.ownerType === QuestionOwnerType.SCHOS_CURATED;
+    const isOwn =
+      question.ownerType === QuestionOwnerType.TEACHER_AUTHORED &&
+      question.authorUserId === callerUserId &&
+      question.schoolId === caller.schoolId;
+    if (!isCurated && !isOwn) {
+      throw new NotFoundException('Question not found');
+    }
+
+    return question;
+  }
+
+  async create(callerUserId: string, dto: CreateQuestionDto) {
+    const caller = await this.getCallerContext(callerUserId);
+    const { ownerType, schoolId } = this.resolveOwnership(caller);
+
+    let canonicalSubjectName = dto.canonicalSubjectName ?? null;
+    let canonicalLevelCode = dto.canonicalLevelCode ?? null;
+    let canonicalTermName = dto.canonicalTermName ?? null;
+
+    if (ownerType === QuestionOwnerType.TEACHER_AUTHORED) {
+      if (!dto.subjectId || !dto.levelId) {
+        throw new BadRequestException(
+          'subjectId and levelId are required for teacher-authored questions',
+        );
+      }
+      const refs = await this.fetchSchoolRefs(
+        schoolId!,
+        dto.subjectId,
+        dto.levelId,
+        dto.defaultTermId,
+      );
+      canonicalSubjectName ??= refs.subject.name;
+      canonicalLevelCode ??= refs.level.code;
+      canonicalTermName ??= refs.term?.name ?? null;
+    } else {
+      if (dto.subjectId || dto.levelId || dto.defaultTermId) {
+        throw new BadRequestException(
+          'Curated questions must not bind to a school subject/level/term — use canonical fields instead',
+        );
+      }
+      if (!canonicalSubjectName || !canonicalLevelCode) {
+        throw new BadRequestException(
+          'Curated questions require canonicalSubjectName and canonicalLevelCode so they are filterable in the library',
+        );
+      }
+    }
+
+    this.validateTypeSpecific(dto.type, dto.options, dto.config, dto.partialCreditMode);
+    if (dto.popularExams) this.assertUniquePopularExamPairs(dto.popularExams);
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      const q = await tx.question.create({
+        data: {
+          ownerType,
+          schoolId,
+          authorUserId: callerUserId,
+          subjectId: dto.subjectId ?? null,
+          levelId: dto.levelId ?? null,
+          defaultTermId: dto.defaultTermId ?? null,
+          canonicalSubjectName,
+          canonicalLevelCode,
+          canonicalTermName,
+          type: dto.type,
+          prompt: dto.prompt as Prisma.InputJsonValue,
+          promptPlainText: dto.promptPlainText,
+          mediaUrls: dto.mediaUrls ?? [],
+          explanation: (dto.explanation ?? null) as Prisma.InputJsonValue,
+          weight: dto.weight ?? 1,
+          difficulty: dto.difficulty,
+          status: dto.status ?? QuestionStatus.DRAFT,
+          config: (dto.config ?? null) as Prisma.InputJsonValue,
+          partialCreditMode: dto.partialCreditMode,
+        },
+      });
+
+      await this.replaceOptions(tx, q.id, dto.options);
+      await this.replaceTopicTags(tx, q.id, dto.topicIds);
+      await this.replacePopularExamTags(tx, q.id, dto.popularExams);
+
+      return q;
+    });
+
+    return this.fetchById(created.id);
+  }
+
+  async update(callerUserId: string, id: string, dto: UpdateQuestionDto) {
+    const existing = await this.findOwnedOrCurated(callerUserId, id);
+    await this.assertEditable(existing.id, existing.status);
+
+    if (dto.subjectId !== undefined || dto.levelId !== undefined || dto.defaultTermId !== undefined) {
+      if (existing.ownerType === QuestionOwnerType.SCHOS_CURATED) {
+        throw new BadRequestException(
+          'Curated questions cannot bind to a school subject/level/term',
+        );
+      }
+    }
+    if (dto.subjectId && dto.levelId && existing.schoolId) {
+      await this.assertSubjectAndLevelInSchool(dto.subjectId, dto.levelId, existing.schoolId);
+    }
+
+    const nextType = dto.type ?? existing.type;
+    if (
+      dto.type !== undefined ||
+      dto.options !== undefined ||
+      dto.config !== undefined ||
+      dto.partialCreditMode !== undefined
+    ) {
+      this.validateTypeSpecific(
+        nextType,
+        dto.options ?? undefined,
+        dto.config ?? (existing.config as Record<string, unknown> | null) ?? undefined,
+        dto.partialCreditMode ?? existing.partialCreditMode ?? undefined,
+      );
+    }
+
+    if (dto.popularExams) this.assertUniquePopularExamPairs(dto.popularExams);
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.question.update({
+        where: { id },
+        data: {
+          ...(dto.type !== undefined && { type: dto.type }),
+          ...(dto.prompt !== undefined && { prompt: dto.prompt as Prisma.InputJsonValue }),
+          ...(dto.promptPlainText !== undefined && { promptPlainText: dto.promptPlainText }),
+          ...(dto.mediaUrls !== undefined && { mediaUrls: dto.mediaUrls }),
+          ...(dto.explanation !== undefined && {
+            explanation: dto.explanation as Prisma.InputJsonValue,
+          }),
+          ...(dto.weight !== undefined && { weight: dto.weight }),
+          ...(dto.difficulty !== undefined && { difficulty: dto.difficulty }),
+          ...(dto.status !== undefined && { status: dto.status }),
+          ...(dto.subjectId !== undefined && { subjectId: dto.subjectId }),
+          ...(dto.levelId !== undefined && { levelId: dto.levelId }),
+          ...(dto.defaultTermId !== undefined && { defaultTermId: dto.defaultTermId }),
+          ...(dto.canonicalSubjectName !== undefined && {
+            canonicalSubjectName: dto.canonicalSubjectName,
+          }),
+          ...(dto.canonicalLevelCode !== undefined && {
+            canonicalLevelCode: dto.canonicalLevelCode,
+          }),
+          ...(dto.canonicalTermName !== undefined && { canonicalTermName: dto.canonicalTermName }),
+          ...(dto.config !== undefined && { config: dto.config as Prisma.InputJsonValue }),
+          ...(dto.partialCreditMode !== undefined && {
+            partialCreditMode: dto.partialCreditMode,
+          }),
+          version: { increment: 1 },
+        },
+      });
+
+      if (dto.options !== undefined) {
+        await tx.questionOption.deleteMany({ where: { questionId: id } });
+        await this.replaceOptions(tx, id, dto.options);
+      }
+      if (dto.topicIds !== undefined) {
+        await tx.questionTopic.deleteMany({ where: { questionId: id } });
+        await this.replaceTopicTags(tx, id, dto.topicIds);
+      }
+      if (dto.popularExams !== undefined) {
+        await tx.questionPopularExam.deleteMany({ where: { questionId: id } });
+        await this.replacePopularExamTags(tx, id, dto.popularExams);
+      }
+    });
+
+    return this.fetchById(id);
+  }
+
+  async softDelete(callerUserId: string, id: string) {
+    const existing = await this.findOwnedOrCurated(callerUserId, id);
+
+    const refCount = await this.prisma.quizQuestion.count({ where: { questionId: id } });
+    if (refCount > 0) {
+      throw new ConflictException(
+        `Cannot archive: ${refCount} quiz(zes) reference this question. Detach it from those quizzes first.`,
+      );
+    }
+
+    await this.prisma.question.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+        status: QuestionStatus.ARCHIVED,
+      },
+    });
+  }
+
+  async clone(callerUserId: string, id: string) {
+    const caller = await this.getCallerContext(callerUserId);
+    if (caller.type !== UserTypes.TEACHER) {
+      throw new ForbiddenException('Only teachers can clone curated questions');
+    }
+    if (!caller.schoolId) {
+      throw new BadRequestException('Caller has no schoolId');
+    }
+
+    const source = await this.prisma.question.findFirst({
+      where: {
+        id,
+        deletedAt: null,
+        ownerType: QuestionOwnerType.SCHOS_CURATED,
+      },
+      include: QUESTION_INCLUDE,
+    });
+    if (!source) {
+      throw new NotFoundException('Curated question not found (only SCHOS_CURATED questions can be cloned)');
+    }
+
+    const cloned = await this.prisma.$transaction(async (tx) => {
+      const q = await tx.question.create({
+        data: {
+          ownerType: QuestionOwnerType.TEACHER_AUTHORED,
+          schoolId: caller.schoolId,
+          authorUserId: callerUserId,
+          subjectId: null,
+          levelId: null,
+          defaultTermId: null,
+          canonicalSubjectName: source.canonicalSubjectName,
+          canonicalLevelCode: source.canonicalLevelCode,
+          canonicalTermName: source.canonicalTermName,
+          type: source.type,
+          prompt: source.prompt as Prisma.InputJsonValue,
+          promptPlainText: source.promptPlainText,
+          mediaUrls: source.mediaUrls,
+          explanation: (source.explanation ?? null) as Prisma.InputJsonValue,
+          weight: source.weight,
+          difficulty: source.difficulty,
+          status: QuestionStatus.DRAFT,
+          sourceQuestionId: source.id,
+          config: (source.config ?? null) as Prisma.InputJsonValue,
+          partialCreditMode: source.partialCreditMode,
+        },
+      });
+
+      if (source.options.length > 0) {
+        await tx.questionOption.createMany({
+          data: source.options.map((o) => ({
+            questionId: q.id,
+            order: o.order,
+            label: o.label as Prisma.InputJsonValue,
+            labelPlainText: o.labelPlainText,
+            isCorrect: o.isCorrect,
+            mediaUrl: o.mediaUrl,
+          })),
+        });
+      }
+
+      if (source.topics.length > 0) {
+        await tx.questionTopic.createMany({
+          data: source.topics.map((t) => ({ questionId: q.id, topicId: t.topicId })),
+        });
+      }
+
+      if (source.popularExams.length > 0) {
+        await tx.questionPopularExam.createMany({
+          data: source.popularExams.map((p) => ({
+            questionId: q.id,
+            popularExamId: p.popularExamId,
+            examYear: p.examYear,
+            questionNumber: p.questionNumber,
+          })),
+        });
+      }
+
+      return q;
+    });
+
+    return this.fetchById(cloned.id);
+  }
+
+  // ---- internals ----
+
+  private async fetchById(id: string) {
+    const q = await this.prisma.question.findUnique({
+      where: { id },
+      include: QUESTION_INCLUDE,
+    });
+    if (!q) throw new NotFoundException('Question not found');
+    return q;
+  }
+
+  private async findOwnedOrCurated(callerUserId: string, id: string) {
+    const caller = await this.getCallerContext(callerUserId);
+    const question = await this.prisma.question.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!question) throw new NotFoundException('Question not found');
+
+    if (caller.type === UserTypes.TEACHER) {
+      if (
+        question.ownerType !== QuestionOwnerType.TEACHER_AUTHORED ||
+        question.authorUserId !== callerUserId ||
+        question.schoolId !== caller.schoolId
+      ) {
+        throw new ForbiddenException('You can only modify your own questions');
+      }
+    } else if (caller.type === UserTypes.SYSTEM_ADMIN) {
+      if (question.ownerType !== QuestionOwnerType.SCHOS_CURATED) {
+        throw new ForbiddenException('System admins can only modify curated questions');
+      }
+    } else {
+      throw new ForbiddenException('Not authorized to modify questions');
+    }
+
+    return question;
+  }
+
+  private async assertEditable(questionId: string, status: QuestionStatus) {
+    if (status !== QuestionStatus.PUBLISHED) return;
+
+    const blockers = await this.prisma.quizQuestion.findMany({
+      where: {
+        questionId,
+        quiz: { status: QuizStatus.PUBLISHED, deletedAt: null },
+      },
+      select: { quiz: { select: { id: true, title: true } } },
+      take: 5,
+    });
+    if (blockers.length === 0) return;
+
+    const titles = blockers.map((b) => `"${b.quiz.title}"`).join(', ');
+    throw new ConflictException(
+      `Cannot edit: question is in use by published quiz(zes) ${titles}. Clone it and edit the clone instead.`,
+    );
+  }
+
+  private async getCallerContext(userId: string): Promise<CallerContext> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, type: true, schoolId: true },
+    });
+    if (!user) throw new ForbiddenException('Caller not found');
+    return { userId: user.id, type: user.type, schoolId: user.schoolId };
+  }
+
+  private resolveOwnership(caller: CallerContext) {
+    if (caller.type === UserTypes.TEACHER) {
+      if (!caller.schoolId) {
+        throw new BadRequestException('Teacher has no schoolId');
+      }
+      return { ownerType: QuestionOwnerType.TEACHER_AUTHORED, schoolId: caller.schoolId };
+    }
+    if (caller.type === UserTypes.SYSTEM_ADMIN) {
+      return { ownerType: QuestionOwnerType.SCHOS_CURATED, schoolId: null as string | null };
+    }
+    throw new ForbiddenException('Only teachers and system admins can author questions');
+  }
+
+  private async fetchSchoolRefs(
+    schoolId: string,
+    subjectId: string,
+    levelId: string,
+    termId: string | undefined,
+  ) {
+    const [subject, level, term] = await Promise.all([
+      this.prisma.subject.findFirst({
+        where: { id: subjectId, schoolId, deletedAt: null },
+        select: { id: true, name: true },
+      }),
+      this.prisma.level.findFirst({
+        where: { id: levelId, schoolId, deletedAt: null },
+        select: { id: true, code: true },
+      }),
+      termId
+        ? this.prisma.term.findFirst({
+            where: { id: termId, deletedAt: null },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve(null),
+    ]);
+    if (!subject) throw new BadRequestException('Subject not found in your school');
+    if (!level) throw new BadRequestException('Level not found in your school');
+    if (termId && !term) throw new BadRequestException('Term not found');
+    return { subject, level, term };
+  }
+
+  private async assertSubjectAndLevelInSchool(
+    subjectId: string,
+    levelId: string,
+    schoolId: string,
+  ) {
+    await this.fetchSchoolRefs(schoolId, subjectId, levelId, undefined);
+  }
+
+  private validateTypeSpecific(
+    type: QuestionType,
+    options: QuestionOptionDto[] | undefined,
+    config: Record<string, unknown> | null | undefined,
+    partialCreditMode: unknown,
+  ) {
+    switch (type) {
+      case QuestionType.MCQ_SINGLE: {
+        if (!options || options.length < 2) {
+          throw new BadRequestException('MCQ_SINGLE requires at least 2 options');
+        }
+        const correct = options.filter((o) => o.isCorrect).length;
+        if (correct !== 1) {
+          throw new BadRequestException('MCQ_SINGLE must have exactly one correct option');
+        }
+        return;
+      }
+      case QuestionType.MCQ_MULTI: {
+        if (!options || options.length < 2) {
+          throw new BadRequestException('MCQ_MULTI requires at least 2 options');
+        }
+        const correct = options.filter((o) => o.isCorrect).length;
+        if (correct < 1) {
+          throw new BadRequestException('MCQ_MULTI must have at least one correct option');
+        }
+        return;
+      }
+      case QuestionType.TRUE_FALSE: {
+        if (options && options.length > 0) {
+          throw new BadRequestException('TRUE_FALSE must not include options');
+        }
+        if (!config || typeof (config as { correctAnswer?: unknown }).correctAnswer !== 'boolean') {
+          throw new BadRequestException('TRUE_FALSE requires config.correctAnswer (boolean)');
+        }
+        return;
+      }
+      case QuestionType.NUMERIC: {
+        if (options && options.length > 0) {
+          throw new BadRequestException('NUMERIC must not include options');
+        }
+        const c = (config ?? {}) as { correctAnswer?: unknown; tolerance?: unknown; toleranceMode?: unknown };
+        if (typeof c.correctAnswer !== 'number') {
+          throw new BadRequestException('NUMERIC requires config.correctAnswer (number)');
+        }
+        if (typeof c.tolerance !== 'number' || c.tolerance < 0) {
+          throw new BadRequestException('NUMERIC requires config.tolerance (non-negative number)');
+        }
+        if (c.toleranceMode !== 'ABSOLUTE' && c.toleranceMode !== 'PERCENT') {
+          throw new BadRequestException('NUMERIC requires config.toleranceMode of ABSOLUTE | PERCENT');
+        }
+        return;
+      }
+      case QuestionType.SHORT_ANSWER: {
+        if (options && options.length > 0) {
+          throw new BadRequestException('SHORT_ANSWER must not include options');
+        }
+        const c = (config ?? {}) as { acceptedAnswers?: unknown };
+        if (
+          !Array.isArray(c.acceptedAnswers) ||
+          c.acceptedAnswers.length === 0 ||
+          !c.acceptedAnswers.every((a) => typeof a === 'string')
+        ) {
+          throw new BadRequestException(
+            'SHORT_ANSWER requires config.acceptedAnswers (non-empty string array)',
+          );
+        }
+        return;
+      }
+      default:
+        throw new BadRequestException(`Unsupported question type: ${type}`);
+    }
+  }
+
+  private assertUniquePopularExamPairs(tags: QuestionPopularExamTagDto[]) {
+    const seen = new Set<string>();
+    for (const t of tags) {
+      const key = `${t.popularExamId}:${t.examYear ?? 'null'}`;
+      if (seen.has(key)) {
+        throw new BadRequestException(
+          `Duplicate popular-exam tag for popularExamId=${t.popularExamId} examYear=${t.examYear ?? 'null'}`,
+        );
+      }
+      seen.add(key);
+    }
+  }
+
+  private async replaceOptions(
+    tx: Prisma.TransactionClient,
+    questionId: string,
+    options: QuestionOptionDto[] | undefined,
+  ) {
+    if (!options?.length) return;
+    await tx.questionOption.createMany({
+      data: options.map((o) => ({
+        questionId,
+        order: o.order,
+        label: o.label as Prisma.InputJsonValue,
+        labelPlainText: o.labelPlainText,
+        isCorrect: o.isCorrect,
+        mediaUrl: o.mediaUrl,
+      })),
+    });
+  }
+
+  private async replaceTopicTags(
+    tx: Prisma.TransactionClient,
+    questionId: string,
+    topicIds: string[] | undefined,
+  ) {
+    if (!topicIds?.length) return;
+    await tx.questionTopic.createMany({
+      data: topicIds.map((topicId) => ({ questionId, topicId })),
+      skipDuplicates: true,
+    });
+  }
+
+  private async replacePopularExamTags(
+    tx: Prisma.TransactionClient,
+    questionId: string,
+    tags: QuestionPopularExamTagDto[] | undefined,
+  ) {
+    if (!tags?.length) return;
+    await tx.questionPopularExam.createMany({
+      data: tags.map((t) => ({
+        questionId,
+        popularExamId: t.popularExamId,
+        examYear: t.examYear ?? null,
+        questionNumber: t.questionNumber ?? null,
+      })),
+    });
+  }
+}

--- a/src/components/questions/questions.swagger.ts
+++ b/src/components/questions/questions.swagger.ts
@@ -1,0 +1,86 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+
+import { CreateQuestionDto, UpdateQuestionDto } from './dto';
+import {
+  CloneQuestionResult,
+  CreateQuestionResult,
+  DeleteQuestionResult,
+  QuestionResult,
+  QuestionsListResult,
+  UpdateQuestionResult,
+} from './results/question.result';
+
+export function CreateQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Create a question (teacher → TEACHER_AUTHORED, system admin → SCHOS_CURATED)',
+    }),
+    ApiBody({ type: CreateQuestionDto }),
+    ApiResponse({ status: 201, type: CreateQuestionResult }),
+    ApiResponse({ status: 400, description: 'Validation failed (subject/level mismatch, type-specific config invalid)' }),
+    ApiResponse({ status: 403, description: 'User type not allowed to author questions' }),
+  );
+}
+
+export function ListMyQuestionsSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: "List the calling teacher's question bank (filterable, paginated)" }),
+    ApiResponse({ status: 200, type: QuestionsListResult }),
+  );
+}
+
+export function ListLibraryQuestionsSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Browse the schos curated question library (filterable, paginated)' }),
+    ApiResponse({ status: 200, type: QuestionsListResult }),
+  );
+}
+
+export function GetQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get a question by id (visible if curated or owned by caller)',
+    }),
+    ApiParam({ name: 'id', description: 'Question id' }),
+    ApiResponse({ status: 200, type: QuestionResult }),
+    ApiResponse({ status: 404, description: 'Not found or not visible' }),
+  );
+}
+
+export function UpdateQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Update a question. Rejected if it is referenced by any PUBLISHED quiz — clone it instead.',
+    }),
+    ApiParam({ name: 'id', description: 'Question id' }),
+    ApiBody({ type: UpdateQuestionDto }),
+    ApiResponse({ status: 200, type: UpdateQuestionResult }),
+    ApiResponse({ status: 403, description: 'You can only modify your own questions' }),
+    ApiResponse({ status: 409, description: 'Question is in use by a published quiz' }),
+  );
+}
+
+export function DeleteQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Soft-archive a question. Rejected if any quiz still references it.',
+    }),
+    ApiParam({ name: 'id', description: 'Question id' }),
+    ApiResponse({ status: 200, type: DeleteQuestionResult }),
+    ApiResponse({ status: 409, description: 'Question is referenced by quizzes; detach first' }),
+  );
+}
+
+export function CloneQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: "Clone a curated (SCHOS_CURATED) question into the calling teacher's bank as DRAFT",
+    }),
+    ApiParam({ name: 'id', description: 'Curated question id' }),
+    ApiResponse({ status: 201, type: CloneQuestionResult }),
+    ApiResponse({ status: 403, description: 'Only teachers can clone' }),
+    ApiResponse({ status: 404, description: 'Curated question not found' }),
+  );
+}
+

--- a/src/components/questions/results/index.ts
+++ b/src/components/questions/results/index.ts
@@ -1,0 +1,1 @@
+export * from './question.result';

--- a/src/components/questions/results/question.result.ts
+++ b/src/components/questions/results/question.result.ts
@@ -1,0 +1,204 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  PartialCreditMode,
+  PopularExam,
+  Question,
+  QuestionDifficulty,
+  QuestionOption,
+  QuestionOwnerType,
+  QuestionPopularExam,
+  QuestionStatus,
+  QuestionTopic,
+  QuestionType,
+  Topic,
+} from '@prisma/client';
+
+type QuestionWithRelations = Question & {
+  options: QuestionOption[];
+  topics: (QuestionTopic & { topic: Topic })[];
+  popularExams: (QuestionPopularExam & { popularExam: PopularExam })[];
+  _count?: { quizUses: number };
+};
+
+export class QuestionOptionResult {
+  @ApiProperty() id: string;
+  @ApiProperty() order: number;
+  @ApiProperty({ description: 'TipTap JSON document' }) label: unknown;
+  @ApiProperty() labelPlainText: string;
+  @ApiProperty() isCorrect: boolean;
+  @ApiProperty({ required: false, nullable: true }) mediaUrl: string | null;
+
+  constructor(o: QuestionOption) {
+    this.id = o.id;
+    this.order = o.order;
+    this.label = o.label;
+    this.labelPlainText = o.labelPlainText;
+    this.isCorrect = o.isCorrect;
+    this.mediaUrl = o.mediaUrl;
+  }
+}
+
+export class QuestionTopicTagResult {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() slug: string;
+
+  constructor(t: Topic) {
+    this.id = t.id;
+    this.name = t.name;
+    this.slug = t.slug;
+  }
+}
+
+export class QuestionPopularExamTagResult {
+  @ApiProperty() id: string;
+  @ApiProperty() popularExamId: string;
+  @ApiProperty() code: string;
+  @ApiProperty() name: string;
+  @ApiProperty({ required: false, nullable: true }) examYear: number | null;
+  @ApiProperty({ required: false, nullable: true }) questionNumber: string | null;
+
+  constructor(t: QuestionPopularExam & { popularExam: PopularExam }) {
+    this.id = t.id;
+    this.popularExamId = t.popularExamId;
+    this.code = t.popularExam.code;
+    this.name = t.popularExam.name;
+    this.examYear = t.examYear;
+    this.questionNumber = t.questionNumber;
+  }
+}
+
+export class QuestionResult {
+  @ApiProperty() id: string;
+  @ApiProperty({ enum: QuestionOwnerType }) ownerType: QuestionOwnerType;
+  @ApiProperty({ required: false, nullable: true }) schoolId: string | null;
+  @ApiProperty() authorUserId: string;
+  @ApiProperty({ required: false, nullable: true }) subjectId: string | null;
+  @ApiProperty({ required: false, nullable: true }) levelId: string | null;
+  @ApiProperty({ required: false, nullable: true }) defaultTermId: string | null;
+  @ApiProperty({ required: false, nullable: true }) canonicalSubjectName: string | null;
+  @ApiProperty({ required: false, nullable: true }) canonicalLevelCode: string | null;
+  @ApiProperty({ required: false, nullable: true }) canonicalTermName: string | null;
+  @ApiProperty({ enum: QuestionType }) type: QuestionType;
+  @ApiProperty({ description: 'TipTap JSON document' }) prompt: unknown;
+  @ApiProperty() promptPlainText: string;
+  @ApiProperty({ type: [String] }) mediaUrls: string[];
+  @ApiProperty({ required: false, nullable: true, description: 'TipTap JSON document' })
+  explanation: unknown;
+  @ApiProperty({ description: 'Base weight (default 1.0)' }) weight: string;
+  @ApiProperty({ enum: QuestionDifficulty, required: false, nullable: true })
+  difficulty: QuestionDifficulty | null;
+  @ApiProperty({ enum: QuestionStatus }) status: QuestionStatus;
+  @ApiProperty() version: number;
+  @ApiProperty({ required: false, nullable: true }) sourceQuestionId: string | null;
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description: 'Type-specific config (see CreateQuestionDto)',
+  })
+  config: unknown;
+  @ApiProperty({ enum: PartialCreditMode, required: false, nullable: true })
+  partialCreditMode: PartialCreditMode | null;
+  @ApiProperty({ type: [QuestionOptionResult] }) options: QuestionOptionResult[];
+  @ApiProperty({ type: [QuestionTopicTagResult] }) topics: QuestionTopicTagResult[];
+  @ApiProperty({ type: [QuestionPopularExamTagResult] })
+  popularExams: QuestionPopularExamTagResult[];
+  @ApiProperty({ description: 'Number of quizzes that reference this question' })
+  usageCount: number;
+  @ApiProperty() createdAt: Date;
+  @ApiProperty() updatedAt: Date;
+
+  constructor(q: QuestionWithRelations) {
+    this.id = q.id;
+    this.ownerType = q.ownerType;
+    this.schoolId = q.schoolId;
+    this.authorUserId = q.authorUserId;
+    this.subjectId = q.subjectId;
+    this.levelId = q.levelId;
+    this.defaultTermId = q.defaultTermId;
+    this.canonicalSubjectName = q.canonicalSubjectName;
+    this.canonicalLevelCode = q.canonicalLevelCode;
+    this.canonicalTermName = q.canonicalTermName;
+    this.type = q.type;
+    this.prompt = q.prompt;
+    this.promptPlainText = q.promptPlainText;
+    this.mediaUrls = q.mediaUrls;
+    this.explanation = q.explanation;
+    this.weight = q.weight.toString();
+    this.difficulty = q.difficulty;
+    this.status = q.status;
+    this.version = q.version;
+    this.sourceQuestionId = q.sourceQuestionId;
+    this.config = q.config;
+    this.partialCreditMode = q.partialCreditMode;
+    this.options = q.options
+      .sort((a, b) => a.order - b.order)
+      .map((o) => new QuestionOptionResult(o));
+    this.topics = q.topics.map((t) => new QuestionTopicTagResult(t.topic));
+    this.popularExams = q.popularExams.map((p) => new QuestionPopularExamTagResult(p));
+    this.usageCount = q._count?.quizUses ?? 0;
+    this.createdAt = q.createdAt;
+    this.updatedAt = q.updatedAt;
+  }
+}
+
+export class QuestionsListResult {
+  @ApiProperty({ type: [QuestionResult] }) items: QuestionResult[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+
+  constructor(items: QuestionResult[], total: number, page: number, limit: number) {
+    this.items = items;
+    this.total = total;
+    this.page = page;
+    this.limit = limit;
+  }
+}
+
+export class CreateQuestionResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuestionResult }) question: QuestionResult;
+
+  constructor(question: QuestionResult) {
+    this.success = true;
+    this.message = 'Question created successfully';
+    this.question = question;
+  }
+}
+
+export class UpdateQuestionResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuestionResult }) question: QuestionResult;
+
+  constructor(question: QuestionResult) {
+    this.success = true;
+    this.message = 'Question updated successfully';
+    this.question = question;
+  }
+}
+
+export class DeleteQuestionResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+
+  constructor() {
+    this.success = true;
+    this.message = 'Question archived successfully';
+  }
+}
+
+export class CloneQuestionResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuestionResult }) question: QuestionResult;
+
+  constructor(question: QuestionResult) {
+    this.success = true;
+    this.message = 'Question cloned successfully';
+    this.question = question;
+  }
+}
+

--- a/src/components/quiz-aggregations/compute.ts
+++ b/src/components/quiz-aggregations/compute.ts
@@ -1,0 +1,143 @@
+import { AggregationMethod, MissingAttemptPolicy } from '@prisma/client';
+
+export interface ItemAttemptInput {
+  /** Item weight (used by WEIGHTED). */
+  weight: number;
+  /**
+   * Quiz's deterministic max score (sum of question weights at attempt-start time).
+   * Used by SUM when the student has no attempt — must reflect what they would
+   * have lost. Caller derives from any peer attempt, or from quiz questions if
+   * no peer attempt exists. Falls back to 0 only when truly unknowable.
+   */
+  expectedMaxScore: number;
+  /**
+   * The student's GRADED attempt for this item, or null if missing.
+   * percentage is in [0, 100]; totalScore / maxScore are decimal numbers.
+   */
+  attempt: {
+    percentage: number;
+    totalScore: number;
+    maxScore: number;
+  } | null;
+}
+
+export interface PerItemBreakdown {
+  weight: number;
+  percentage: number | null; // null when missing AND policy excludes
+  missing: boolean;
+  contributingPercentage: number; // what we actually used in the aggregation (0 if treat-as-zero, else percentage)
+}
+
+export interface ComputeResult {
+  /** Aggregated percentage in [0, 100]. */
+  computedPercentage: number;
+  /** computedPercentage / 100 * rescaleToMaxScore, rounded to integer. */
+  rescaledScore: number;
+  /** Item-by-item breakdown for the preview UI. */
+  items: PerItemBreakdown[];
+}
+
+/**
+ * Pure aggregation. No DB. Easily unit-tested.
+ *
+ * Method semantics:
+ * - AVERAGE   : equal-weighted mean of item percentages, rescaled
+ * - WEIGHTED  : item.weight-weighted mean of percentages, rescaled
+ * - SUM       : Σ totalScore / Σ maxScore, rescaled (mass-weighted by maxScore)
+ * - BEST_OF_N : top N percentages averaged, rescaled. n is clamped to
+ *               participating-item count.
+ */
+export function computeForStudent(
+  items: ItemAttemptInput[],
+  method: AggregationMethod,
+  missingPolicy: MissingAttemptPolicy,
+  rescaleToMaxScore: number,
+  bestOfN?: number | null,
+): ComputeResult {
+  const breakdown: PerItemBreakdown[] = items.map((item) => {
+    if (item.attempt) {
+      return {
+        weight: item.weight,
+        percentage: item.attempt.percentage,
+        missing: false,
+        contributingPercentage: item.attempt.percentage,
+      };
+    }
+    if (missingPolicy === MissingAttemptPolicy.TREAT_AS_ZERO) {
+      return {
+        weight: item.weight,
+        percentage: 0,
+        missing: true,
+        contributingPercentage: 0,
+      };
+    }
+    return {
+      weight: item.weight,
+      percentage: null,
+      missing: true,
+      contributingPercentage: 0,
+    };
+  });
+
+  const participating = breakdown.filter(
+    (b) => !b.missing || missingPolicy === MissingAttemptPolicy.TREAT_AS_ZERO,
+  );
+  if (participating.length === 0) {
+    return { computedPercentage: 0, rescaledScore: 0, items: breakdown };
+  }
+
+  let computedPercentage = 0;
+
+  switch (method) {
+    case AggregationMethod.AVERAGE: {
+      const sum = participating.reduce((a, b) => a + b.contributingPercentage, 0);
+      computedPercentage = sum / participating.length;
+      break;
+    }
+    case AggregationMethod.WEIGHTED: {
+      const num = participating.reduce((a, b) => a + b.contributingPercentage * b.weight, 0);
+      const den = participating.reduce((a, b) => a + b.weight, 0);
+      computedPercentage = den > 0 ? num / den : 0;
+      break;
+    }
+    case AggregationMethod.SUM: {
+      // mass-weighted by maxScore: sum totalScores / sum maxScores.
+      // Missing + TREAT_AS_ZERO contributes the quiz's full expectedMaxScore
+      // to the denominator (zero earned, full possible) — matching the
+      // intuitive "missed quiz = scored 0/total" semantics.
+      let totalScore = 0;
+      let totalMax = 0;
+      for (const item of items) {
+        if (item.attempt) {
+          totalScore += item.attempt.totalScore;
+          totalMax += item.attempt.maxScore;
+        } else if (missingPolicy === MissingAttemptPolicy.TREAT_AS_ZERO) {
+          totalMax += item.expectedMaxScore;
+        }
+      }
+      computedPercentage = totalMax > 0 ? (totalScore / totalMax) * 100 : 0;
+      break;
+    }
+    case AggregationMethod.BEST_OF_N: {
+      const n = Math.max(1, Math.min(bestOfN ?? participating.length, participating.length));
+      const sorted = [...participating].sort(
+        (a, b) => b.contributingPercentage - a.contributingPercentage,
+      );
+      const top = sorted.slice(0, n);
+      const sum = top.reduce((a, b) => a + b.contributingPercentage, 0);
+      computedPercentage = sum / top.length;
+      break;
+    }
+  }
+
+  const rescaledScore = Math.round((computedPercentage / 100) * rescaleToMaxScore);
+  return {
+    computedPercentage: round2(computedPercentage),
+    rescaledScore,
+    items: breakdown,
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/components/quiz-aggregations/dto/aggregation-query.dto.ts
+++ b/src/components/quiz-aggregations/dto/aggregation-query.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+import { QuizAggregationStatus } from '@prisma/client';
+
+export class AggregationQueryDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  classArmSubjectId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  termId?: string;
+
+  @ApiProperty({ required: false, enum: QuizAggregationStatus })
+  @IsOptional()
+  @IsEnum(QuizAggregationStatus)
+  status?: QuizAggregationStatus;
+
+  @ApiProperty({ required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ required: false, default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/components/quiz-aggregations/dto/create-aggregation.dto.ts
+++ b/src/components/quiz-aggregations/dto/create-aggregation.dto.ts
@@ -1,0 +1,93 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { AggregationMethod, MissingAttemptPolicy } from '@prisma/client';
+
+export class AggregationItemDto {
+  @ApiProperty()
+  @IsUUID()
+  quizAssignmentId: string;
+
+  @ApiProperty({ required: false, default: 1, description: 'Used by WEIGHTED method' })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Max(99999.99)
+  weight?: number;
+}
+
+export class CreateAggregationDto {
+  @ApiProperty()
+  @IsUUID()
+  classArmSubjectId: string;
+
+  @ApiProperty()
+  @IsUUID()
+  termId: string;
+
+  @ApiProperty({
+    description:
+      'UUID of the entry inside AssessmentStructureTemplate.assessments JSON to write into',
+  })
+  @IsUUID()
+  assessmentTemplateEntryId: string;
+
+  @ApiProperty({ description: "Internal label for this aggregation (not the slot's name)" })
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({ enum: AggregationMethod })
+  @IsEnum(AggregationMethod)
+  aggregationMethod: AggregationMethod;
+
+  @ApiProperty({
+    required: false,
+    description: 'Required for BEST_OF_N. Clamped to the number of items at compute time.',
+    minimum: 1,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  bestOfN?: number;
+
+  @ApiProperty({
+    description:
+      "Final maxScore to rescale to — should match the assessment slot's maxScore. Stored explicitly so historical aggregations stay accurate even if the slot is later edited.",
+    minimum: 1,
+  })
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  rescaleToMaxScore: number;
+
+  @ApiProperty({
+    required: false,
+    enum: MissingAttemptPolicy,
+    default: MissingAttemptPolicy.TREAT_AS_ZERO,
+  })
+  @IsOptional()
+  @IsEnum(MissingAttemptPolicy)
+  missingAttemptPolicy?: MissingAttemptPolicy;
+
+  @ApiProperty({ type: [AggregationItemDto], description: 'Quizzes to aggregate' })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => AggregationItemDto)
+  items: AggregationItemDto[];
+}

--- a/src/components/quiz-aggregations/dto/index.ts
+++ b/src/components/quiz-aggregations/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './create-aggregation.dto';
+export * from './update-aggregation.dto';
+export * from './aggregation-query.dto';

--- a/src/components/quiz-aggregations/dto/update-aggregation.dto.ts
+++ b/src/components/quiz-aggregations/dto/update-aggregation.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { AggregationMethod, MissingAttemptPolicy } from '@prisma/client';
+
+import { AggregationItemDto } from './create-aggregation.dto';
+
+/**
+ * Only allowed while status is DRAFT. classArmSubjectId, termId, and
+ * assessmentTemplateEntryId cannot be changed — delete and recreate
+ * if the target slot needs to change.
+ */
+export class UpdateAggregationDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @ApiProperty({ required: false, enum: AggregationMethod })
+  @IsOptional()
+  @IsEnum(AggregationMethod)
+  aggregationMethod?: AggregationMethod;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  bestOfN?: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  rescaleToMaxScore?: number;
+
+  @ApiProperty({ required: false, enum: MissingAttemptPolicy })
+  @IsOptional()
+  @IsEnum(MissingAttemptPolicy)
+  missingAttemptPolicy?: MissingAttemptPolicy;
+
+  @ApiProperty({
+    required: false,
+    type: [AggregationItemDto],
+    description: 'When provided, replaces the items list wholesale',
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => AggregationItemDto)
+  items?: AggregationItemDto[];
+}

--- a/src/components/quiz-aggregations/quiz-aggregations.controller.ts
+++ b/src/components/quiz-aggregations/quiz-aggregations.controller.ts
@@ -1,0 +1,128 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { AggregationQueryDto, CreateAggregationDto, UpdateAggregationDto } from './dto';
+import { QuizAggregationsService } from './quiz-aggregations.service';
+import {
+  CreateAggregationSwagger,
+  DeleteAggregationSwagger,
+  FinalizeAggregationSwagger,
+  GetAggregationSwagger,
+  ListAggregationsSwagger,
+  PreviewAggregationSwagger,
+  UpdateAggregationSwagger,
+} from './quiz-aggregations.swagger';
+import {
+  AggregationItemPreviewResult,
+  AggregationPreviewResult,
+  AggregationResult,
+  AggregationsListResult,
+  CreateAggregationResult,
+  DeleteAggregationResult,
+  FinalizeAggregationResult,
+  StudentPreviewRowResult,
+  UpdateAggregationResult,
+} from './results/aggregation.result';
+
+@Controller('quiz-aggregations')
+@ApiTags('Quiz Aggregations')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class QuizAggregationsController {
+  constructor(private readonly service: QuizAggregationsService) {}
+
+  @Post()
+  @CreateAggregationSwagger()
+  async create(@GetCurrentUserId() userId: string, @Body() dto: CreateAggregationDto) {
+    const a = await this.service.create(userId, dto);
+    return new CreateAggregationResult(new AggregationResult(a));
+  }
+
+  @Get()
+  @ListAggregationsSwagger()
+  async list(@GetCurrentUserId() userId: string, @Query() query: AggregationQueryDto) {
+    const { items, total, page, limit } = await this.service.list(userId, query);
+    return new AggregationsListResult(
+      items.map((a) => new AggregationResult(a)),
+      total,
+      page,
+      limit,
+    );
+  }
+
+  @Get(':id')
+  @GetAggregationSwagger()
+  async findById(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const a = await this.service.findById(userId, id);
+    return new AggregationResult(a);
+  }
+
+  @Patch(':id')
+  @UpdateAggregationSwagger()
+  async update(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: UpdateAggregationDto,
+  ) {
+    const a = await this.service.update(userId, id, dto);
+    return new UpdateAggregationResult(new AggregationResult(a));
+  }
+
+  @Delete(':id')
+  @DeleteAggregationSwagger()
+  async delete(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    await this.service.softDelete(userId, id);
+    return new DeleteAggregationResult();
+  }
+
+  @Post(':id/preview')
+  @HttpCode(HttpStatus.OK)
+  @PreviewAggregationSwagger()
+  async preview(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const { aggregation, rows } = await this.service.preview(userId, id);
+    const aggregationResult = new AggregationResult(aggregation);
+    const previewRows = rows.map((row) => {
+      const r = new StudentPreviewRowResult();
+      r.studentId = row.studentId;
+      r.studentNo = row.studentNo;
+      r.firstName = row.firstName;
+      r.lastName = row.lastName;
+      r.items = row.items.map(
+        (it) =>
+          new AggregationItemPreviewResult(
+            it.quizAssignmentId,
+            it.quizTitle,
+            it.percentage,
+            it.missing,
+          ),
+      );
+      r.computedPercentage = row.computedPercentage;
+      r.rescaledScore = row.rescaledScore;
+      return r;
+    });
+    return new AggregationPreviewResult(aggregationResult, previewRows);
+  }
+
+  @Post(':id/finalize')
+  @HttpCode(HttpStatus.OK)
+  @FinalizeAggregationSwagger()
+  async finalize(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const { upsertedRows, finalizedAt } = await this.service.finalize(userId, id);
+    return new FinalizeAggregationResult(upsertedRows, finalizedAt);
+  }
+}

--- a/src/components/quiz-aggregations/quiz-aggregations.module.ts
+++ b/src/components/quiz-aggregations/quiz-aggregations.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { QuizAggregationsController } from './quiz-aggregations.controller';
+import { QuizAggregationsService } from './quiz-aggregations.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [QuizAggregationsController],
+  providers: [QuizAggregationsService, Encryptor],
+  exports: [QuizAggregationsService],
+})
+export class QuizAggregationsModule {}

--- a/src/components/quiz-aggregations/quiz-aggregations.service.ts
+++ b/src/components/quiz-aggregations/quiz-aggregations.service.ts
@@ -1,0 +1,549 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  AggregationMethod,
+  AssessmentStructureTemplate,
+  MissingAttemptPolicy,
+  Prisma,
+  QuizAggregationStatus,
+  QuizAttemptStatus,
+} from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { UserTypes } from '../users/constants';
+import { computeForStudent, ItemAttemptInput } from './compute';
+import {
+  AggregationItemDto,
+  AggregationQueryDto,
+  CreateAggregationDto,
+  UpdateAggregationDto,
+} from './dto';
+
+interface AssessmentSlotEntry {
+  id: string;
+  name: string;
+  maxScore: number;
+  isExam: boolean;
+  order: number;
+}
+
+const AGGREGATION_INCLUDE = {
+  items: {
+    include: {
+      quizAssignment: {
+        select: {
+          id: true,
+          windowOpensAt: true,
+          quiz: { select: { id: true, title: true } },
+        },
+      },
+    },
+  },
+} as const satisfies Prisma.QuizScoreAggregationInclude;
+
+@Injectable()
+export class QuizAggregationsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ---------- public API ----------
+
+  async create(callerUserId: string, dto: CreateAggregationDto) {
+    const teacher = await this.requireTeacher(callerUserId);
+    const { schoolId, classArmId } = await this.assertTeacherTeachesClassArmSubject(
+      teacher.id,
+      dto.classArmSubjectId,
+    );
+
+    await this.validateAssessmentSlot(schoolId, dto.termId, dto.assessmentTemplateEntryId);
+    await this.validateItems(dto.items, dto.classArmSubjectId, dto.termId);
+    if (dto.aggregationMethod === AggregationMethod.BEST_OF_N && !dto.bestOfN) {
+      throw new BadRequestException('BEST_OF_N requires bestOfN');
+    }
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      const agg = await tx.quizScoreAggregation.create({
+        data: {
+          schoolId,
+          classArmSubjectId: dto.classArmSubjectId,
+          termId: dto.termId,
+          assessmentTemplateEntryId: dto.assessmentTemplateEntryId,
+          name: dto.name,
+          aggregationMethod: dto.aggregationMethod,
+          bestOfN: dto.bestOfN ?? null,
+          rescaleToMaxScore: dto.rescaleToMaxScore,
+          missingAttemptPolicy: dto.missingAttemptPolicy ?? MissingAttemptPolicy.TREAT_AS_ZERO,
+          status: QuizAggregationStatus.DRAFT,
+        },
+      });
+      await tx.quizScoreAggregationItem.createMany({
+        data: dto.items.map((i) => ({
+          aggregationId: agg.id,
+          quizAssignmentId: i.quizAssignmentId,
+          weight: new Prisma.Decimal((i.weight ?? 1).toFixed(2)),
+        })),
+      });
+      return agg;
+    });
+
+    void classArmId;
+    return this.fetchById(created.id);
+  }
+
+  async update(callerUserId: string, id: string, dto: UpdateAggregationDto) {
+    const teacher = await this.requireTeacher(callerUserId);
+    const existing = await this.findOrThrow(id);
+    await this.assertTeacherTeachesClassArmSubject(teacher.id, existing.classArmSubjectId);
+
+    if (existing.status !== QuizAggregationStatus.DRAFT) {
+      throw new ConflictException('Only DRAFT aggregations can be edited');
+    }
+
+    if (dto.items) {
+      await this.validateItems(dto.items, existing.classArmSubjectId, existing.termId);
+    }
+
+    const nextMethod = dto.aggregationMethod ?? existing.aggregationMethod;
+    const nextBestOfN = dto.bestOfN ?? existing.bestOfN;
+    if (nextMethod === AggregationMethod.BEST_OF_N && !nextBestOfN) {
+      throw new BadRequestException('BEST_OF_N requires bestOfN');
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.quizScoreAggregation.update({
+        where: { id },
+        data: {
+          ...(dto.name !== undefined && { name: dto.name }),
+          ...(dto.aggregationMethod !== undefined && { aggregationMethod: dto.aggregationMethod }),
+          ...(dto.bestOfN !== undefined && { bestOfN: dto.bestOfN }),
+          ...(dto.rescaleToMaxScore !== undefined && { rescaleToMaxScore: dto.rescaleToMaxScore }),
+          ...(dto.missingAttemptPolicy !== undefined && {
+            missingAttemptPolicy: dto.missingAttemptPolicy,
+          }),
+        },
+      });
+      if (dto.items) {
+        await tx.quizScoreAggregationItem.deleteMany({ where: { aggregationId: id } });
+        await tx.quizScoreAggregationItem.createMany({
+          data: dto.items.map((i) => ({
+            aggregationId: id,
+            quizAssignmentId: i.quizAssignmentId,
+            weight: new Prisma.Decimal((i.weight ?? 1).toFixed(2)),
+          })),
+        });
+      }
+    });
+
+    return this.fetchById(id);
+  }
+
+  async softDelete(callerUserId: string, id: string) {
+    const teacher = await this.requireTeacher(callerUserId);
+    const existing = await this.findOrThrow(id);
+    await this.assertTeacherTeachesClassArmSubject(teacher.id, existing.classArmSubjectId);
+
+    if (existing.status !== QuizAggregationStatus.DRAFT) {
+      throw new ConflictException(
+        'Cannot delete a FINALIZED aggregation — the gradebook entries it created remain in place',
+      );
+    }
+    await this.prisma.quizScoreAggregation.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  async findById(callerUserId: string, id: string) {
+    const teacher = await this.requireTeacher(callerUserId);
+    const agg = await this.findOrThrow(id);
+    await this.assertTeacherTeachesClassArmSubject(teacher.id, agg.classArmSubjectId);
+    return this.fetchById(id);
+  }
+
+  async list(callerUserId: string, query: AggregationQueryDto) {
+    const teacher = await this.requireTeacher(callerUserId);
+
+    const taughtSubjects = await this.prisma.classArmSubjectTeacher.findMany({
+      where: { teacherId: teacher.id, deletedAt: null },
+      select: { classArmSubjectId: true },
+    });
+    const taughtIds = taughtSubjects.map((t) => t.classArmSubjectId);
+    if (taughtIds.length === 0) {
+      return { items: [], total: 0, page: query.page ?? 1, limit: query.limit ?? 20 };
+    }
+
+    const where: Prisma.QuizScoreAggregationWhereInput = {
+      deletedAt: null,
+      classArmSubjectId: { in: taughtIds },
+    };
+    if (query.classArmSubjectId) where.classArmSubjectId = query.classArmSubjectId;
+    if (query.termId) where.termId = query.termId;
+    if (query.status) where.status = query.status;
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const [items, total] = await Promise.all([
+      this.prisma.quizScoreAggregation.findMany({
+        where,
+        include: AGGREGATION_INCLUDE,
+        orderBy: [{ updatedAt: 'desc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.quizScoreAggregation.count({ where }),
+    ]);
+    return { items, total, page, limit };
+  }
+
+  async preview(callerUserId: string, id: string) {
+    const teacher = await this.requireTeacher(callerUserId);
+    const agg = await this.fetchById(id);
+    await this.assertTeacherTeachesClassArmSubject(teacher.id, agg.classArmSubjectId);
+    return this.computeRows(agg);
+  }
+
+  /**
+   * Synchronous transactional finalize. Recomputes from latest data, upserts
+   * one ClassArmStudentAssessment per active student keyed by the slot's name,
+   * and flips the aggregation to FINALIZED. Idempotent — re-finalize re-runs
+   * compute and re-upserts.
+   */
+  async finalize(callerUserId: string, id: string) {
+    const teacher = await this.requireTeacher(callerUserId);
+    const agg = await this.fetchById(id);
+    await this.assertTeacherTeachesClassArmSubject(teacher.id, agg.classArmSubjectId);
+
+    const slot = await this.lookupSlot(agg.schoolId, agg.termId, agg.assessmentTemplateEntryId);
+
+    const computed = await this.computeRows(agg);
+
+    const finalizedAt = new Date();
+    let upsertedRows = 0;
+
+    // Batch upserts in chunks so a single class with hundreds of students
+    // doesn't hold one giant transaction. Upserts are idempotent on the
+    // composite unique key, so re-finalizing after a partial failure
+    // safely picks up where it left off.
+    const BATCH_SIZE = 50;
+    for (let i = 0; i < computed.rows.length; i += BATCH_SIZE) {
+      const batch = computed.rows.slice(i, i + BATCH_SIZE);
+      await this.prisma.$transaction(async (tx) => {
+        for (const row of batch) {
+          await tx.classArmStudentAssessment.upsert({
+            where: {
+              classArmSubjectId_studentId_termId_name: {
+                classArmSubjectId: agg.classArmSubjectId,
+                studentId: row.studentId,
+                termId: agg.termId,
+                name: slot.name,
+              },
+            },
+            create: {
+              classArmSubjectId: agg.classArmSubjectId,
+              studentId: row.studentId,
+              termId: agg.termId,
+              name: slot.name,
+              score: row.rescaledScore,
+              maxScore: agg.rescaleToMaxScore,
+              isExam: slot.isExam,
+              assessmentTypeId: slot.id,
+            },
+            update: {
+              score: row.rescaledScore,
+              maxScore: agg.rescaleToMaxScore,
+              isExam: slot.isExam,
+              assessmentTypeId: slot.id,
+            },
+          });
+          upsertedRows += 1;
+        }
+      });
+    }
+
+    // Mark FINALIZED only after all student rows are written. If the loop
+    // above threw partway, the aggregation stays DRAFT — re-finalizing will
+    // re-upsert (idempotent) and only flip status when the full sweep succeeds.
+    await this.prisma.quizScoreAggregation.update({
+      where: { id },
+      data: {
+        status: QuizAggregationStatus.FINALIZED,
+        finalizedAt,
+        finalizedByTeacherId: teacher.id,
+      },
+    });
+
+    return { upsertedRows, finalizedAt };
+  }
+
+  // ---------- internals ----------
+
+  private async fetchById(id: string) {
+    const agg = await this.prisma.quizScoreAggregation.findFirst({
+      where: { id, deletedAt: null },
+      include: AGGREGATION_INCLUDE,
+    });
+    if (!agg) throw new NotFoundException('Aggregation not found');
+    return agg;
+  }
+
+  private async findOrThrow(id: string) {
+    const agg = await this.prisma.quizScoreAggregation.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!agg) throw new NotFoundException('Aggregation not found');
+    return agg;
+  }
+
+  private async requireTeacher(callerUserId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: callerUserId },
+      select: {
+        id: true,
+        type: true,
+        schoolId: true,
+        teacher: { select: { id: true } },
+      },
+    });
+    if (!user || user.type !== UserTypes.TEACHER || !user.teacher) {
+      throw new ForbiddenException('Only teachers can manage quiz aggregations');
+    }
+    return { id: user.teacher.id, schoolId: user.schoolId };
+  }
+
+  private async assertTeacherTeachesClassArmSubject(
+    teacherId: string,
+    classArmSubjectId: string,
+  ) {
+    const link = await this.prisma.classArmSubjectTeacher.findFirst({
+      where: { teacherId, classArmSubjectId, deletedAt: null },
+      include: {
+        classArmSubject: {
+          include: { classArm: { select: { id: true, schoolId: true } } },
+        },
+      },
+    });
+    if (!link) {
+      throw new ForbiddenException('You do not teach this class arm subject');
+    }
+    return {
+      schoolId: link.classArmSubject.classArm.schoolId,
+      classArmId: link.classArmSubject.classArm.id,
+    };
+  }
+
+  private async validateItems(
+    items: AggregationItemDto[],
+    classArmSubjectId: string,
+    termId: string,
+  ) {
+    const ids = items.map((i) => i.quizAssignmentId);
+    if (new Set(ids).size !== ids.length) {
+      throw new BadRequestException('Duplicate quizAssignmentIds in items');
+    }
+    const found = await this.prisma.quizAssignment.findMany({
+      where: { id: { in: ids }, deletedAt: null },
+      select: { id: true, classArmSubjectId: true, termId: true },
+    });
+    const byId = new Map(found.map((a) => [a.id, a]));
+    for (const id of ids) {
+      const a = byId.get(id);
+      if (!a) {
+        throw new BadRequestException(`Quiz assignment ${id} not found`);
+      }
+      if (a.classArmSubjectId !== classArmSubjectId || a.termId !== termId) {
+        throw new BadRequestException(
+          `Quiz assignment ${id} does not match this aggregation's classArmSubject + term`,
+        );
+      }
+    }
+  }
+
+  private async validateAssessmentSlot(
+    schoolId: string,
+    termId: string,
+    entryId: string,
+  ) {
+    await this.lookupSlot(schoolId, termId, entryId);
+  }
+
+  private async lookupSlot(
+    schoolId: string,
+    termId: string,
+    entryId: string,
+  ): Promise<AssessmentSlotEntry> {
+    const term = await this.prisma.term.findFirst({
+      where: { id: termId, deletedAt: null },
+      select: { academicSessionId: true },
+    });
+    if (!term) throw new BadRequestException('Term not found');
+
+    const template = (await this.prisma.assessmentStructureTemplate.findFirst({
+      where: {
+        schoolId,
+        academicSessionId: term.academicSessionId,
+        isActive: true,
+        deletedAt: null,
+      },
+    })) as AssessmentStructureTemplate | null;
+    if (!template) {
+      throw new BadRequestException(
+        'No active assessment structure template for this school + session — set one up first',
+      );
+    }
+    const entries = (template.assessments as unknown) as AssessmentSlotEntry[];
+    const entry = Array.isArray(entries)
+      ? entries.find((e) => e?.id === entryId)
+      : undefined;
+    if (!entry) {
+      throw new BadRequestException(
+        `assessmentTemplateEntryId ${entryId} not found in the active template`,
+      );
+    }
+    return entry;
+  }
+
+  /**
+   * Loads the class arm's active students + their best attempts per item,
+   * then runs the pure compute for each student.
+   */
+  private async computeRows(agg: Awaited<ReturnType<typeof this.fetchById>>) {
+    const classArmSubject = await this.prisma.classArmSubject.findUnique({
+      where: { id: agg.classArmSubjectId },
+      select: { classArmId: true },
+    });
+    if (!classArmSubject) {
+      throw new BadRequestException('classArmSubject not found');
+    }
+
+    const enrollments = await this.prisma.classArmStudent.findMany({
+      where: {
+        classArmId: classArmSubject.classArmId,
+        isActive: true,
+        deletedAt: null,
+      },
+      include: {
+        student: {
+          include: { user: { select: { firstName: true, lastName: true } } },
+        },
+      },
+      orderBy: [{ student: { studentNo: 'asc' } }],
+    });
+
+    const itemAssignmentIds = agg.items.map((i) => i.quizAssignmentId);
+    const attempts = await this.prisma.quizAttempt.findMany({
+      where: {
+        quizAssignmentId: { in: itemAssignmentIds },
+        status: QuizAttemptStatus.GRADED,
+        studentId: { in: enrollments.map((e) => e.studentId) },
+      },
+      select: {
+        studentId: true,
+        quizAssignmentId: true,
+        totalScore: true,
+        maxScore: true,
+        percentage: true,
+      },
+    });
+
+    // Pick the BEST (highest percentage) GRADED attempt per (student, assignment).
+    const bestKey = (s: string, q: string) => `${s}::${q}`;
+    const best = new Map<string, (typeof attempts)[number]>();
+    for (const a of attempts) {
+      const key = bestKey(a.studentId, a.quizAssignmentId);
+      const prev = best.get(key);
+      if (
+        !prev ||
+        Number(a.percentage?.toString() ?? 0) > Number(prev.percentage?.toString() ?? 0)
+      ) {
+        best.set(key, a);
+      }
+    }
+
+    // Build a per-assignment expectedMaxScore map for SUM aggregation. Source of
+    // truth is any peer attempt's maxScore (deterministic across students for a
+    // given assignment, since maxScore is snapshotted at attempt-start from the
+    // pinned quizVersion). Fallback: query the assignment's quiz questions.
+    const expectedMaxScoreByAssignment = new Map<string, number>();
+    for (const a of attempts) {
+      if (!expectedMaxScoreByAssignment.has(a.quizAssignmentId)) {
+        expectedMaxScoreByAssignment.set(
+          a.quizAssignmentId,
+          Number(a.maxScore.toString()),
+        );
+      }
+    }
+    const assignmentsNeedingFallback = itemAssignmentIds.filter(
+      (id) => !expectedMaxScoreByAssignment.has(id),
+    );
+    if (assignmentsNeedingFallback.length > 0) {
+      const fallbackAssignments = await this.prisma.quizAssignment.findMany({
+        where: { id: { in: assignmentsNeedingFallback } },
+        select: {
+          id: true,
+          quiz: {
+            select: {
+              questions: {
+                select: { weightOverride: true, question: { select: { weight: true } } },
+              },
+            },
+          },
+        },
+      });
+      for (const a of fallbackAssignments) {
+        const sum = a.quiz.questions.reduce((acc, q) => {
+          const w = q.weightOverride ?? q.question.weight;
+          return acc + Number(w.toString());
+        }, 0);
+        expectedMaxScoreByAssignment.set(a.id, sum);
+      }
+    }
+
+    const aggregation = agg;
+
+    const rows = enrollments.map((e) => {
+      const itemInputs: ItemAttemptInput[] = aggregation.items.map((item) => {
+        const a = best.get(bestKey(e.studentId, item.quizAssignmentId));
+        return {
+          weight: Number(item.weight.toString()),
+          expectedMaxScore: expectedMaxScoreByAssignment.get(item.quizAssignmentId) ?? 0,
+          attempt: a
+            ? {
+                percentage: Number(a.percentage?.toString() ?? 0),
+                totalScore: Number(a.totalScore?.toString() ?? 0),
+                maxScore: Number(a.maxScore.toString()),
+              }
+            : null,
+        };
+      });
+
+      const result = computeForStudent(
+        itemInputs,
+        aggregation.aggregationMethod,
+        aggregation.missingAttemptPolicy,
+        aggregation.rescaleToMaxScore,
+        aggregation.bestOfN,
+      );
+
+      return {
+        studentId: e.studentId,
+        studentNo: e.student.studentNo,
+        firstName: e.student.user.firstName,
+        lastName: e.student.user.lastName,
+        items: aggregation.items.map((item, idx) => ({
+          quizAssignmentId: item.quizAssignmentId,
+          quizTitle: item.quizAssignment.quiz.title,
+          percentage: result.items[idx].percentage,
+          missing: result.items[idx].missing,
+        })),
+        computedPercentage: result.computedPercentage,
+        rescaledScore: result.rescaledScore,
+      };
+    });
+
+    return { aggregation, rows };
+  }
+}

--- a/src/components/quiz-aggregations/quiz-aggregations.swagger.ts
+++ b/src/components/quiz-aggregations/quiz-aggregations.swagger.ts
@@ -1,0 +1,90 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+import { CreateAggregationDto, UpdateAggregationDto } from './dto';
+import {
+  AggregationPreviewResult,
+  AggregationResult,
+  AggregationsListResult,
+  CreateAggregationResult,
+  DeleteAggregationResult,
+  FinalizeAggregationResult,
+  UpdateAggregationResult,
+} from './results/aggregation.result';
+
+export function CreateAggregationSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Create a DRAFT aggregation that maps N quiz assignments to a single AssessmentStructureTemplate slot.',
+    }),
+    ApiBody({ type: CreateAggregationDto }),
+    ApiResponse({ status: 201, type: CreateAggregationResult }),
+    ApiResponse({ status: 400, description: 'Invalid items or slot not found in template' }),
+    ApiResponse({ status: 403, description: 'Caller does not teach this class arm subject' }),
+  );
+}
+
+export function ListAggregationsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'List aggregations for class arm subjects the caller teaches',
+    }),
+    ApiResponse({ status: 200, type: AggregationsListResult }),
+  );
+}
+
+export function GetAggregationSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get an aggregation with its items' }),
+    ApiParam({ name: 'id', description: 'Aggregation id' }),
+    ApiResponse({ status: 200, type: AggregationResult }),
+  );
+}
+
+export function UpdateAggregationSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Edit a DRAFT aggregation. Items list is replaced wholesale when provided. classArmSubjectId / termId / assessmentTemplateEntryId cannot be changed.',
+    }),
+    ApiParam({ name: 'id', description: 'Aggregation id' }),
+    ApiBody({ type: UpdateAggregationDto }),
+    ApiResponse({ status: 200, type: UpdateAggregationResult }),
+    ApiResponse({ status: 409, description: 'Aggregation is FINALIZED' }),
+  );
+}
+
+export function DeleteAggregationSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Delete a DRAFT aggregation. FINALIZED aggregations cannot be deleted (their gradebook entries already exist).',
+    }),
+    ApiParam({ name: 'id', description: 'Aggregation id' }),
+    ApiResponse({ status: 200, type: DeleteAggregationResult }),
+    ApiResponse({ status: 409, description: 'Aggregation is FINALIZED' }),
+  );
+}
+
+export function PreviewAggregationSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Compute per-student scores without persisting. Use this to sanity-check before /finalize.',
+    }),
+    ApiParam({ name: 'id', description: 'Aggregation id' }),
+    ApiResponse({ status: 200, type: AggregationPreviewResult }),
+  );
+}
+
+export function FinalizeAggregationSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        "Recompute and write ClassArmStudentAssessment rows into the gradebook. Idempotent — re-finalizing re-runs compute and re-upserts. The slot's name is used for the upsert key, so the score lands in the correct gradebook column.",
+    }),
+    ApiParam({ name: 'id', description: 'Aggregation id' }),
+    ApiResponse({ status: 200, type: FinalizeAggregationResult }),
+  );
+}

--- a/src/components/quiz-aggregations/results/aggregation.result.ts
+++ b/src/components/quiz-aggregations/results/aggregation.result.ts
@@ -1,0 +1,172 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  AggregationMethod,
+  MissingAttemptPolicy,
+  QuizAggregationStatus,
+  QuizScoreAggregation,
+  QuizScoreAggregationItem,
+} from '@prisma/client';
+
+type AggregationWithRelations = QuizScoreAggregation & {
+  items: (QuizScoreAggregationItem & {
+    quizAssignment: {
+      id: string;
+      quiz: { id: string; title: string };
+      windowOpensAt: Date;
+    };
+  })[];
+};
+
+export class AggregationItemResult {
+  @ApiProperty() id: string;
+  @ApiProperty() quizAssignmentId: string;
+  @ApiProperty() quizTitle: string;
+  @ApiProperty() windowOpensAt: Date;
+  @ApiProperty({ description: 'Decimal as string' }) weight: string;
+
+  constructor(item: AggregationWithRelations['items'][number]) {
+    this.id = item.id;
+    this.quizAssignmentId = item.quizAssignmentId;
+    this.quizTitle = item.quizAssignment.quiz.title;
+    this.windowOpensAt = item.quizAssignment.windowOpensAt;
+    this.weight = item.weight.toString();
+  }
+}
+
+export class AggregationResult {
+  @ApiProperty() id: string;
+  @ApiProperty() schoolId: string;
+  @ApiProperty() classArmSubjectId: string;
+  @ApiProperty() termId: string;
+  @ApiProperty() assessmentTemplateEntryId: string;
+  @ApiProperty() name: string;
+  @ApiProperty({ enum: AggregationMethod }) aggregationMethod: AggregationMethod;
+  @ApiProperty({ required: false, nullable: true }) bestOfN: number | null;
+  @ApiProperty() rescaleToMaxScore: number;
+  @ApiProperty({ enum: MissingAttemptPolicy }) missingAttemptPolicy: MissingAttemptPolicy;
+  @ApiProperty({ enum: QuizAggregationStatus }) status: QuizAggregationStatus;
+  @ApiProperty({ required: false, nullable: true }) finalizedAt: Date | null;
+  @ApiProperty({ required: false, nullable: true }) finalizedByTeacherId: string | null;
+  @ApiProperty({ type: [AggregationItemResult] }) items: AggregationItemResult[];
+  @ApiProperty() createdAt: Date;
+  @ApiProperty() updatedAt: Date;
+
+  constructor(a: AggregationWithRelations) {
+    this.id = a.id;
+    this.schoolId = a.schoolId;
+    this.classArmSubjectId = a.classArmSubjectId;
+    this.termId = a.termId;
+    this.assessmentTemplateEntryId = a.assessmentTemplateEntryId;
+    this.name = a.name;
+    this.aggregationMethod = a.aggregationMethod;
+    this.bestOfN = a.bestOfN;
+    this.rescaleToMaxScore = a.rescaleToMaxScore;
+    this.missingAttemptPolicy = a.missingAttemptPolicy;
+    this.status = a.status;
+    this.finalizedAt = a.finalizedAt;
+    this.finalizedByTeacherId = a.finalizedByTeacherId;
+    this.items = a.items.map((i) => new AggregationItemResult(i));
+    this.createdAt = a.createdAt;
+    this.updatedAt = a.updatedAt;
+  }
+}
+
+export class AggregationsListResult {
+  @ApiProperty({ type: [AggregationResult] }) items: AggregationResult[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+
+  constructor(items: AggregationResult[], total: number, page: number, limit: number) {
+    this.items = items;
+    this.total = total;
+    this.page = page;
+    this.limit = limit;
+  }
+}
+
+export class CreateAggregationResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: AggregationResult }) aggregation: AggregationResult;
+
+  constructor(aggregation: AggregationResult) {
+    this.success = true;
+    this.message = 'Aggregation created';
+    this.aggregation = aggregation;
+  }
+}
+
+export class UpdateAggregationResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: AggregationResult }) aggregation: AggregationResult;
+
+  constructor(aggregation: AggregationResult) {
+    this.success = true;
+    this.message = 'Aggregation updated';
+    this.aggregation = aggregation;
+  }
+}
+
+export class DeleteAggregationResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  constructor() {
+    this.success = true;
+    this.message = 'Aggregation deleted';
+  }
+}
+
+// ---- Preview ----
+
+export class AggregationItemPreviewResult {
+  @ApiProperty() quizAssignmentId: string;
+  @ApiProperty() quizTitle: string;
+  @ApiProperty({ required: false, nullable: true }) percentage: number | null;
+  @ApiProperty({ description: 'true if the student has no GRADED attempt for this item' })
+  missing: boolean;
+
+  constructor(quizAssignmentId: string, quizTitle: string, percentage: number | null, missing: boolean) {
+    this.quizAssignmentId = quizAssignmentId;
+    this.quizTitle = quizTitle;
+    this.percentage = percentage;
+    this.missing = missing;
+  }
+}
+
+export class StudentPreviewRowResult {
+  @ApiProperty() studentId: string;
+  @ApiProperty() studentNo: string;
+  @ApiProperty() firstName: string;
+  @ApiProperty() lastName: string;
+  @ApiProperty({ type: [AggregationItemPreviewResult] }) items: AggregationItemPreviewResult[];
+  @ApiProperty({ description: 'Aggregated percentage in [0, 100]' })
+  computedPercentage: number;
+  @ApiProperty({ description: 'Computed percentage * rescaleToMaxScore / 100, rounded' })
+  rescaledScore: number;
+}
+
+export class AggregationPreviewResult {
+  @ApiProperty({ type: AggregationResult }) aggregation: AggregationResult;
+  @ApiProperty({ type: [StudentPreviewRowResult] }) rows: StudentPreviewRowResult[];
+
+  constructor(aggregation: AggregationResult, rows: StudentPreviewRowResult[]) {
+    this.aggregation = aggregation;
+    this.rows = rows;
+  }
+}
+
+export class FinalizeAggregationResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty() upsertedRows: number;
+  @ApiProperty() finalizedAt: Date;
+
+  constructor(upsertedRows: number, finalizedAt: Date) {
+    this.success = true;
+    this.message = `Aggregation finalized: ${upsertedRows} student score(s) written to gradebook`;
+    this.upsertedRows = upsertedRows;
+    this.finalizedAt = finalizedAt;
+  }
+}

--- a/src/components/quiz-aggregations/results/index.ts
+++ b/src/components/quiz-aggregations/results/index.ts
@@ -1,0 +1,1 @@
+export * from './aggregation.result';

--- a/src/components/quiz-assignments/dto/create-quiz-assignment.dto.ts
+++ b/src/components/quiz-assignments/dto/create-quiz-assignment.dto.ts
@@ -1,0 +1,76 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+import { QuizDeliveryMode } from '@prisma/client';
+
+export class CreateQuizAssignmentDto {
+  @ApiProperty({ description: 'Quiz to assign — must be PUBLISHED and visible to caller' })
+  @IsUUID()
+  quizId: string;
+
+  @ApiProperty({ description: 'classArmSubjectId — caller must teach this' })
+  @IsUUID()
+  classArmSubjectId: string;
+
+  @ApiProperty()
+  @IsUUID()
+  termId: string;
+
+  @ApiProperty({ enum: QuizDeliveryMode })
+  @IsEnum(QuizDeliveryMode)
+  mode: QuizDeliveryMode;
+
+  @ApiProperty({ description: 'ISO date-time when students can begin' })
+  @IsDateString()
+  windowOpensAt: string;
+
+  @ApiProperty({ description: 'ISO date-time when window closes' })
+  @IsDateString()
+  windowClosesAt: string;
+
+  @ApiProperty({ description: 'Per-student timer in minutes', minimum: 1, maximum: 600 })
+  @IsInt()
+  @Min(1)
+  @Max(600)
+  durationMinutes: number;
+
+  @ApiProperty({
+    required: false,
+    default: 60,
+    description: 'SYNC_START only — late-joiner grace period in seconds',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(900)
+  syncGracePeriodSeconds?: number;
+
+  @ApiProperty({ required: false, default: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  maxAttempts?: number;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Override Quiz.defaultSettings.showResultsImmediately for this assignment. If false, teacher must call /release-results.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  showResultsImmediately?: boolean;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  showCorrectAnswers?: boolean;
+}

--- a/src/components/quiz-assignments/dto/grant-override.dto.ts
+++ b/src/components/quiz-assignments/dto/grant-override.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+import { QuizOverrideType } from '@prisma/client';
+
+export class GrantOverrideDto {
+  @ApiProperty({ description: 'Student receiving the override' })
+  @IsUUID()
+  studentId: string;
+
+  @ApiProperty({ enum: QuizOverrideType })
+  @IsEnum(QuizOverrideType)
+  type: QuizOverrideType;
+
+  @ApiProperty({
+    required: false,
+    description: 'RETRY only — number of additional attempts to grant (must be >= 1)',
+    minimum: 1,
+    maximum: 10,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  extraAttempts?: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'EXTRA_TIME only — additional minutes added to the student\'s dueAt',
+    minimum: 1,
+    maximum: 600,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  extraMinutes?: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'EXTEND_WINDOW only — new windowClosesAt for this student',
+  })
+  @IsOptional()
+  @IsDateString()
+  newWindowClosesAt?: string;
+
+  @ApiProperty({
+    description: 'Why this override was granted (required, audit trail)',
+    minLength: 3,
+    maxLength: 500,
+  })
+  @IsString()
+  @MinLength(3)
+  @MaxLength(500)
+  reason: string;
+}

--- a/src/components/quiz-assignments/dto/index.ts
+++ b/src/components/quiz-assignments/dto/index.ts
@@ -1,0 +1,4 @@
+export * from './create-quiz-assignment.dto';
+export * from './update-quiz-assignment.dto';
+export * from './quiz-assignment-query.dto';
+export * from './grant-override.dto';

--- a/src/components/quiz-assignments/dto/quiz-assignment-query.dto.ts
+++ b/src/components/quiz-assignments/dto/quiz-assignment-query.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+import { QuizAssignmentStatus, QuizDeliveryMode } from '@prisma/client';
+
+export class QuizAssignmentQueryDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  classArmSubjectId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  termId?: string;
+
+  @ApiProperty({ required: false, enum: QuizAssignmentStatus })
+  @IsOptional()
+  @IsEnum(QuizAssignmentStatus)
+  status?: QuizAssignmentStatus;
+
+  @ApiProperty({ required: false, enum: QuizDeliveryMode })
+  @IsOptional()
+  @IsEnum(QuizDeliveryMode)
+  mode?: QuizDeliveryMode;
+
+  @ApiProperty({ required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ required: false, default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/components/quiz-assignments/dto/update-quiz-assignment.dto.ts
+++ b/src/components/quiz-assignments/dto/update-quiz-assignment.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
+
+/**
+ * Edits are only allowed while the assignment is still in SCHEDULED state
+ * (now < windowOpensAt). quizId, classArmSubjectId, and termId cannot be
+ * changed — cancel and re-create instead.
+ */
+export class UpdateQuizAssignmentDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsDateString()
+  windowOpensAt?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsDateString()
+  windowClosesAt?: string;
+
+  @ApiProperty({ required: false, minimum: 1, maximum: 600 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(600)
+  durationMinutes?: number;
+
+  @ApiProperty({ required: false, minimum: 0, maximum: 900 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(900)
+  syncGracePeriodSeconds?: number;
+
+  @ApiProperty({ required: false, minimum: 1, maximum: 20 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  maxAttempts?: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  showResultsImmediately?: boolean;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  showCorrectAnswers?: boolean;
+}

--- a/src/components/quiz-assignments/quiz-assignments.controller.ts
+++ b/src/components/quiz-assignments/quiz-assignments.controller.ts
@@ -1,0 +1,174 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { AssessmentsFeatureGuard } from '../../common/guards';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import {
+  CreateQuizAssignmentDto,
+  GrantOverrideDto,
+  QuizAssignmentQueryDto,
+  UpdateQuizAssignmentDto,
+} from './dto';
+import { QuizAssignmentsService } from './quiz-assignments.service';
+import {
+  CreateQuizAssignmentSwagger,
+  DeleteQuizAssignmentSwagger,
+  GetAssignmentResultsSwagger,
+  GetQuizAssignmentSwagger,
+  GrantOverrideSwagger,
+  ListStudentAssignmentsSwagger,
+  ListTeacherAssignmentsSwagger,
+  MonitorAssignmentSwagger,
+  ReleaseResultsSwagger,
+  UpdateQuizAssignmentSwagger,
+} from './quiz-assignments.swagger';
+import {
+  CreateQuizAssignmentResult,
+  DeleteQuizAssignmentResult,
+  GrantOverrideResult,
+  QuizAssignmentMonitorResult,
+  QuizAssignmentResult,
+  QuizAssignmentResultsResult,
+  QuizAssignmentsListResult,
+  ReleaseResultsResult,
+  StudentMonitorRowResult,
+  StudentResultRowResult,
+  UpdateQuizAssignmentResult,
+} from './results/quiz-assignment.result';
+
+@Controller('quiz-assignments')
+@ApiTags('Quiz Assignments')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class QuizAssignmentsController {
+  constructor(private readonly service: QuizAssignmentsService) {}
+
+  @Post()
+  @UseGuards(AssessmentsFeatureGuard)
+  @CreateQuizAssignmentSwagger()
+  async create(@GetCurrentUserId() userId: string, @Body() dto: CreateQuizAssignmentDto) {
+    const a = await this.service.create(userId, dto);
+    return new CreateQuizAssignmentResult(new QuizAssignmentResult(a));
+  }
+
+  @Get()
+  @ListTeacherAssignmentsSwagger()
+  async listForTeacher(
+    @GetCurrentUserId() userId: string,
+    @Query() query: QuizAssignmentQueryDto,
+  ) {
+    const { items, total, page, limit } = await this.service.listForTeacher(userId, query);
+    return new QuizAssignmentsListResult(
+      items.map((a) => new QuizAssignmentResult(a)),
+      total,
+      page,
+      limit,
+    );
+  }
+
+  @Get('mine')
+  @ListStudentAssignmentsSwagger()
+  async listForStudent(
+    @GetCurrentUserId() userId: string,
+    @Query() query: QuizAssignmentQueryDto,
+  ) {
+    const { items, total, page, limit } = await this.service.listForStudent(userId, query);
+    return new QuizAssignmentsListResult(
+      items.map((a) => new QuizAssignmentResult(a)),
+      total,
+      page,
+      limit,
+    );
+  }
+
+  @Get(':id')
+  @GetQuizAssignmentSwagger()
+  async findById(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const a = await this.findVisibleToCaller(userId, id);
+    return new QuizAssignmentResult(a);
+  }
+
+  @Patch(':id')
+  @UpdateQuizAssignmentSwagger()
+  async update(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: UpdateQuizAssignmentDto,
+  ) {
+    const a = await this.service.update(userId, id, dto);
+    return new UpdateQuizAssignmentResult(new QuizAssignmentResult(a));
+  }
+
+  @Delete(':id')
+  @DeleteQuizAssignmentSwagger()
+  async delete(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    await this.service.softDelete(userId, id);
+    return new DeleteQuizAssignmentResult();
+  }
+
+  @Post(':id/overrides')
+  @HttpCode(HttpStatus.CREATED)
+  @GrantOverrideSwagger()
+  async grantOverride(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: GrantOverrideDto,
+  ) {
+    const o = await this.service.grantOverride(userId, id, dto);
+    return new GrantOverrideResult(o);
+  }
+
+  @Post(':id/release-results')
+  @HttpCode(HttpStatus.OK)
+  @ReleaseResultsSwagger()
+  async releaseResults(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const releasedAt = await this.service.releaseResults(userId, id);
+    return new ReleaseResultsResult(releasedAt);
+  }
+
+  @Get(':id/monitor')
+  @MonitorAssignmentSwagger()
+  async monitor(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const { assignment, students } = await this.service.getMonitor(userId, id);
+    const rows = students.map(
+      ({ student, attempts }) => new StudentMonitorRowResult(student, attempts),
+    );
+    return new QuizAssignmentMonitorResult(new QuizAssignmentResult(assignment), rows);
+  }
+
+  @Get(':id/results')
+  @GetAssignmentResultsSwagger()
+  async results(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const { assignment, attempts } = await this.service.getResults(userId, id);
+    const rows = attempts.map((a) => new StudentResultRowResult(a, a.student));
+    return new QuizAssignmentResultsResult(new QuizAssignmentResult(assignment), rows);
+  }
+
+  /**
+   * GET :id is visible to either the managing teacher or an enrolled student.
+   * Try teacher path first; on Forbidden/NotFound, fall back to student path.
+   */
+  private async findVisibleToCaller(userId: string, id: string) {
+    try {
+      return await this.service.findByIdForTeacher(userId, id);
+    } catch (err) {
+      const name = (err as { name?: string }).name;
+      if (name !== 'ForbiddenException' && name !== 'NotFoundException') throw err;
+      return this.service.findByIdForStudent(userId, id);
+    }
+  }
+}

--- a/src/components/quiz-assignments/quiz-assignments.module.ts
+++ b/src/components/quiz-assignments/quiz-assignments.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+
+import { AssessmentsFeatureGuard } from '../../common/guards';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { QuizAssignmentsController } from './quiz-assignments.controller';
+import { QuizAssignmentsService } from './quiz-assignments.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [QuizAssignmentsController],
+  providers: [QuizAssignmentsService, Encryptor, AssessmentsFeatureGuard],
+  exports: [QuizAssignmentsService],
+})
+export class QuizAssignmentsModule {}

--- a/src/components/quiz-assignments/quiz-assignments.service.ts
+++ b/src/components/quiz-assignments/quiz-assignments.service.ts
@@ -1,0 +1,551 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  Prisma,
+  QuizAssignmentStatus,
+  QuizDeliveryMode,
+  QuizOwnerType,
+  QuizOverrideType,
+  QuizStatus,
+} from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { UserTypes } from '../users/constants';
+import {
+  CreateQuizAssignmentDto,
+  GrantOverrideDto,
+  QuizAssignmentQueryDto,
+  UpdateQuizAssignmentDto,
+} from './dto';
+import {
+  AssignmentWithRelations,
+  computeEffectiveStatus,
+} from './results/quiz-assignment.result';
+
+const ASSIGNMENT_INCLUDE = {
+  quiz: { select: { id: true, title: true, version: true, status: true, estimatedMinutes: true } },
+  classArmSubject: {
+    include: {
+      classArm: { include: { level: true } },
+      subject: true,
+    },
+  },
+  term: { select: { id: true, name: true } },
+  assignedByTeacher: {
+    include: { user: { select: { firstName: true, lastName: true } } },
+  },
+  _count: { select: { attempts: true, overrides: true } },
+} as const satisfies Prisma.QuizAssignmentInclude;
+
+interface CallerContext {
+  userId: string;
+  type: string;
+  schoolId: string | null;
+  teacherId?: string;
+  studentId?: string;
+}
+
+@Injectable()
+export class QuizAssignmentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(callerUserId: string, dto: CreateQuizAssignmentDto) {
+    const caller = await this.requireTeacher(callerUserId);
+
+    await this.assertTeacherTeachesClassArmSubject(caller.teacherId!, dto.classArmSubjectId);
+
+    const windowOpensAt = new Date(dto.windowOpensAt);
+    const windowClosesAt = new Date(dto.windowClosesAt);
+    this.validateWindow(windowOpensAt, windowClosesAt, dto.durationMinutes, dto.mode);
+
+    const term = await this.prisma.term.findFirst({
+      where: { id: dto.termId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!term) throw new BadRequestException('Term not found');
+
+    const quiz = await this.prisma.quiz.findFirst({
+      where: { id: dto.quizId, deletedAt: null },
+      select: { id: true, version: true, status: true, ownerType: true, schoolId: true },
+    });
+    if (!quiz) throw new NotFoundException('Quiz not found');
+    if (quiz.status !== QuizStatus.PUBLISHED) {
+      throw new BadRequestException('Quiz must be PUBLISHED before it can be assigned');
+    }
+    const isCurated = quiz.ownerType === QuizOwnerType.SCHOS_CURATED;
+    const isOwnSchool = quiz.schoolId === caller.schoolId;
+    if (!isCurated && !isOwnSchool) {
+      throw new ForbiddenException('Quiz is not visible to your school');
+    }
+
+    const created = await this.prisma.quizAssignment.create({
+      data: {
+        quizId: quiz.id,
+        quizVersion: quiz.version,
+        classArmSubjectId: dto.classArmSubjectId,
+        termId: dto.termId,
+        assignedByTeacherId: caller.teacherId!,
+        mode: dto.mode,
+        windowOpensAt,
+        windowClosesAt,
+        durationMinutes: dto.durationMinutes,
+        syncGracePeriodSeconds: dto.syncGracePeriodSeconds ?? 60,
+        maxAttempts: dto.maxAttempts ?? 1,
+        showResultsImmediately: dto.showResultsImmediately,
+        showCorrectAnswers: dto.showCorrectAnswers,
+        status: QuizAssignmentStatus.SCHEDULED,
+      },
+    });
+
+    return this.fetchById(created.id);
+  }
+
+  async update(callerUserId: string, id: string, dto: UpdateQuizAssignmentDto) {
+    const caller = await this.requireTeacher(callerUserId);
+    const existing = await this.prisma.quizAssignment.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!existing) throw new NotFoundException('Quiz assignment not found');
+    await this.assertTeacherCanManage(caller.teacherId!, existing);
+
+    if (existing.status === QuizAssignmentStatus.ARCHIVED) {
+      throw new ConflictException('Cannot edit an archived assignment');
+    }
+    const now = new Date();
+    if (now >= existing.windowOpensAt) {
+      throw new ConflictException(
+        'Edits are only allowed before the assignment window opens',
+      );
+    }
+
+    const nextOpens = dto.windowOpensAt ? new Date(dto.windowOpensAt) : existing.windowOpensAt;
+    const nextCloses = dto.windowClosesAt
+      ? new Date(dto.windowClosesAt)
+      : existing.windowClosesAt;
+    const nextDuration = dto.durationMinutes ?? existing.durationMinutes;
+    this.validateWindow(nextOpens, nextCloses, nextDuration, existing.mode);
+
+    await this.prisma.quizAssignment.update({
+      where: { id },
+      data: {
+        ...(dto.windowOpensAt !== undefined && { windowOpensAt: nextOpens }),
+        ...(dto.windowClosesAt !== undefined && { windowClosesAt: nextCloses }),
+        ...(dto.durationMinutes !== undefined && { durationMinutes: dto.durationMinutes }),
+        ...(dto.syncGracePeriodSeconds !== undefined && {
+          syncGracePeriodSeconds: dto.syncGracePeriodSeconds,
+        }),
+        ...(dto.maxAttempts !== undefined && { maxAttempts: dto.maxAttempts }),
+        ...(dto.showResultsImmediately !== undefined && {
+          showResultsImmediately: dto.showResultsImmediately,
+        }),
+        ...(dto.showCorrectAnswers !== undefined && {
+          showCorrectAnswers: dto.showCorrectAnswers,
+        }),
+      },
+    });
+
+    return this.fetchById(id);
+  }
+
+  async softDelete(callerUserId: string, id: string) {
+    const caller = await this.requireTeacher(callerUserId);
+    const existing = await this.prisma.quizAssignment.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!existing) throw new NotFoundException('Quiz assignment not found');
+    await this.assertTeacherCanManage(caller.teacherId!, existing);
+
+    const attemptCount = await this.prisma.quizAttempt.count({ where: { quizAssignmentId: id } });
+    if (attemptCount > 0) {
+      throw new ConflictException(
+        `Cannot cancel: ${attemptCount} attempt(s) already started. Archive after the window closes instead.`,
+      );
+    }
+
+    await this.prisma.quizAssignment.update({
+      where: { id },
+      data: { deletedAt: new Date(), status: QuizAssignmentStatus.ARCHIVED },
+    });
+  }
+
+  async grantOverride(callerUserId: string, assignmentId: string, dto: GrantOverrideDto) {
+    const caller = await this.requireTeacher(callerUserId);
+    const assignment = await this.prisma.quizAssignment.findFirst({
+      where: { id: assignmentId, deletedAt: null },
+      include: {
+        classArmSubject: { select: { classArmId: true } },
+      },
+    });
+    if (!assignment) throw new NotFoundException('Quiz assignment not found');
+    await this.assertTeacherCanManage(caller.teacherId!, assignment);
+
+    const studentEnrollment = await this.prisma.classArmStudent.findFirst({
+      where: {
+        studentId: dto.studentId,
+        classArmId: assignment.classArmSubject.classArmId,
+        isActive: true,
+        deletedAt: null,
+      },
+    });
+    if (!studentEnrollment) {
+      throw new BadRequestException(
+        'Student is not actively enrolled in this class arm',
+      );
+    }
+
+    this.validateOverridePayload(dto, assignment.windowClosesAt);
+
+    const created = await this.prisma.quizAttemptOverride.create({
+      data: {
+        quizAssignmentId: assignmentId,
+        studentId: dto.studentId,
+        grantedByTeacherId: caller.teacherId!,
+        type: dto.type,
+        extraAttempts: dto.type === QuizOverrideType.RETRY ? dto.extraAttempts ?? 1 : null,
+        extraMinutes: dto.type === QuizOverrideType.EXTRA_TIME ? dto.extraMinutes ?? null : null,
+        newWindowClosesAt:
+          dto.type === QuizOverrideType.EXTEND_WINDOW
+            ? new Date(dto.newWindowClosesAt!)
+            : null,
+        reason: dto.reason,
+      },
+    });
+
+    return created;
+  }
+
+  async releaseResults(callerUserId: string, id: string) {
+    const caller = await this.requireTeacher(callerUserId);
+    const existing = await this.prisma.quizAssignment.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!existing) throw new NotFoundException('Quiz assignment not found');
+    await this.assertTeacherCanManage(caller.teacherId!, existing);
+
+    if (existing.resultsReleasedAt) {
+      return existing.resultsReleasedAt;
+    }
+    if (existing.showResultsImmediately === true) {
+      throw new ConflictException(
+        'Results are already shown immediately for this assignment — nothing to release',
+      );
+    }
+
+    const now = new Date();
+    await this.prisma.quizAssignment.update({
+      where: { id },
+      data: { resultsReleasedAt: now },
+    });
+    return now;
+  }
+
+  async getMonitor(callerUserId: string, id: string) {
+    const caller = await this.requireTeacher(callerUserId);
+    const assignment = await this.prisma.quizAssignment.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        ...ASSIGNMENT_INCLUDE,
+        classArmSubject: {
+          include: {
+            classArm: { include: { level: true } },
+            subject: true,
+          },
+        },
+      },
+    });
+    if (!assignment) throw new NotFoundException('Quiz assignment not found');
+    await this.assertTeacherCanManage(caller.teacherId!, assignment);
+
+    const enrollments = await this.prisma.classArmStudent.findMany({
+      where: {
+        classArmId: assignment.classArmSubject.classArmId,
+        isActive: true,
+        deletedAt: null,
+      },
+      include: {
+        student: { include: { user: { select: { firstName: true, lastName: true } } } },
+      },
+      orderBy: [{ student: { studentNo: 'asc' } }],
+    });
+
+    const attempts = await this.prisma.quizAttempt.findMany({
+      where: { quizAssignmentId: id },
+      select: {
+        id: true,
+        studentId: true,
+        attemptNumber: true,
+        status: true,
+        startedAt: true,
+        submittedAt: true,
+        percentage: true,
+      },
+    });
+    const attemptsByStudent = new Map<string, typeof attempts>();
+    for (const a of attempts) {
+      const list = attemptsByStudent.get(a.studentId) ?? [];
+      list.push(a);
+      attemptsByStudent.set(a.studentId, list);
+    }
+
+    return {
+      assignment: assignment as AssignmentWithRelations,
+      students: enrollments.map((e) => ({
+        student: e.student,
+        attempts: attemptsByStudent.get(e.studentId) ?? [],
+      })),
+    };
+  }
+
+  async getResults(callerUserId: string, id: string) {
+    const caller = await this.requireTeacher(callerUserId);
+    const assignment = await this.prisma.quizAssignment.findFirst({
+      where: { id, deletedAt: null },
+      include: ASSIGNMENT_INCLUDE,
+    });
+    if (!assignment) throw new NotFoundException('Quiz assignment not found');
+    await this.assertTeacherCanManage(caller.teacherId!, assignment);
+
+    const attempts = await this.prisma.quizAttempt.findMany({
+      where: {
+        quizAssignmentId: id,
+        status: { in: ['SUBMITTED', 'GRADING', 'GRADED'] },
+      },
+      include: {
+        student: { include: { user: { select: { firstName: true, lastName: true } } } },
+      },
+      orderBy: [{ student: { studentNo: 'asc' } }, { attemptNumber: 'desc' }],
+    });
+
+    return { assignment: assignment as AssignmentWithRelations, attempts };
+  }
+
+  async listForTeacher(callerUserId: string, query: QuizAssignmentQueryDto) {
+    const caller = await this.requireTeacher(callerUserId);
+    const teachingClassArmSubjects = await this.prisma.classArmSubjectTeacher.findMany({
+      where: { teacherId: caller.teacherId!, deletedAt: null },
+      select: { classArmSubjectId: true },
+    });
+    const taughtIds = teachingClassArmSubjects.map((t) => t.classArmSubjectId);
+
+    const where: Prisma.QuizAssignmentWhereInput = {
+      deletedAt: null,
+      OR: [
+        { assignedByTeacherId: caller.teacherId! },
+        ...(taughtIds.length > 0
+          ? [{ classArmSubjectId: { in: taughtIds } } as Prisma.QuizAssignmentWhereInput]
+          : []),
+      ],
+    };
+    if (query.classArmSubjectId) where.classArmSubjectId = query.classArmSubjectId;
+    if (query.termId) where.termId = query.termId;
+    if (query.status) where.status = query.status;
+    if (query.mode) where.mode = query.mode;
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const [items, total] = await Promise.all([
+      this.prisma.quizAssignment.findMany({
+        where,
+        include: ASSIGNMENT_INCLUDE,
+        orderBy: [{ windowOpensAt: 'desc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.quizAssignment.count({ where }),
+    ]);
+    return { items, total, page, limit };
+  }
+
+  async listForStudent(callerUserId: string, query: QuizAssignmentQueryDto) {
+    const caller = await this.requireStudent(callerUserId);
+    const enrollments = await this.prisma.classArmStudent.findMany({
+      where: { studentId: caller.studentId!, isActive: true, deletedAt: null },
+      select: { classArmId: true },
+    });
+    const classArmIds = enrollments.map((e) => e.classArmId);
+    if (classArmIds.length === 0) {
+      return { items: [], total: 0, page: query.page ?? 1, limit: query.limit ?? 20 };
+    }
+
+    const where: Prisma.QuizAssignmentWhereInput = {
+      deletedAt: null,
+      classArmSubject: { classArmId: { in: classArmIds } },
+    };
+    if (query.termId) where.termId = query.termId;
+    if (query.status) where.status = query.status;
+    if (query.mode) where.mode = query.mode;
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const [items, total] = await Promise.all([
+      this.prisma.quizAssignment.findMany({
+        where,
+        include: ASSIGNMENT_INCLUDE,
+        orderBy: [{ windowOpensAt: 'asc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.quizAssignment.count({ where }),
+    ]);
+    return { items, total, page, limit };
+  }
+
+  async findByIdForTeacher(callerUserId: string, id: string) {
+    const caller = await this.requireTeacher(callerUserId);
+    const assignment = await this.fetchById(id);
+    await this.assertTeacherCanManage(caller.teacherId!, assignment);
+    return assignment;
+  }
+
+  async findByIdForStudent(callerUserId: string, id: string) {
+    const caller = await this.requireStudent(callerUserId);
+    const assignment = await this.fetchById(id);
+    const enrolled = await this.prisma.classArmStudent.findFirst({
+      where: {
+        studentId: caller.studentId!,
+        classArmId: assignment.classArmSubject.classArmId,
+        isActive: true,
+        deletedAt: null,
+      },
+    });
+    if (!enrolled) {
+      throw new NotFoundException('Quiz assignment not found');
+    }
+    return assignment;
+  }
+
+  // ---- internals ----
+
+  private async fetchById(id: string): Promise<AssignmentWithRelations> {
+    const assignment = await this.prisma.quizAssignment.findFirst({
+      where: { id, deletedAt: null },
+      include: ASSIGNMENT_INCLUDE,
+    });
+    if (!assignment) throw new NotFoundException('Quiz assignment not found');
+    return assignment as AssignmentWithRelations;
+  }
+
+  private async requireTeacher(callerUserId: string): Promise<CallerContext> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: callerUserId },
+      select: { id: true, type: true, schoolId: true, teacher: { select: { id: true } } },
+    });
+    if (!user) throw new ForbiddenException('Caller not found');
+    if (user.type !== UserTypes.TEACHER || !user.teacher) {
+      throw new ForbiddenException('Only teachers can manage quiz assignments');
+    }
+    return {
+      userId: user.id,
+      type: user.type,
+      schoolId: user.schoolId,
+      teacherId: user.teacher.id,
+    };
+  }
+
+  private async requireStudent(callerUserId: string): Promise<CallerContext> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: callerUserId },
+      select: { id: true, type: true, schoolId: true, student: { select: { id: true } } },
+    });
+    if (!user) throw new ForbiddenException('Caller not found');
+    if (user.type !== UserTypes.STUDENT || !user.student) {
+      throw new ForbiddenException('Only students can use this endpoint');
+    }
+    return {
+      userId: user.id,
+      type: user.type,
+      schoolId: user.schoolId,
+      studentId: user.student.id,
+    };
+  }
+
+  private async assertTeacherTeachesClassArmSubject(
+    teacherId: string,
+    classArmSubjectId: string,
+  ) {
+    const link = await this.prisma.classArmSubjectTeacher.findFirst({
+      where: { teacherId, classArmSubjectId, deletedAt: null },
+    });
+    if (!link) {
+      throw new ForbiddenException('You do not teach this class arm subject');
+    }
+  }
+
+  private async assertTeacherCanManage(
+    teacherId: string,
+    assignment: { assignedByTeacherId: string; classArmSubjectId: string },
+  ) {
+    if (assignment.assignedByTeacherId === teacherId) return;
+    const link = await this.prisma.classArmSubjectTeacher.findFirst({
+      where: {
+        teacherId,
+        classArmSubjectId: assignment.classArmSubjectId,
+        deletedAt: null,
+      },
+    });
+    if (!link) {
+      throw new ForbiddenException('You are not authorized to manage this assignment');
+    }
+  }
+
+  private validateWindow(
+    opensAt: Date,
+    closesAt: Date,
+    durationMinutes: number,
+    mode: QuizDeliveryMode,
+  ) {
+    if (Number.isNaN(opensAt.getTime()) || Number.isNaN(closesAt.getTime())) {
+      throw new BadRequestException('Invalid window timestamps');
+    }
+    if (closesAt <= opensAt) {
+      throw new BadRequestException('windowClosesAt must be after windowOpensAt');
+    }
+    const windowMinutes = (closesAt.getTime() - opensAt.getTime()) / 60_000;
+    if (mode === QuizDeliveryMode.SYNC_START && durationMinutes > windowMinutes) {
+      throw new BadRequestException(
+        `SYNC_START requires durationMinutes (${durationMinutes}) to fit inside the window (${windowMinutes.toFixed(0)} min)`,
+      );
+    }
+    if (mode === QuizDeliveryMode.OPEN_WINDOW && durationMinutes > windowMinutes) {
+      throw new BadRequestException(
+        `OPEN_WINDOW requires durationMinutes (${durationMinutes}) to fit inside the window (${windowMinutes.toFixed(0)} min) — last students could be cut off`,
+      );
+    }
+  }
+
+  private validateOverridePayload(dto: GrantOverrideDto, currentWindowClosesAt: Date) {
+    switch (dto.type) {
+      case QuizOverrideType.RETRY:
+        if (!dto.extraAttempts || dto.extraAttempts < 1) {
+          throw new BadRequestException('RETRY override requires extraAttempts >= 1');
+        }
+        return;
+      case QuizOverrideType.EXTRA_TIME:
+        if (!dto.extraMinutes || dto.extraMinutes < 1) {
+          throw new BadRequestException('EXTRA_TIME override requires extraMinutes >= 1');
+        }
+        return;
+      case QuizOverrideType.EXTEND_WINDOW: {
+        if (!dto.newWindowClosesAt) {
+          throw new BadRequestException(
+            'EXTEND_WINDOW override requires newWindowClosesAt',
+          );
+        }
+        const next = new Date(dto.newWindowClosesAt);
+        if (Number.isNaN(next.getTime()) || next <= currentWindowClosesAt) {
+          throw new BadRequestException(
+            'newWindowClosesAt must be after the assignment\'s current windowClosesAt',
+          );
+        }
+        return;
+      }
+    }
+  }
+
+  computeEffectiveStatus = computeEffectiveStatus;
+}

--- a/src/components/quiz-assignments/quiz-assignments.swagger.ts
+++ b/src/components/quiz-assignments/quiz-assignments.swagger.ts
@@ -1,0 +1,133 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+import {
+  CreateQuizAssignmentDto,
+  GrantOverrideDto,
+  UpdateQuizAssignmentDto,
+} from './dto';
+import {
+  CreateQuizAssignmentResult,
+  DeleteQuizAssignmentResult,
+  GrantOverrideResult,
+  QuizAssignmentMonitorResult,
+  QuizAssignmentResult,
+  QuizAssignmentResultsResult,
+  QuizAssignmentsListResult,
+  ReleaseResultsResult,
+  UpdateQuizAssignmentResult,
+} from './results/quiz-assignment.result';
+
+export function CreateQuizAssignmentSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Schedule a published quiz to a class arm subject. Snapshots quiz.version so future quiz edits do not affect this assignment.',
+    }),
+    ApiBody({ type: CreateQuizAssignmentDto }),
+    ApiResponse({ status: 201, type: CreateQuizAssignmentResult }),
+    ApiResponse({ status: 400, description: 'Invalid window / mode mismatch / quiz not PUBLISHED' }),
+    ApiResponse({ status: 403, description: 'Caller does not teach this class arm subject' }),
+  );
+}
+
+export function ListTeacherAssignmentsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        "Teacher view: list assignments the caller created OR teaches. Filter by classArmSubjectId, termId, status, mode.",
+    }),
+    ApiResponse({ status: 200, type: QuizAssignmentsListResult }),
+  );
+}
+
+export function ListStudentAssignmentsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        "Student view: list assignments for the caller's active class arms. Use effectiveStatus for state.",
+    }),
+    ApiResponse({ status: 200, type: QuizAssignmentsListResult }),
+  );
+}
+
+export function GetQuizAssignmentSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get assignment detail (teacher or enrolled student)' }),
+    ApiParam({ name: 'id', description: 'QuizAssignment id' }),
+    ApiResponse({ status: 200, type: QuizAssignmentResult }),
+    ApiResponse({ status: 404, description: 'Not found or not visible to caller' }),
+  );
+}
+
+export function UpdateQuizAssignmentSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Edit window / duration / settings. Only allowed before windowOpensAt. Cannot change quiz, classArmSubject, term — cancel and recreate instead.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAssignment id' }),
+    ApiBody({ type: UpdateQuizAssignmentDto }),
+    ApiResponse({ status: 200, type: UpdateQuizAssignmentResult }),
+    ApiResponse({ status: 409, description: 'Window already opened or assignment archived' }),
+  );
+}
+
+export function DeleteQuizAssignmentSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Cancel an assignment. Rejected if any attempt has already started.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAssignment id' }),
+    ApiResponse({ status: 200, type: DeleteQuizAssignmentResult }),
+    ApiResponse({ status: 409, description: 'Attempts already exist' }),
+  );
+}
+
+export function GrantOverrideSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Grant a per-student exception (RETRY / EXTRA_TIME / EXTEND_WINDOW). Reason is required for audit.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAssignment id' }),
+    ApiBody({ type: GrantOverrideDto }),
+    ApiResponse({ status: 201, type: GrantOverrideResult }),
+    ApiResponse({ status: 400, description: 'Override payload invalid for the chosen type' }),
+    ApiResponse({ status: 403, description: 'Caller does not manage this assignment' }),
+  );
+}
+
+export function ReleaseResultsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Release results to students for an assignment that was held (showResultsImmediately = false). Idempotent.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAssignment id' }),
+    ApiResponse({ status: 200, type: ReleaseResultsResult }),
+    ApiResponse({ status: 409, description: 'Already shown immediately or already released' }),
+  );
+}
+
+export function MonitorAssignmentSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Teacher live-monitor view: list of every active student in the class arm with their attempt status.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAssignment id' }),
+    ApiResponse({ status: 200, type: QuizAssignmentMonitorResult }),
+  );
+}
+
+export function GetAssignmentResultsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Teacher results view: per-student attempts that are SUBMITTED / GRADING / GRADED with scores.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAssignment id' }),
+    ApiResponse({ status: 200, type: QuizAssignmentResultsResult }),
+  );
+}

--- a/src/components/quiz-assignments/results/index.ts
+++ b/src/components/quiz-assignments/results/index.ts
@@ -1,0 +1,1 @@
+export * from './quiz-assignment.result';

--- a/src/components/quiz-assignments/results/quiz-assignment.result.ts
+++ b/src/components/quiz-assignments/results/quiz-assignment.result.ts
@@ -1,0 +1,318 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ClassArm,
+  ClassArmSubject,
+  Level,
+  Quiz,
+  QuizAssignment,
+  QuizAssignmentStatus,
+  QuizAttempt,
+  QuizAttemptOverride,
+  QuizAttemptStatus,
+  QuizDeliveryMode,
+  QuizOverrideType,
+  Student,
+  Subject,
+  Teacher,
+  Term,
+  User,
+} from '@prisma/client';
+
+export type AssignmentWithRelations = QuizAssignment & {
+  quiz: Pick<Quiz, 'id' | 'title' | 'version' | 'status' | 'estimatedMinutes'>;
+  classArmSubject: ClassArmSubject & {
+    classArm: ClassArm & { level: Level };
+    subject: Subject;
+  };
+  term: Pick<Term, 'id' | 'name'>;
+  assignedByTeacher: Teacher & {
+    user: Pick<User, 'firstName' | 'lastName'>;
+  };
+  _count?: { attempts: number; overrides: number };
+};
+
+export function computeEffectiveStatus(
+  assignment: Pick<QuizAssignment, 'status' | 'windowOpensAt' | 'windowClosesAt'>,
+  now: Date = new Date(),
+): QuizAssignmentStatus {
+  if (assignment.status === 'ARCHIVED') return 'ARCHIVED';
+  if (now < assignment.windowOpensAt) return 'SCHEDULED';
+  if (now < assignment.windowClosesAt) return 'OPEN';
+  return 'CLOSED';
+}
+
+export class QuizAssignmentResult {
+  @ApiProperty() id: string;
+  @ApiProperty() quizId: string;
+  @ApiProperty() quizVersion: number;
+  @ApiProperty() quizTitle: string;
+  @ApiProperty() classArmSubjectId: string;
+  @ApiProperty() classArmName: string;
+  @ApiProperty() subjectName: string;
+  @ApiProperty() levelCode: string;
+  @ApiProperty() termId: string;
+  @ApiProperty() termName: string;
+  @ApiProperty() assignedByTeacherId: string;
+  @ApiProperty() assignedByName: string;
+  @ApiProperty({ enum: ['OPEN_WINDOW', 'SYNC_START'] }) mode: QuizDeliveryMode;
+  @ApiProperty() windowOpensAt: Date;
+  @ApiProperty() windowClosesAt: Date;
+  @ApiProperty() durationMinutes: number;
+  @ApiProperty({ required: false, nullable: true }) syncGracePeriodSeconds: number | null;
+  @ApiProperty() maxAttempts: number;
+  @ApiProperty({ required: false, nullable: true }) showResultsImmediately: boolean | null;
+  @ApiProperty({ required: false, nullable: true }) showCorrectAnswers: boolean | null;
+  @ApiProperty({ required: false, nullable: true }) resultsReleasedAt: Date | null;
+  @ApiProperty({
+    enum: ['SCHEDULED', 'OPEN', 'CLOSED', 'ARCHIVED'],
+    description: 'Stored status — only ARCHIVED is meaningful (manual cancel)',
+  })
+  status: QuizAssignmentStatus;
+  @ApiProperty({
+    enum: ['SCHEDULED', 'OPEN', 'CLOSED', 'ARCHIVED'],
+    description: 'Computed from window times + stored status — use this for gating',
+  })
+  effectiveStatus: QuizAssignmentStatus;
+  @ApiProperty() attemptCount: number;
+  @ApiProperty() overrideCount: number;
+  @ApiProperty() createdAt: Date;
+  @ApiProperty() updatedAt: Date;
+
+  constructor(a: AssignmentWithRelations, now: Date = new Date()) {
+    this.id = a.id;
+    this.quizId = a.quizId;
+    this.quizVersion = a.quizVersion;
+    this.quizTitle = a.quiz.title;
+    this.classArmSubjectId = a.classArmSubjectId;
+    this.classArmName = a.classArmSubject.classArm.name;
+    this.subjectName = a.classArmSubject.subject.name;
+    this.levelCode = a.classArmSubject.classArm.level.code;
+    this.termId = a.termId;
+    this.termName = a.term.name;
+    this.assignedByTeacherId = a.assignedByTeacherId;
+    this.assignedByName = `${a.assignedByTeacher.user.firstName} ${a.assignedByTeacher.user.lastName}`;
+    this.mode = a.mode;
+    this.windowOpensAt = a.windowOpensAt;
+    this.windowClosesAt = a.windowClosesAt;
+    this.durationMinutes = a.durationMinutes;
+    this.syncGracePeriodSeconds = a.syncGracePeriodSeconds;
+    this.maxAttempts = a.maxAttempts;
+    this.showResultsImmediately = a.showResultsImmediately;
+    this.showCorrectAnswers = a.showCorrectAnswers;
+    this.resultsReleasedAt = a.resultsReleasedAt;
+    this.status = a.status;
+    this.effectiveStatus = computeEffectiveStatus(a, now);
+    this.attemptCount = a._count?.attempts ?? 0;
+    this.overrideCount = a._count?.overrides ?? 0;
+    this.createdAt = a.createdAt;
+    this.updatedAt = a.updatedAt;
+  }
+}
+
+export class QuizAssignmentsListResult {
+  @ApiProperty({ type: [QuizAssignmentResult] }) items: QuizAssignmentResult[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+
+  constructor(items: QuizAssignmentResult[], total: number, page: number, limit: number) {
+    this.items = items;
+    this.total = total;
+    this.page = page;
+    this.limit = limit;
+  }
+}
+
+export class CreateQuizAssignmentResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuizAssignmentResult }) assignment: QuizAssignmentResult;
+
+  constructor(assignment: QuizAssignmentResult) {
+    this.success = true;
+    this.message = 'Quiz assignment created successfully';
+    this.assignment = assignment;
+  }
+}
+
+export class UpdateQuizAssignmentResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuizAssignmentResult }) assignment: QuizAssignmentResult;
+
+  constructor(assignment: QuizAssignmentResult) {
+    this.success = true;
+    this.message = 'Quiz assignment updated successfully';
+    this.assignment = assignment;
+  }
+}
+
+export class DeleteQuizAssignmentResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+
+  constructor() {
+    this.success = true;
+    this.message = 'Quiz assignment cancelled successfully';
+  }
+}
+
+export class ReleaseResultsResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty() resultsReleasedAt: Date;
+
+  constructor(resultsReleasedAt: Date) {
+    this.success = true;
+    this.message = 'Results released to students';
+    this.resultsReleasedAt = resultsReleasedAt;
+  }
+}
+
+export class GrantOverrideResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty() id: string;
+  @ApiProperty() studentId: string;
+  @ApiProperty({ enum: ['RETRY', 'EXTEND_WINDOW', 'EXTRA_TIME'] }) type: QuizOverrideType;
+  @ApiProperty({ required: false, nullable: true }) extraAttempts: number | null;
+  @ApiProperty({ required: false, nullable: true }) extraMinutes: number | null;
+  @ApiProperty({ required: false, nullable: true }) newWindowClosesAt: Date | null;
+  @ApiProperty() reason: string;
+  @ApiProperty() grantedByTeacherId: string;
+  @ApiProperty() createdAt: Date;
+
+  constructor(o: QuizAttemptOverride) {
+    this.success = true;
+    this.message = 'Override granted';
+    this.id = o.id;
+    this.studentId = o.studentId;
+    this.type = o.type;
+    this.extraAttempts = o.extraAttempts;
+    this.extraMinutes = o.extraMinutes;
+    this.newWindowClosesAt = o.newWindowClosesAt;
+    this.reason = o.reason;
+    this.grantedByTeacherId = o.grantedByTeacherId;
+    this.createdAt = o.createdAt;
+  }
+}
+
+// ---- Monitor (teacher polling view) ----
+
+export type StudentForMonitor = Student & {
+  user: Pick<User, 'firstName' | 'lastName'>;
+};
+
+export type AttemptForMonitor = Pick<
+  QuizAttempt,
+  'id' | 'attemptNumber' | 'status' | 'startedAt' | 'submittedAt' | 'percentage'
+>;
+
+export class StudentMonitorRowResult {
+  @ApiProperty() studentId: string;
+  @ApiProperty() studentNo: string;
+  @ApiProperty() firstName: string;
+  @ApiProperty() lastName: string;
+  @ApiProperty({ enum: ['NOT_STARTED', 'IN_PROGRESS', 'SUBMITTED', 'GRADING', 'GRADED'] })
+  attemptStatus: 'NOT_STARTED' | QuizAttemptStatus;
+  @ApiProperty() attemptCount: number;
+  @ApiProperty({ required: false, nullable: true }) lastStartedAt: Date | null;
+  @ApiProperty({ required: false, nullable: true }) lastSubmittedAt: Date | null;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal as string' })
+  latestPercentage: string | null;
+
+  constructor(student: StudentForMonitor, attempts: AttemptForMonitor[]) {
+    this.studentId = student.id;
+    this.studentNo = student.studentNo;
+    this.firstName = student.user.firstName;
+    this.lastName = student.user.lastName;
+    this.attemptCount = attempts.length;
+    if (attempts.length === 0) {
+      this.attemptStatus = 'NOT_STARTED';
+      this.lastStartedAt = null;
+      this.lastSubmittedAt = null;
+      this.latestPercentage = null;
+    } else {
+      const latest = attempts.reduce((best, cur) =>
+        cur.attemptNumber > best.attemptNumber ? cur : best,
+      );
+      this.attemptStatus = latest.status;
+      this.lastStartedAt = latest.startedAt;
+      this.lastSubmittedAt = latest.submittedAt;
+      this.latestPercentage = latest.percentage !== null ? latest.percentage.toString() : null;
+    }
+  }
+}
+
+export class QuizAssignmentMonitorResult {
+  @ApiProperty({ type: QuizAssignmentResult }) assignment: QuizAssignmentResult;
+  @ApiProperty({ type: [StudentMonitorRowResult] }) students: StudentMonitorRowResult[];
+  @ApiProperty({ description: 'Counts by status for the dashboard summary' })
+  summary: {
+    notStarted: number;
+    inProgress: number;
+    submitted: number;
+    grading: number;
+    graded: number;
+  };
+
+  constructor(assignment: QuizAssignmentResult, students: StudentMonitorRowResult[]) {
+    this.assignment = assignment;
+    this.students = students;
+    this.summary = {
+      notStarted: students.filter((s) => s.attemptStatus === 'NOT_STARTED').length,
+      inProgress: students.filter((s) => s.attemptStatus === 'IN_PROGRESS').length,
+      submitted: students.filter((s) => s.attemptStatus === 'SUBMITTED').length,
+      grading: students.filter((s) => s.attemptStatus === 'GRADING').length,
+      graded: students.filter((s) => s.attemptStatus === 'GRADED').length,
+    };
+  }
+}
+
+// ---- Final results listing ----
+
+export class StudentResultRowResult {
+  @ApiProperty() studentId: string;
+  @ApiProperty() studentNo: string;
+  @ApiProperty() firstName: string;
+  @ApiProperty() lastName: string;
+  @ApiProperty() attemptNumber: number;
+  @ApiProperty() submittedAt: Date | null;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal as string' })
+  totalScore: string | null;
+  @ApiProperty({ description: 'Decimal as string' })
+  maxScore: string;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal as string' })
+  percentage: string | null;
+  @ApiProperty({ enum: ['SUBMITTED', 'GRADING', 'GRADED'] })
+  status: QuizAttemptStatus;
+
+  constructor(
+    attempt: Pick<
+      QuizAttempt,
+      'attemptNumber' | 'submittedAt' | 'totalScore' | 'maxScore' | 'percentage' | 'status'
+    >,
+    student: StudentForMonitor,
+  ) {
+    this.studentId = student.id;
+    this.studentNo = student.studentNo;
+    this.firstName = student.user.firstName;
+    this.lastName = student.user.lastName;
+    this.attemptNumber = attempt.attemptNumber;
+    this.submittedAt = attempt.submittedAt;
+    this.totalScore = attempt.totalScore !== null ? attempt.totalScore.toString() : null;
+    this.maxScore = attempt.maxScore.toString();
+    this.percentage = attempt.percentage !== null ? attempt.percentage.toString() : null;
+    this.status = attempt.status;
+  }
+}
+
+export class QuizAssignmentResultsResult {
+  @ApiProperty({ type: QuizAssignmentResult }) assignment: QuizAssignmentResult;
+  @ApiProperty({ type: [StudentResultRowResult] }) attempts: StudentResultRowResult[];
+
+  constructor(assignment: QuizAssignmentResult, attempts: StudentResultRowResult[]) {
+    this.assignment = assignment;
+    this.attempts = attempts;
+  }
+}

--- a/src/components/quiz-attempts/dto/index.ts
+++ b/src/components/quiz-attempts/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './start-attempt.dto';
+export * from './save-responses.dto';
+export * from './page-event.dto';

--- a/src/components/quiz-attempts/dto/page-event.dto.ts
+++ b/src/components/quiz-attempts/dto/page-event.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsIn, IsString } from 'class-validator';
+
+export class PageEventDto {
+  @ApiProperty({ enum: ['HIDDEN', 'VISIBLE', 'BLUR', 'FOCUS', 'PASTE'] })
+  @IsString()
+  @IsIn(['HIDDEN', 'VISIBLE', 'BLUR', 'FOCUS', 'PASTE'])
+  event: 'HIDDEN' | 'VISIBLE' | 'BLUR' | 'FOCUS' | 'PASTE';
+
+  @ApiProperty({ description: 'Client timestamp (ISO). Server also records its own.' })
+  @IsDateString()
+  ts: string;
+}

--- a/src/components/quiz-attempts/dto/save-responses.dto.ts
+++ b/src/components/quiz-attempts/dto/save-responses.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsObject,
+  IsOptional,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
+
+export class ResponseEntryDto {
+  @ApiProperty()
+  @IsUUID()
+  questionId: string;
+
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description:
+      "Per-type response shape. MCQ_SINGLE: { selectedOptionId }. MCQ_MULTI: { selectedOptionIds: string[] }. TRUE_FALSE: { value: boolean }. NUMERIC: { value: number, unit?: string }. SHORT_ANSWER: { text: string }. Pass null to clear an answer.",
+  })
+  @IsOptional()
+  @IsObject()
+  responseJson: Record<string, unknown> | null;
+}
+
+export class SaveResponsesDto {
+  @ApiProperty({
+    type: [ResponseEntryDto],
+    description: 'One or more response updates. Server upserts in a transaction.',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => ResponseEntryDto)
+  responses: ResponseEntryDto[];
+}

--- a/src/components/quiz-attempts/dto/start-attempt.dto.ts
+++ b/src/components/quiz-attempts/dto/start-attempt.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class StartAttemptDto {
+  @ApiProperty({ description: 'QuizAssignment to attempt' })
+  @IsUUID()
+  quizAssignmentId: string;
+}

--- a/src/components/quiz-attempts/grading/graders.ts
+++ b/src/components/quiz-attempts/grading/graders.ts
@@ -1,0 +1,113 @@
+import { PartialCreditMode, QuestionType } from '@prisma/client';
+
+export interface GraderQuestionContext {
+  type: QuestionType;
+  options: { id: string; isCorrect: boolean }[];
+  config: Record<string, unknown> | null;
+  partialCreditMode: PartialCreditMode | null;
+}
+
+/**
+ * Returns a fraction in [0, 1]. Multiplied by the question's snapshot weight
+ * to yield pointsAwarded. Returns 0 for malformed responses (no exception)
+ * so a single bad response can't poison the whole attempt.
+ */
+export function gradeResponse(
+  response: unknown,
+  question: GraderQuestionContext,
+): number {
+  if (response == null || typeof response !== 'object') return 0;
+  const r = response as Record<string, unknown>;
+
+  switch (question.type) {
+    case QuestionType.MCQ_SINGLE: {
+      const selected = r.selectedOptionId;
+      if (typeof selected !== 'string') return 0;
+      const correct = question.options.find((o) => o.isCorrect);
+      return correct && correct.id === selected ? 1 : 0;
+    }
+    case QuestionType.MCQ_MULTI: {
+      const selectedIds = Array.isArray(r.selectedOptionIds)
+        ? (r.selectedOptionIds as unknown[]).filter((s): s is string => typeof s === 'string')
+        : null;
+      if (!selectedIds) return 0;
+      const correctSet = new Set(question.options.filter((o) => o.isCorrect).map((o) => o.id));
+      const totalCorrect = correctSet.size;
+      if (totalCorrect === 0) return 0;
+
+      const correctSelected = selectedIds.filter((id) => correctSet.has(id)).length;
+      const incorrectSelected = selectedIds.filter((id) => !correctSet.has(id)).length;
+
+      if (question.partialCreditMode === PartialCreditMode.PROPORTIONAL) {
+        const fraction = (correctSelected - incorrectSelected) / totalCorrect;
+        return Math.max(0, Math.min(1, fraction));
+      }
+      // all-or-nothing
+      const allCorrectChosen = correctSelected === totalCorrect;
+      const noneIncorrectChosen = incorrectSelected === 0;
+      return allCorrectChosen && noneIncorrectChosen ? 1 : 0;
+    }
+    case QuestionType.TRUE_FALSE: {
+      const cfg = question.config as { correctAnswer?: boolean } | null;
+      if (!cfg || typeof cfg.correctAnswer !== 'boolean') return 0;
+      const value = r.value;
+      if (typeof value !== 'boolean') return 0;
+      return value === cfg.correctAnswer ? 1 : 0;
+    }
+    case QuestionType.NUMERIC: {
+      const cfg = question.config as
+        | {
+            correctAnswer?: number;
+            tolerance?: number;
+            unit?: string;
+            toleranceMode?: 'ABSOLUTE' | 'PERCENT';
+          }
+        | null;
+      if (
+        !cfg ||
+        typeof cfg.correctAnswer !== 'number' ||
+        !Number.isFinite(cfg.correctAnswer) ||
+        typeof cfg.tolerance !== 'number' ||
+        !Number.isFinite(cfg.tolerance) ||
+        cfg.tolerance < 0
+      ) {
+        return 0;
+      }
+      const value = r.value;
+      if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+      if (cfg.unit && r.unit !== cfg.unit) return 0;
+
+      const diff = Math.abs(value - cfg.correctAnswer);
+      const allowed =
+        cfg.toleranceMode === 'PERCENT'
+          ? Math.abs(cfg.correctAnswer) * (cfg.tolerance / 100)
+          : cfg.tolerance;
+      return diff <= allowed ? 1 : 0;
+    }
+    case QuestionType.SHORT_ANSWER: {
+      const cfg = question.config as
+        | {
+            acceptedAnswers?: string[];
+            caseSensitive?: boolean;
+            normalizeWhitespace?: boolean;
+          }
+        | null;
+      if (!cfg || !Array.isArray(cfg.acceptedAnswers) || cfg.acceptedAnswers.length === 0) {
+        return 0;
+      }
+      const text = r.text;
+      if (typeof text !== 'string') return 0;
+
+      const normalize = (s: string) => {
+        let n = s;
+        if (cfg.normalizeWhitespace !== false) n = n.trim().replace(/\s+/g, ' ');
+        if (!cfg.caseSensitive) n = n.toLowerCase();
+        return n;
+      };
+      const target = normalize(text);
+      return cfg.acceptedAnswers.some((a) => normalize(a) === target) ? 1 : 0;
+    }
+    default:
+      return 0;
+  }
+}

--- a/src/components/quiz-attempts/grading/grading.service.ts
+++ b/src/components/quiz-attempts/grading/grading.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Prisma, QuizAttemptStatus } from '@prisma/client';
+
+import { PrismaService } from '../../../prisma/prisma.service';
+import { gradeResponse } from './graders';
+
+@Injectable()
+export class GradingService {
+  private readonly logger = new Logger(GradingService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Grades every QuestionResponse on an attempt and rolls up totalScore /
+   * percentage / status. Idempotent — calling it on an already-GRADED
+   * attempt re-runs grading (useful if a question's correctness was
+   * corrected after the fact, though in v1 we never do that).
+   */
+  async gradeAttempt(attemptId: string): Promise<void> {
+    const attempt = await this.prisma.quizAttempt.findUnique({
+      where: { id: attemptId },
+      include: {
+        responses: {
+          include: {
+            question: {
+              select: {
+                id: true,
+                type: true,
+                config: true,
+                partialCreditMode: true,
+                options: { select: { id: true, isCorrect: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+    if (!attempt) throw new NotFoundException(`QuizAttempt ${attemptId} not found`);
+
+    if (
+      attempt.status !== QuizAttemptStatus.SUBMITTED &&
+      attempt.status !== QuizAttemptStatus.GRADING &&
+      attempt.status !== QuizAttemptStatus.GRADED
+    ) {
+      this.logger.warn(
+        `Skipping grade for attempt ${attemptId}: status=${attempt.status} (expected SUBMITTED/GRADING/GRADED)`,
+      );
+      return;
+    }
+
+    await this.prisma.quizAttempt.update({
+      where: { id: attemptId },
+      data: { status: QuizAttemptStatus.GRADING },
+    });
+
+    let totalScore = 0;
+    const updates: Array<Promise<unknown>> = [];
+
+    for (const response of attempt.responses) {
+      const fraction = gradeResponse(response.responseJson, {
+        type: response.question.type,
+        options: response.question.options,
+        config: response.question.config as Record<string, unknown> | null,
+        partialCreditMode: response.question.partialCreditMode,
+      });
+      const weight = Number(response.weight.toString());
+      const pointsAwarded = +(weight * fraction).toFixed(2);
+      totalScore += pointsAwarded;
+
+      updates.push(
+        this.prisma.questionResponse.update({
+          where: { id: response.id },
+          data: {
+            pointsAwarded,
+            isCorrect: fraction === 1,
+            autoGraded: true,
+          },
+        }),
+      );
+    }
+
+    await Promise.all(updates);
+
+    const maxScore = Number(attempt.maxScore.toString());
+    const percentage = maxScore > 0 ? +((totalScore / maxScore) * 100).toFixed(2) : 0;
+
+    await this.prisma.quizAttempt.update({
+      where: { id: attemptId },
+      data: {
+        totalScore: new Prisma.Decimal(totalScore.toFixed(2)),
+        percentage: new Prisma.Decimal(percentage.toFixed(2)),
+        status: QuizAttemptStatus.GRADED,
+      },
+    });
+
+    this.logger.log(
+      `Graded attempt ${attemptId}: ${totalScore}/${maxScore} (${percentage}%)`,
+    );
+  }
+}

--- a/src/components/quiz-attempts/processors/quiz-attempts.processor.ts
+++ b/src/components/quiz-attempts/processors/quiz-attempts.processor.ts
@@ -1,0 +1,62 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+
+import { GradingService } from '../grading/grading.service';
+import { QuizAttemptsService } from '../quiz-attempts.service';
+import {
+  GradeAttemptJobData,
+  QUIZ_ATTEMPTS_QUEUE,
+  QuizAttemptsJob,
+} from '../types';
+
+@Processor(QUIZ_ATTEMPTS_QUEUE)
+export class QuizAttemptsProcessor extends WorkerHost {
+  private readonly logger = new Logger(QuizAttemptsProcessor.name);
+
+  constructor(
+    private readonly grading: GradingService,
+    private readonly attempts: QuizAttemptsService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<unknown>) {
+    switch (job.name) {
+      case QuizAttemptsJob.GRADE_ATTEMPT:
+        return this.handleGradeAttempt(job as Job<GradeAttemptJobData>);
+      case QuizAttemptsJob.AUTO_SUBMIT_TICK:
+        return this.handleAutoSubmitTick();
+      default:
+        this.logger.warn(`Unknown job: ${job.name}`);
+        return undefined;
+    }
+  }
+
+  private async handleGradeAttempt(job: Job<GradeAttemptJobData>) {
+    const { attemptId } = job.data;
+    await this.grading.gradeAttempt(attemptId);
+  }
+
+  private async handleAutoSubmitTick() {
+    const now = new Date();
+    const expired = await this.attempts.findExpiredInProgressAttempts(now, 100);
+    if (expired.length > 0) {
+      this.logger.log(`Auto-submitting ${expired.length} expired attempts`);
+      for (const { id } of expired) {
+        try {
+          await this.attempts.autoSubmitExpired(id);
+        } catch (err) {
+          this.logger.error(`Auto-submit failed for ${id} (will retry next tick)`, err);
+        }
+      }
+    }
+    // Sweep stale attempts whose dueAt is past the recovery window — these
+    // have likely failed normal auto-submit repeatedly and need a force flip
+    // so they stop polluting the tick.
+    const ancientCount = await this.attempts.forceSubmitAncientStuckAttempts(now);
+    if (ancientCount > 0) {
+      this.logger.warn(`Force-submitted ${ancientCount} stale attempts past recovery window`);
+    }
+  }
+}

--- a/src/components/quiz-attempts/quiz-attempts.controller.ts
+++ b/src/components/quiz-attempts/quiz-attempts.controller.ts
@@ -1,0 +1,135 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { AssessmentsFeatureGuard } from '../../common/guards';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { PageEventDto, SaveResponsesDto, StartAttemptDto } from './dto';
+import { QuizAttemptsService } from './quiz-attempts.service';
+import {
+  GetMyAttemptSwagger,
+  ListMyAttemptsSwagger,
+  PageEventSwagger,
+  SaveResponsesSwagger,
+  StartAttemptSwagger,
+  SubmitAttemptSwagger,
+} from './quiz-attempts.swagger';
+import {
+  AttemptResult,
+  AttemptSummaryResult,
+  AttemptsListResult,
+  PageEventResult,
+  SaveResponsesResult,
+  StartAttemptResult,
+  SubmitAttemptResult,
+} from './results/attempt.result';
+
+class ListAttemptsQueryDto {
+  @IsOptional()
+  @IsUUID()
+  quizAssignmentId?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}
+
+@Controller('quiz-attempts')
+@ApiTags('Quiz Attempts')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class QuizAttemptsController {
+  constructor(private readonly service: QuizAttemptsService) {}
+
+  @Post('start')
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(AssessmentsFeatureGuard)
+  @StartAttemptSwagger()
+  async start(@GetCurrentUserId() userId: string, @Body() dto: StartAttemptDto) {
+    const view = await this.service.start(userId, dto);
+    return new StartAttemptResult(new AttemptResult(view.attempt, view.ctx, view.quizId));
+  }
+
+  @Get('mine')
+  @ListMyAttemptsSwagger()
+  async listMine(
+    @GetCurrentUserId() userId: string,
+    @Query() query: ListAttemptsQueryDto,
+  ) {
+    const { items, total, page, limit } = await this.service.listMine(userId, query);
+    const summaries = items.map((a) => {
+      const settings = (a.quizAssignment.quiz.defaultSettings ?? {}) as Record<string, unknown>;
+      const showResultsImmediately =
+        a.quizAssignment.showResultsImmediately ??
+        (typeof settings.showResultsImmediately === 'boolean'
+          ? settings.showResultsImmediately
+          : false);
+      const resultsVisible =
+        showResultsImmediately || a.quizAssignment.resultsReleasedAt !== null;
+      return new AttemptSummaryResult(a, resultsVisible);
+    });
+    return new AttemptsListResult(summaries, total, page, limit);
+  }
+
+  @Get(':id')
+  @GetMyAttemptSwagger()
+  async getMine(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const view = await this.service.getMine(userId, id);
+    return new AttemptResult(view.attempt, view.ctx, view.quizId);
+  }
+
+  @Patch(':id/responses')
+  @SaveResponsesSwagger()
+  async saveResponses(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: SaveResponsesDto,
+  ) {
+    const { saved, dueAt } = await this.service.saveResponses(userId, id, dto);
+    return new SaveResponsesResult(saved, dueAt);
+  }
+
+  @Post(':id/submit')
+  @HttpCode(HttpStatus.OK)
+  @SubmitAttemptSwagger()
+  async submit(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const attempt = await this.service.submit(userId, id);
+    // resultsVisible irrelevant immediately after submit; set false for the summary.
+    return new SubmitAttemptResult(new AttemptSummaryResult(attempt, false));
+  }
+
+  @Post(':id/page-event')
+  @HttpCode(HttpStatus.OK)
+  @PageEventSwagger()
+  async pageEvent(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: PageEventDto,
+  ) {
+    await this.service.pageEvent(userId, id, dto);
+    return new PageEventResult();
+  }
+}

--- a/src/components/quiz-attempts/quiz-attempts.module.ts
+++ b/src/components/quiz-attempts/quiz-attempts.module.ts
@@ -1,0 +1,32 @@
+import { BullModule } from '@nestjs/bullmq';
+import { Module } from '@nestjs/common';
+
+import { AssessmentsFeatureGuard } from '../../common/guards';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { GradingService } from './grading/grading.service';
+import { QuizAttemptsProcessor } from './processors/quiz-attempts.processor';
+import { QuizAttemptsController } from './quiz-attempts.controller';
+import { QuizAttemptsQueue } from './quiz-attempts.queue';
+import { QuizAttemptsService } from './quiz-attempts.service';
+import { QUIZ_ATTEMPTS_QUEUE } from './types';
+
+@Module({
+  imports: [
+    PrismaModule,
+    AuthModule,
+    BullModule.registerQueue({ name: QUIZ_ATTEMPTS_QUEUE }),
+  ],
+  controllers: [QuizAttemptsController],
+  providers: [
+    QuizAttemptsService,
+    QuizAttemptsQueue,
+    QuizAttemptsProcessor,
+    GradingService,
+    Encryptor,
+    AssessmentsFeatureGuard,
+  ],
+  exports: [QuizAttemptsService, GradingService],
+})
+export class QuizAttemptsModule {}

--- a/src/components/quiz-attempts/quiz-attempts.queue.ts
+++ b/src/components/quiz-attempts/quiz-attempts.queue.ts
@@ -1,0 +1,52 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { Queue } from 'bullmq';
+
+import {
+  AUTO_SUBMIT_TICK_INTERVAL_MS,
+  AUTO_SUBMIT_TICK_JOB_ID,
+  GradeAttemptJobData,
+  QUIZ_ATTEMPTS_QUEUE,
+  QuizAttemptsJob,
+} from './types';
+
+/**
+ * Producer + bootstrap. Schedules the singleton AUTO_SUBMIT_TICK repeatable
+ * job at app start so we have one cron tick across the cluster.
+ */
+@Injectable()
+export class QuizAttemptsQueue implements OnApplicationBootstrap {
+  private readonly logger = new Logger(QuizAttemptsQueue.name);
+
+  constructor(@InjectQueue(QUIZ_ATTEMPTS_QUEUE) private readonly queue: Queue) {}
+
+  async onApplicationBootstrap() {
+    try {
+      await this.queue.add(
+        QuizAttemptsJob.AUTO_SUBMIT_TICK,
+        { scheduledAt: new Date().toISOString() },
+        {
+          repeat: { every: AUTO_SUBMIT_TICK_INTERVAL_MS },
+          jobId: AUTO_SUBMIT_TICK_JOB_ID,
+          removeOnComplete: 100,
+          removeOnFail: 100,
+        },
+      );
+      this.logger.log(
+        `Auto-submit tick scheduled every ${AUTO_SUBMIT_TICK_INTERVAL_MS}ms`,
+      );
+    } catch (err) {
+      this.logger.error('Failed to schedule auto-submit tick', err);
+    }
+  }
+
+  async enqueueGradeAttempt(attemptId: string) {
+    const data: GradeAttemptJobData = { attemptId };
+    await this.queue.add(QuizAttemptsJob.GRADE_ATTEMPT, data, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5_000 },
+      removeOnComplete: 200,
+      removeOnFail: 100,
+    });
+  }
+}

--- a/src/components/quiz-attempts/quiz-attempts.service.ts
+++ b/src/components/quiz-attempts/quiz-attempts.service.ts
@@ -1,0 +1,547 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  Prisma,
+  Quiz,
+  QuizAttemptOverride,
+  QuizAttemptStatus,
+  QuizDeliveryMode,
+  QuizOverrideType,
+} from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { UserTypes } from '../users/constants';
+import {
+  PageEventDto,
+  SaveResponsesDto,
+  StartAttemptDto,
+} from './dto';
+import { GradingService } from './grading/grading.service';
+import { QuizAttemptsQueue } from './quiz-attempts.queue';
+import {
+  UNIT_RATE_NAIRA,
+  computeChargeableUnits,
+  resolveWaiver,
+} from '../quiz-billing/pricing.constants';
+
+const ATTEMPT_DETAIL_INCLUDE = {
+  responses: {
+    include: {
+      question: {
+        include: {
+          options: true,
+          quizUses: true,
+        },
+      },
+    },
+  },
+} as const satisfies Prisma.QuizAttemptInclude;
+
+interface AssignmentForStart {
+  id: string;
+  quizId: string;
+  quizVersion: number;
+  classArmSubject: { classArmId: string };
+  mode: QuizDeliveryMode;
+  windowOpensAt: Date;
+  windowClosesAt: Date;
+  durationMinutes: number;
+  syncGracePeriodSeconds: number | null;
+  maxAttempts: number;
+  showResultsImmediately: boolean | null;
+  showCorrectAnswers: boolean | null;
+  resultsReleasedAt: Date | null;
+  status: string;
+  deletedAt: Date | null;
+  termId: string;
+  quiz: Pick<Quiz, 'id' | 'status' | 'defaultSettings'>;
+}
+
+@Injectable()
+export class QuizAttemptsService {
+  private readonly logger = new Logger(QuizAttemptsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly queue: QuizAttemptsQueue,
+    private readonly grading: GradingService,
+  ) {}
+
+  // ---------- public API ----------
+
+  async start(callerUserId: string, dto: StartAttemptDto) {
+    const studentId = await this.requireStudentId(callerUserId);
+
+    const assignment = await this.prisma.quizAssignment.findFirst({
+      where: { id: dto.quizAssignmentId, deletedAt: null },
+      include: {
+        classArmSubject: { select: { classArmId: true } },
+        quiz: { select: { id: true, status: true, defaultSettings: true } },
+      },
+    });
+    if (!assignment) throw new NotFoundException('Quiz assignment not found');
+    await this.assertEnrolled(studentId, assignment.classArmSubject.classArmId);
+
+    // If they already have an IN_PROGRESS attempt for this assignment, return it
+    // (refresh-resilient — don't burn an attempt on every page reload).
+    const existing = await this.prisma.quizAttempt.findFirst({
+      where: {
+        quizAssignmentId: assignment.id,
+        studentId,
+        status: QuizAttemptStatus.IN_PROGRESS,
+      },
+    });
+    if (existing) {
+      return this.fetchView(existing.id, callerUserId);
+    }
+
+    const overrides = await this.prisma.quizAttemptOverride.findMany({
+      where: { quizAssignmentId: assignment.id, studentId },
+    });
+
+    const now = new Date();
+    this.assertWindowAllowsStart(assignment, overrides, now);
+
+    const usedAttempts = await this.prisma.quizAttempt.count({
+      where: { quizAssignmentId: assignment.id, studentId },
+    });
+    const effectiveMax = this.effectiveMaxAttempts(assignment, overrides);
+    if (usedAttempts >= effectiveMax) {
+      throw new ConflictException(
+        `Maximum attempts reached (${effectiveMax}). Ask your teacher for a RETRY override if needed.`,
+      );
+    }
+
+    const dueAt = this.computeDueAt(assignment, overrides, now);
+
+    const quizQuestions = await this.prisma.quizQuestion.findMany({
+      where: { quizId: assignment.quizId },
+      include: { question: { select: { id: true, weight: true } } },
+      orderBy: { order: 'asc' },
+    });
+    if (quizQuestions.length === 0) {
+      throw new BadRequestException('This quiz has no questions — ask your teacher');
+    }
+
+    const maxScore = quizQuestions.reduce((sum, qq) => {
+      const w = (qq.weightOverride ?? qq.question.weight) as { toString(): string };
+      return sum + Number(w.toString());
+    }, 0);
+
+    const lastNumber = await this.prisma.quizAttempt.findFirst({
+      where: { quizAssignmentId: assignment.id, studentId },
+      orderBy: { attemptNumber: 'desc' },
+      select: { attemptNumber: true },
+    });
+    const attemptNumber = (lastNumber?.attemptNumber ?? 0) + 1;
+
+    const studentRecord = await this.prisma.student.findUniqueOrThrow({
+      where: { id: studentId },
+      select: { user: { select: { schoolId: true, school: { select: { createdAt: true } } } } },
+    });
+    const schoolId = studentRecord.user.schoolId;
+    if (!schoolId || !studentRecord.user.school) {
+      throw new BadRequestException('Student is not associated with a school');
+    }
+    const units = computeChargeableUnits(assignment.durationMinutes, quizQuestions.length);
+    const waiver = resolveWaiver(studentRecord.user.school.createdAt);
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      const attempt = await tx.quizAttempt.create({
+        data: {
+          quizAssignmentId: assignment.id,
+          studentId,
+          attemptNumber,
+          startedAt: now,
+          dueAt,
+          status: QuizAttemptStatus.IN_PROGRESS,
+          maxScore: new Prisma.Decimal(maxScore.toFixed(2)),
+        },
+      });
+      await tx.questionResponse.createMany({
+        data: quizQuestions.map((qq) => ({
+          attemptId: attempt.id,
+          questionId: qq.questionId,
+          weight: qq.weightOverride ?? qq.question.weight,
+        })),
+      });
+      await tx.quizUsageEvent.create({
+        data: {
+          schoolId,
+          quizAttemptId: attempt.id,
+          quizAssignmentId: assignment.id,
+          studentId,
+          durationMinutes: assignment.durationMinutes,
+          questionCount: quizQuestions.length,
+          chargeableUnits: new Prisma.Decimal(units.toFixed(2)),
+          unitRateSnapshot: new Prisma.Decimal(UNIT_RATE_NAIRA.toFixed(4)),
+          amountKobo: Math.round(units * UNIT_RATE_NAIRA * 100),
+          isWaived: waiver.isWaived,
+          waiverReason: waiver.reason,
+        },
+      });
+      return attempt;
+    });
+
+    return this.fetchView(created.id, callerUserId);
+  }
+
+  async saveResponses(callerUserId: string, attemptId: string, dto: SaveResponsesDto) {
+    const studentId = await this.requireStudentId(callerUserId);
+    const attempt = await this.findOwnedAttemptOrThrow(attemptId, studentId);
+
+    if (attempt.status !== QuizAttemptStatus.IN_PROGRESS) {
+      throw new ConflictException('Attempt is no longer accepting responses');
+    }
+    const now = new Date();
+    if (now >= attempt.dueAt) {
+      // Auto-submit + reject
+      await this.markSubmittedAndEnqueue(attemptId, true);
+      throw new ConflictException('Time is up — your attempt has been auto-submitted');
+    }
+
+    // Validate every questionId is attached to this attempt.
+    const responseIds = await this.prisma.questionResponse.findMany({
+      where: { attemptId, questionId: { in: dto.responses.map((r) => r.questionId) } },
+      select: { id: true, questionId: true },
+    });
+    const indexByQuestion = new Map(responseIds.map((r) => [r.questionId, r.id]));
+    const unknown = dto.responses.filter((r) => !indexByQuestion.has(r.questionId));
+    if (unknown.length > 0) {
+      throw new BadRequestException(
+        `Question(s) not part of this attempt: ${unknown.map((u) => u.questionId).join(', ')}`,
+      );
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const entry of dto.responses) {
+        await tx.questionResponse.update({
+          where: { id: indexByQuestion.get(entry.questionId)! },
+          data: { responseJson: (entry.responseJson ?? null) as Prisma.InputJsonValue | null },
+        });
+      }
+    });
+
+    return { saved: dto.responses.length, dueAt: attempt.dueAt };
+  }
+
+  async submit(callerUserId: string, attemptId: string) {
+    const studentId = await this.requireStudentId(callerUserId);
+    const attempt = await this.findOwnedAttemptOrThrow(attemptId, studentId);
+    if (attempt.status !== QuizAttemptStatus.IN_PROGRESS) {
+      throw new ConflictException('Attempt is not IN_PROGRESS');
+    }
+
+    const now = new Date();
+    const late = now > attempt.dueAt;
+
+    await this.markSubmittedAndEnqueue(attemptId, late);
+
+    return this.prisma.quizAttempt.findUniqueOrThrow({ where: { id: attemptId } });
+  }
+
+  async pageEvent(callerUserId: string, attemptId: string, dto: PageEventDto) {
+    const studentId = await this.requireStudentId(callerUserId);
+    const attempt = await this.findOwnedAttemptOrThrow(attemptId, studentId);
+    if (attempt.status !== QuizAttemptStatus.IN_PROGRESS) return; // silently no-op
+
+    const existing = Array.isArray(attempt.pageVisibilityEvents)
+      ? (attempt.pageVisibilityEvents as unknown[])
+      : [];
+    const next = [
+      ...existing,
+      {
+        event: dto.event,
+        clientTs: dto.ts,
+        serverTs: new Date().toISOString(),
+      },
+    ];
+    await this.prisma.quizAttempt.update({
+      where: { id: attemptId },
+      data: { pageVisibilityEvents: next as Prisma.InputJsonValue },
+    });
+  }
+
+  async listMine(
+    callerUserId: string,
+    query: { quizAssignmentId?: string; page?: number; limit?: number },
+  ) {
+    const studentId = await this.requireStudentId(callerUserId);
+    const where: Prisma.QuizAttemptWhereInput = { studentId };
+    if (query.quizAssignmentId) where.quizAssignmentId = query.quizAssignmentId;
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const [items, total] = await Promise.all([
+      this.prisma.quizAttempt.findMany({
+        where,
+        orderBy: [{ startedAt: 'desc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+        include: { quizAssignment: { select: { id: true, showResultsImmediately: true, resultsReleasedAt: true, quiz: { select: { defaultSettings: true } } } } },
+      }),
+      this.prisma.quizAttempt.count({ where }),
+    ]);
+    return { items, total, page, limit };
+  }
+
+  async getMine(callerUserId: string, attemptId: string) {
+    const studentId = await this.requireStudentId(callerUserId);
+    await this.findOwnedAttemptOrThrow(attemptId, studentId);
+    return this.fetchView(attemptId, callerUserId);
+  }
+
+  // ---------- helpers used by processor / cron ----------
+
+  /** Used by AUTO_SUBMIT_TICK processor to find expired in-progress attempts. */
+  /**
+   * Returns expired IN_PROGRESS attempts for the auto-submit tick, but only
+   * those whose dueAt is within the recovery window (default 24h). Older
+   * stuck attempts are handled by `forceSubmitAncientStuckAttempts` so we
+   * don't loop on a permanently broken attempt forever.
+   */
+  async findExpiredInProgressAttempts(now: Date, limit = 100, recoveryWindowMs = 24 * 60 * 60 * 1000) {
+    const cutoff = new Date(now.getTime() - recoveryWindowMs);
+    return this.prisma.quizAttempt.findMany({
+      where: {
+        status: QuizAttemptStatus.IN_PROGRESS,
+        dueAt: { lt: now, gte: cutoff },
+      },
+      select: { id: true },
+      take: limit,
+    });
+  }
+
+  /**
+   * Force-submits attempts whose dueAt is older than the recovery window and
+   * are still IN_PROGRESS — typically because earlier auto-submit attempts
+   * raised a permanent error. Bypasses the queued grading path and writes
+   * the status directly so the attempt no longer pollutes the tick.
+   */
+  async forceSubmitAncientStuckAttempts(now: Date, recoveryWindowMs = 24 * 60 * 60 * 1000, limit = 50) {
+    const cutoff = new Date(now.getTime() - recoveryWindowMs);
+    const ancient = await this.prisma.quizAttempt.findMany({
+      where: { status: QuizAttemptStatus.IN_PROGRESS, dueAt: { lt: cutoff } },
+      select: { id: true },
+      take: limit,
+    });
+    for (const { id } of ancient) {
+      try {
+        await this.prisma.quizAttempt.update({
+          where: { id },
+          data: {
+            status: QuizAttemptStatus.SUBMITTED,
+            submittedAt: now,
+            autoSubmitted: true,
+          },
+        });
+        // Best-effort grading kick — failures here don't requeue.
+        await this.queue.enqueueGradeAttempt(id).catch((err) => {
+          this.logger.error(`Force-submit grading enqueue failed for ${id}`, err);
+        });
+        this.logger.warn(`Force-submitted stale attempt ${id} (dueAt > ${recoveryWindowMs}ms ago)`);
+      } catch (err) {
+        this.logger.error(`Force-submit failed for ${id}`, err);
+      }
+    }
+    return ancient.length;
+  }
+
+  async autoSubmitExpired(attemptId: string) {
+    await this.markSubmittedAndEnqueue(attemptId, true);
+  }
+
+  // ---------- internals ----------
+
+  private async fetchView(attemptId: string, callerUserId: string) {
+    const attempt = await this.prisma.quizAttempt.findUnique({
+      where: { id: attemptId },
+      include: {
+        ...ATTEMPT_DETAIL_INCLUDE,
+        quizAssignment: {
+          select: {
+            id: true,
+            quizId: true,
+            showResultsImmediately: true,
+            showCorrectAnswers: true,
+            resultsReleasedAt: true,
+            quiz: { select: { id: true, defaultSettings: true } },
+          },
+        },
+      },
+    });
+    if (!attempt) throw new NotFoundException('Attempt not found');
+
+    // ownership re-check (fetchView is called from start() too)
+    const studentId = await this.requireStudentId(callerUserId);
+    if (attempt.studentId !== studentId) {
+      throw new ForbiddenException('Not your attempt');
+    }
+
+    const { resultsVisible, showCorrectAnswers } = this.resolveVisibility(attempt.quizAssignment);
+    return {
+      attempt,
+      ctx: { resultsVisible, showCorrectAnswers },
+      quizId: attempt.quizAssignment.quizId,
+    };
+  }
+
+  private resolveVisibility(assignment: {
+    showResultsImmediately: boolean | null;
+    showCorrectAnswers: boolean | null;
+    resultsReleasedAt: Date | null;
+    quiz: { defaultSettings: unknown };
+  }) {
+    const settings = (assignment.quiz.defaultSettings ?? {}) as Record<string, unknown>;
+    const showResultsImmediately =
+      assignment.showResultsImmediately ??
+      (typeof settings.showResultsImmediately === 'boolean'
+        ? settings.showResultsImmediately
+        : false);
+    const showCorrectAnswers =
+      assignment.showCorrectAnswers ??
+      (typeof settings.showCorrectAnswers === 'boolean'
+        ? settings.showCorrectAnswers
+        : false);
+    const resultsVisible = showResultsImmediately || assignment.resultsReleasedAt !== null;
+    return { resultsVisible, showCorrectAnswers };
+  }
+
+  private async markSubmittedAndEnqueue(attemptId: string, autoSubmitted: boolean) {
+    await this.prisma.quizAttempt.update({
+      where: { id: attemptId },
+      data: {
+        status: QuizAttemptStatus.SUBMITTED,
+        submittedAt: new Date(),
+        autoSubmitted,
+      },
+    });
+    try {
+      await this.queue.enqueueGradeAttempt(attemptId);
+    } catch (queueErr) {
+      // Queue down? Fall back to inline grading so the student still gets a result.
+      this.logger.error(
+        `Failed to enqueue grading for attempt ${attemptId}; grading inline`,
+        queueErr,
+      );
+      try {
+        await this.grading.gradeAttempt(attemptId);
+      } catch (gradeErr) {
+        // Both paths failed. Attempt is SUBMITTED but never graded — mark it
+        // so it gets picked up by a future tick or a manual retry rather than
+        // being silently stuck without grading data.
+        this.logger.error(
+          `Inline grading also failed for attempt ${attemptId}; leaving in SUBMITTED for retry`,
+          gradeErr,
+        );
+        // Defensive re-enqueue attempt — best-effort, swallowed if queue still down.
+        await this.queue.enqueueGradeAttempt(attemptId).catch(() => undefined);
+      }
+    }
+  }
+
+  private async findOwnedAttemptOrThrow(attemptId: string, studentId: string) {
+    const attempt = await this.prisma.quizAttempt.findUnique({ where: { id: attemptId } });
+    if (!attempt) throw new NotFoundException('Attempt not found');
+    if (attempt.studentId !== studentId) throw new ForbiddenException('Not your attempt');
+    return attempt;
+  }
+
+  private async requireStudentId(userId: string): Promise<string> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, type: true, student: { select: { id: true } } },
+    });
+    if (!user || user.type !== UserTypes.STUDENT || !user.student) {
+      throw new ForbiddenException('Only students can use this endpoint');
+    }
+    return user.student.id;
+  }
+
+  private async assertEnrolled(studentId: string, classArmId: string) {
+    const enrolment = await this.prisma.classArmStudent.findFirst({
+      where: { studentId, classArmId, isActive: true, deletedAt: null },
+    });
+    if (!enrolment) {
+      throw new ForbiddenException('You are not enrolled in this class arm');
+    }
+  }
+
+  private assertWindowAllowsStart(
+    assignment: AssignmentForStart,
+    overrides: QuizAttemptOverride[],
+    now: Date,
+  ) {
+    if (assignment.quiz.status !== 'PUBLISHED') {
+      throw new BadRequestException('Quiz is no longer available');
+    }
+    if (now < assignment.windowOpensAt) {
+      throw new ConflictException('Window has not opened yet');
+    }
+
+    const extended = this.effectiveWindowClosesAt(assignment, overrides);
+    if (now >= extended) {
+      throw new ConflictException('Window has closed');
+    }
+
+    if (assignment.mode === QuizDeliveryMode.SYNC_START) {
+      const grace = assignment.syncGracePeriodSeconds ?? 0;
+      const lateCutoff = new Date(assignment.windowOpensAt.getTime() + grace * 1000);
+      if (now > lateCutoff) {
+        throw new ConflictException(
+          `Sync-start grace period (${grace}s) elapsed — too late to join`,
+        );
+      }
+    }
+  }
+
+  private effectiveMaxAttempts(
+    assignment: { maxAttempts: number },
+    overrides: QuizAttemptOverride[],
+  ): number {
+    const extra = overrides
+      .filter((o) => o.type === QuizOverrideType.RETRY)
+      .reduce((sum, o) => sum + (o.extraAttempts ?? 0), 0);
+    return assignment.maxAttempts + extra;
+  }
+
+  private effectiveWindowClosesAt(
+    assignment: { windowClosesAt: Date },
+    overrides: QuizAttemptOverride[],
+  ): Date {
+    let latest = assignment.windowClosesAt;
+    for (const o of overrides) {
+      if (o.type === QuizOverrideType.EXTEND_WINDOW && o.newWindowClosesAt) {
+        if (o.newWindowClosesAt > latest) latest = o.newWindowClosesAt;
+      }
+    }
+    return latest;
+  }
+
+  private computeDueAt(
+    assignment: AssignmentForStart,
+    overrides: QuizAttemptOverride[],
+    now: Date,
+  ): Date {
+    const extraMs = overrides
+      .filter((o) => o.type === QuizOverrideType.EXTRA_TIME)
+      .reduce((sum, o) => sum + (o.extraMinutes ?? 0) * 60_000, 0);
+
+    const cap = this.effectiveWindowClosesAt(assignment, overrides);
+    const baseMs = assignment.durationMinutes * 60_000;
+
+    let dueAt: Date;
+    if (assignment.mode === QuizDeliveryMode.SYNC_START) {
+      dueAt = new Date(assignment.windowOpensAt.getTime() + baseMs + extraMs);
+    } else {
+      dueAt = new Date(now.getTime() + baseMs + extraMs);
+    }
+    return dueAt < cap ? dueAt : cap;
+  }
+}
+

--- a/src/components/quiz-attempts/quiz-attempts.swagger.ts
+++ b/src/components/quiz-attempts/quiz-attempts.swagger.ts
@@ -1,0 +1,83 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+import { PageEventDto, SaveResponsesDto, StartAttemptDto } from './dto';
+import {
+  AttemptResult,
+  AttemptsListResult,
+  PageEventResult,
+  SaveResponsesResult,
+  StartAttemptResult,
+  SubmitAttemptResult,
+} from './results/attempt.result';
+
+export function StartAttemptSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        "Start (or resume) an attempt. Returns the attempt with stripped questions. If an IN_PROGRESS attempt already exists for this assignment, returns it instead of creating a new one.",
+    }),
+    ApiBody({ type: StartAttemptDto }),
+    ApiResponse({ status: 201, type: StartAttemptResult }),
+    ApiResponse({ status: 403, description: 'Not enrolled in the class arm' }),
+    ApiResponse({ status: 409, description: 'Window closed / max attempts reached / SYNC_START grace passed' }),
+  );
+}
+
+export function SaveResponsesSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Autosave responses for the in-progress attempt. Returns the server-canonical dueAt — client should re-sync the timer.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAttempt id' }),
+    ApiBody({ type: SaveResponsesDto }),
+    ApiResponse({ status: 200, type: SaveResponsesResult }),
+    ApiResponse({
+      status: 409,
+      description: 'Time is up — attempt has been auto-submitted, or status is no longer IN_PROGRESS',
+    }),
+  );
+}
+
+export function SubmitAttemptSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Submit the attempt early. Marks it SUBMITTED and enqueues grading. autoSubmitted=true if past dueAt.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAttempt id' }),
+    ApiResponse({ status: 200, type: SubmitAttemptResult }),
+    ApiResponse({ status: 409, description: 'Already submitted' }),
+  );
+}
+
+export function PageEventSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Append a page-visibility event to the attempt for anti-cheat trace (HIDDEN, BLUR, PASTE, etc).',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAttempt id' }),
+    ApiBody({ type: PageEventDto }),
+    ApiResponse({ status: 200, type: PageEventResult }),
+  );
+}
+
+export function ListMyAttemptsSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: "List the calling student's attempts" }),
+    ApiResponse({ status: 200, type: AttemptsListResult }),
+  );
+}
+
+export function GetMyAttemptSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Get attempt detail. Correctness + explanations + scores are included only when results are visible (showResultsImmediately or resultsReleasedAt set) AND showCorrectAnswers is true.',
+    }),
+    ApiParam({ name: 'id', description: 'QuizAttempt id' }),
+    ApiResponse({ status: 200, type: AttemptResult }),
+  );
+}

--- a/src/components/quiz-attempts/results/attempt.result.ts
+++ b/src/components/quiz-attempts/results/attempt.result.ts
@@ -1,0 +1,297 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  PartialCreditMode,
+  Question,
+  QuestionOption,
+  QuestionResponse,
+  QuestionType,
+  QuizAttempt,
+  QuizAttemptStatus,
+  QuizQuestion,
+} from '@prisma/client';
+
+export type AttemptForView = QuizAttempt & {
+  responses: (QuestionResponse & {
+    question: Question & { options: QuestionOption[]; quizUses: QuizQuestion[] };
+  })[];
+};
+
+export interface AttemptViewContext {
+  /** Whether scores + correctness should be exposed (after submission + release). */
+  resultsVisible: boolean;
+  /** Whether to expose per-question correct answer / explanation (only when results visible). */
+  showCorrectAnswers: boolean;
+}
+
+export class StudentOptionResult {
+  @ApiProperty() id: string;
+  @ApiProperty() order: number;
+  @ApiProperty({ description: 'TipTap JSON' }) label: unknown;
+  @ApiProperty() labelPlainText: string;
+  @ApiProperty({ required: false, nullable: true }) mediaUrl: string | null;
+  @ApiProperty({
+    required: false,
+    description: 'Only included when results are visible AND showCorrectAnswers',
+  })
+  isCorrect?: boolean;
+
+  constructor(o: QuestionOption, includeCorrect: boolean) {
+    this.id = o.id;
+    this.order = o.order;
+    this.label = o.label;
+    this.labelPlainText = o.labelPlainText;
+    this.mediaUrl = o.mediaUrl;
+    if (includeCorrect) this.isCorrect = o.isCorrect;
+  }
+}
+
+export class StudentQuestionResult {
+  @ApiProperty() id: string;
+  @ApiProperty({ enum: QuestionType }) type: QuestionType;
+  @ApiProperty({ description: 'TipTap JSON' }) prompt: unknown;
+  @ApiProperty() promptPlainText: string;
+  @ApiProperty({ type: [String] }) mediaUrls: string[];
+  @ApiProperty({ description: 'Resolved weight (override or base), as decimal string' })
+  weight: string;
+  @ApiProperty({ type: [StudentOptionResult] }) options: StudentOptionResult[];
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description: 'Type-specific config (NUMERIC unit etc). Sensitive fields stripped during attempt.',
+  })
+  config: unknown;
+  @ApiProperty({ enum: PartialCreditMode, required: false, nullable: true })
+  partialCreditMode: PartialCreditMode | null;
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description: 'Only included when results are visible AND showCorrectAnswers',
+  })
+  explanation?: unknown;
+
+  constructor(
+    question: Question & { options: QuestionOption[] },
+    weightSnapshot: string,
+    ctx: AttemptViewContext,
+  ) {
+    const reveal = ctx.resultsVisible && ctx.showCorrectAnswers;
+    this.id = question.id;
+    this.type = question.type;
+    this.prompt = question.prompt;
+    this.promptPlainText = question.promptPlainText;
+    this.mediaUrls = question.mediaUrls;
+    this.weight = weightSnapshot;
+    this.options = (question.options ?? [])
+      .sort((a, b) => a.order - b.order)
+      .map((o) => new StudentOptionResult(o, reveal));
+    this.partialCreditMode = question.partialCreditMode;
+    this.config = reveal ? question.config : redactConfig(question.type, question.config);
+    if (reveal) this.explanation = question.explanation;
+  }
+}
+
+export class StudentResponseResult {
+  @ApiProperty() questionId: string;
+  @ApiProperty({ required: false, nullable: true, description: 'Whatever the student last saved' })
+  responseJson: unknown;
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description: 'Only present when results are visible',
+  })
+  pointsAwarded?: string | null;
+  @ApiProperty({
+    required: false,
+    nullable: true,
+    description: 'Only present when results are visible',
+  })
+  isCorrect?: boolean | null;
+  @ApiProperty({ description: 'Decimal string', required: false })
+  weight?: string;
+
+  constructor(
+    response: QuestionResponse,
+    ctx: AttemptViewContext,
+  ) {
+    this.questionId = response.questionId;
+    this.responseJson = response.responseJson;
+    this.weight = response.weight.toString();
+    if (ctx.resultsVisible) {
+      this.pointsAwarded =
+        response.pointsAwarded !== null ? response.pointsAwarded.toString() : null;
+      this.isCorrect = response.isCorrect;
+    }
+  }
+}
+
+export class AttemptResult {
+  @ApiProperty() id: string;
+  @ApiProperty() quizAssignmentId: string;
+  @ApiProperty() studentId: string;
+  @ApiProperty() attemptNumber: number;
+  @ApiProperty({ enum: QuizAttemptStatus }) status: QuizAttemptStatus;
+  @ApiProperty() startedAt: Date;
+  @ApiProperty() dueAt: Date;
+  @ApiProperty({ required: false, nullable: true }) submittedAt: Date | null;
+  @ApiProperty() autoSubmitted: boolean;
+  @ApiProperty({ description: 'Decimal string' }) maxScore: string;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal string' })
+  totalScore: string | null;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal string' })
+  percentage: string | null;
+  @ApiProperty({
+    description:
+      'Computed: true if results may be shown to the student now (showResultsImmediately or resultsReleasedAt set).',
+  })
+  resultsVisible: boolean;
+  @ApiProperty({
+    description:
+      'Computed: true if correct-answer flags should be revealed in review mode. Mirrors backend redaction.',
+  })
+  showCorrectAnswers: boolean;
+  @ApiProperty({ type: [StudentQuestionResult] }) questions: StudentQuestionResult[];
+  @ApiProperty({ type: [StudentResponseResult] }) responses: StudentResponseResult[];
+
+  constructor(attempt: AttemptForView, ctx: AttemptViewContext, quizId: string) {
+    this.id = attempt.id;
+    this.quizAssignmentId = attempt.quizAssignmentId;
+    this.studentId = attempt.studentId;
+    this.attemptNumber = attempt.attemptNumber;
+    this.status = attempt.status;
+    this.startedAt = attempt.startedAt;
+    this.dueAt = attempt.dueAt;
+    this.submittedAt = attempt.submittedAt;
+    this.autoSubmitted = attempt.autoSubmitted;
+    this.maxScore = attempt.maxScore.toString();
+    this.totalScore = attempt.totalScore !== null ? attempt.totalScore.toString() : null;
+    this.percentage = attempt.percentage !== null ? attempt.percentage.toString() : null;
+    this.resultsVisible = ctx.resultsVisible;
+    this.showCorrectAnswers = ctx.resultsVisible && ctx.showCorrectAnswers;
+
+    // Display order: respect QuizQuestion.order (joined via question.quizUses where quizId matches).
+    const sorted = [...attempt.responses].sort((a, b) => {
+      const aOrder = a.question.quizUses.find((qq) => qq.quizId === quizId)?.order ?? 0;
+      const bOrder = b.question.quizUses.find((qq) => qq.quizId === quizId)?.order ?? 0;
+      return aOrder - bOrder;
+    });
+
+    this.questions = sorted.map(
+      (r) => new StudentQuestionResult(r.question, r.weight.toString(), ctx),
+    );
+    this.responses = sorted.map((r) => new StudentResponseResult(r, ctx));
+
+    void quizId;
+  }
+}
+
+export class AttemptSummaryResult {
+  @ApiProperty() id: string;
+  @ApiProperty() quizAssignmentId: string;
+  @ApiProperty() attemptNumber: number;
+  @ApiProperty({ enum: QuizAttemptStatus }) status: QuizAttemptStatus;
+  @ApiProperty() startedAt: Date;
+  @ApiProperty() dueAt: Date;
+  @ApiProperty({ required: false, nullable: true }) submittedAt: Date | null;
+  @ApiProperty({ description: 'Decimal string' }) maxScore: string;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal string' })
+  totalScore: string | null;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal string' })
+  percentage: string | null;
+  @ApiProperty() resultsVisible: boolean;
+
+  constructor(attempt: QuizAttempt, resultsVisible: boolean) {
+    this.id = attempt.id;
+    this.quizAssignmentId = attempt.quizAssignmentId;
+    this.attemptNumber = attempt.attemptNumber;
+    this.status = attempt.status;
+    this.startedAt = attempt.startedAt;
+    this.dueAt = attempt.dueAt;
+    this.submittedAt = attempt.submittedAt;
+    this.maxScore = attempt.maxScore.toString();
+    this.totalScore = attempt.totalScore !== null ? attempt.totalScore.toString() : null;
+    this.percentage = attempt.percentage !== null ? attempt.percentage.toString() : null;
+    this.resultsVisible = resultsVisible;
+  }
+}
+
+export class AttemptsListResult {
+  @ApiProperty({ type: [AttemptSummaryResult] }) items: AttemptSummaryResult[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+
+  constructor(items: AttemptSummaryResult[], total: number, page: number, limit: number) {
+    this.items = items;
+    this.total = total;
+    this.page = page;
+    this.limit = limit;
+  }
+}
+
+export class StartAttemptResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: AttemptResult }) attempt: AttemptResult;
+
+  constructor(attempt: AttemptResult) {
+    this.success = true;
+    this.message = 'Attempt started';
+    this.attempt = attempt;
+  }
+}
+
+export class SaveResponsesResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty() saved: number;
+  @ApiProperty({ description: 'Server-canonical dueAt — client should re-sync timer' })
+  dueAt: Date;
+
+  constructor(saved: number, dueAt: Date) {
+    this.success = true;
+    this.message = `${saved} response(s) saved`;
+    this.saved = saved;
+    this.dueAt = dueAt;
+  }
+}
+
+export class SubmitAttemptResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: AttemptSummaryResult }) attempt: AttemptSummaryResult;
+
+  constructor(attempt: AttemptSummaryResult) {
+    this.success = true;
+    this.message = 'Attempt submitted; grading is queued';
+    this.attempt = attempt;
+  }
+}
+
+export class PageEventResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+
+  constructor() {
+    this.success = true;
+    this.message = 'Event recorded';
+  }
+}
+
+/**
+ * Strips fields from question.config that would reveal the correct answer.
+ * Keeps display-only fields (NUMERIC unit, etc.) so the student UI can show
+ * the expected unit alongside the input.
+ */
+function redactConfig(type: QuestionType, config: unknown) {
+  if (config == null || typeof config !== 'object') return null;
+  const c = config as Record<string, unknown>;
+  switch (type) {
+    case QuestionType.NUMERIC:
+      return c.unit ? { unit: c.unit } : {};
+    case QuestionType.TRUE_FALSE:
+    case QuestionType.SHORT_ANSWER:
+      return {};
+    default:
+      return {};
+  }
+}

--- a/src/components/quiz-attempts/results/index.ts
+++ b/src/components/quiz-attempts/results/index.ts
@@ -1,0 +1,1 @@
+export * from './attempt.result';

--- a/src/components/quiz-attempts/types.ts
+++ b/src/components/quiz-attempts/types.ts
@@ -1,0 +1,18 @@
+export const QUIZ_ATTEMPTS_QUEUE = 'quiz-attempts-queue';
+
+export enum QuizAttemptsJob {
+  GRADE_ATTEMPT = 'GRADE_ATTEMPT',
+  AUTO_SUBMIT_TICK = 'AUTO_SUBMIT_TICK',
+}
+
+export interface GradeAttemptJobData {
+  attemptId: string;
+}
+
+export interface AutoSubmitTickJobData {
+  // empty — the worker scans for due attempts
+  scheduledAt?: string;
+}
+
+export const AUTO_SUBMIT_TICK_INTERVAL_MS = 60_000;
+export const AUTO_SUBMIT_TICK_JOB_ID = 'auto-submit-tick-singleton';

--- a/src/components/quiz-billing/pricing.constants.spec.ts
+++ b/src/components/quiz-billing/pricing.constants.spec.ts
@@ -1,0 +1,98 @@
+import {
+  BETA_UNTIL,
+  FREE_TRIAL_DAYS,
+  computeChargeableUnits,
+  durationTier,
+  freeUntil,
+  questionTier,
+  resolveWaiver,
+} from './pricing.constants';
+
+describe('pricing.constants', () => {
+  describe('durationTier', () => {
+    it.each<[number, number]>([
+      [1, 1.0],
+      [30, 1.0],
+      [31, 1.5],
+      [60, 1.5],
+      [61, 2.0],
+      [180, 2.0],
+    ])('durationTier(%i) === %p', (mins, expected) => {
+      expect(durationTier(mins)).toBe(expected);
+    });
+  });
+
+  describe('questionTier', () => {
+    it.each<[number, number]>([
+      [1, 1.0],
+      [10, 1.0],
+      [11, 1.25],
+      [25, 1.25],
+      [26, 1.5],
+      [200, 1.5],
+    ])('questionTier(%i) === %p', (count, expected) => {
+      expect(questionTier(count)).toBe(expected);
+    });
+  });
+
+  describe('computeChargeableUnits', () => {
+    it('multiplies duration tier by question tier', () => {
+      expect(computeChargeableUnits(45, 20)).toBeCloseTo(1.875);
+      expect(computeChargeableUnits(15, 5)).toBeCloseTo(1.0);
+      expect(computeChargeableUnits(120, 50)).toBeCloseTo(3.0);
+    });
+  });
+
+  describe('resolveWaiver', () => {
+    const day = 86_400_000;
+    const beforeBeta = new Date(BETA_UNTIL.getTime() - 7 * day);
+    const afterBeta = new Date(BETA_UNTIL.getTime() + 7 * day);
+
+    it('returns BETA when now is before BETA_UNTIL, regardless of school age', () => {
+      const oldSchool = new Date(beforeBeta.getTime() - 5 * 365 * day);
+      const result = resolveWaiver(oldSchool, beforeBeta);
+      expect(result).toEqual({ isWaived: true, reason: 'BETA' });
+    });
+
+    it('returns FIRST_YEAR when past Beta but school is younger than FREE_TRIAL_DAYS', () => {
+      const youngSchool = new Date(afterBeta.getTime() - 30 * day);
+      const result = resolveWaiver(youngSchool, afterBeta);
+      expect(result).toEqual({ isWaived: true, reason: 'FIRST_YEAR' });
+    });
+
+    it('returns no waiver when past Beta and school is older than FREE_TRIAL_DAYS', () => {
+      const oldSchool = new Date(afterBeta.getTime() - (FREE_TRIAL_DAYS + 30) * day);
+      const result = resolveWaiver(oldSchool, afterBeta);
+      expect(result).toEqual({ isWaived: false, reason: null });
+    });
+
+    it('treats the FIRST_YEAR boundary inclusively at the start, exclusively at the end', () => {
+      const exactlyTrialEnd = new Date(afterBeta.getTime() - FREE_TRIAL_DAYS * day);
+      // school is exactly FREE_TRIAL_DAYS old at `afterBeta` — trial just ended
+      expect(resolveWaiver(exactlyTrialEnd, afterBeta)).toEqual({
+        isWaived: false,
+        reason: null,
+      });
+    });
+  });
+
+  describe('freeUntil', () => {
+    const day = 86_400_000;
+
+    it('returns BETA_UNTIL when it is later than school+365d (school created well before Beta ends)', () => {
+      // school created (FREE_TRIAL_DAYS + 30) days before BETA_UNTIL
+      // → trialEnd = BETA_UNTIL - 30d, which is earlier than BETA_UNTIL
+      const oldSchool = new Date(BETA_UNTIL.getTime() - (FREE_TRIAL_DAYS + 30) * day);
+      const fu = freeUntil(oldSchool);
+      expect(fu.date.getTime()).toBe(BETA_UNTIL.getTime());
+    });
+
+    it('returns school+365d when it is later than BETA_UNTIL (school created near or after Beta)', () => {
+      // school created 30d before BETA_UNTIL → trialEnd = BETA_UNTIL + 335d, which beats BETA_UNTIL
+      const youngSchool = new Date(BETA_UNTIL.getTime() - 30 * day);
+      const fu = freeUntil(youngSchool);
+      const trialEnd = new Date(youngSchool.getTime() + FREE_TRIAL_DAYS * day);
+      expect(fu.date.getTime()).toBe(trialEnd.getTime());
+    });
+  });
+});

--- a/src/components/quiz-billing/pricing.constants.ts
+++ b/src/components/quiz-billing/pricing.constants.ts
@@ -1,0 +1,61 @@
+/**
+ * Quiz/Assessments billing constants and waiver logic.
+ *
+ * Usage is metered per QuizAttempt at start. The nominal amount is computed
+ * from a duration tier × question-count tier × unit rate. Every metered event
+ * also resolves a waiver: while the global Beta period is active OR the school
+ * is within its first FREE_TRIAL_DAYS days, the event is recorded with
+ * `isWaived = true` and billing systems must skip it.
+ *
+ * MIRROR: keep `UNIT_RATE_NAIRA` and the duration/question tier values in sync
+ * with the frontend mirror at:
+ *   schoolos-frontend/apps/admin-portal/app/(root)/assessments/pricing.ts
+ * The frontend constants are a fallback; the API also returns `unitRateNaira`
+ * via /bff/admin/assessments-settings so the page renders the live value.
+ */
+
+export const UNIT_RATE_NAIRA = 50;
+export const FREE_TRIAL_DAYS = 365;
+
+export const BETA_UNTIL = new Date(
+  process.env.ASSESSMENTS_BETA_UNTIL ?? '2026-12-31T23:59:59Z',
+);
+
+export type WaiverReason = 'BETA' | 'FIRST_YEAR';
+
+export function durationTier(durationMinutes: number): number {
+  if (durationMinutes <= 30) return 1.0;
+  if (durationMinutes <= 60) return 1.5;
+  return 2.0;
+}
+
+export function questionTier(questionCount: number): number {
+  if (questionCount <= 10) return 1.0;
+  if (questionCount <= 25) return 1.25;
+  return 1.5;
+}
+
+export function computeChargeableUnits(durationMinutes: number, questionCount: number): number {
+  return durationTier(durationMinutes) * questionTier(questionCount);
+}
+
+export function resolveWaiver(
+  schoolCreatedAt: Date,
+  now: Date = new Date(),
+): { isWaived: boolean; reason: WaiverReason | null } {
+  if (now < BETA_UNTIL) return { isWaived: true, reason: 'BETA' };
+  const trialEnd = new Date(schoolCreatedAt.getTime() + FREE_TRIAL_DAYS * 86_400_000);
+  if (now < trialEnd) return { isWaived: true, reason: 'FIRST_YEAR' };
+  return { isWaived: false, reason: null };
+}
+
+export function freeUntil(schoolCreatedAt: Date): {
+  date: Date;
+  reason: WaiverReason | null;
+} {
+  const trialEnd = new Date(schoolCreatedAt.getTime() + FREE_TRIAL_DAYS * 86_400_000);
+  if (BETA_UNTIL >= trialEnd) {
+    return { date: BETA_UNTIL, reason: new Date() < BETA_UNTIL ? 'BETA' : null };
+  }
+  return { date: trialEnd, reason: new Date() < trialEnd ? 'FIRST_YEAR' : null };
+}

--- a/src/components/quiz-billing/quiz-billing.service.ts
+++ b/src/components/quiz-billing/quiz-billing.service.ts
@@ -1,0 +1,197 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { freeUntil, UNIT_RATE_NAIRA } from './pricing.constants';
+
+export interface AssessmentsSettingsView {
+  assessmentsEnabled: boolean;
+  assessmentsEnabledAt: Date | null;
+  assessmentsEnabledByName: string | null;
+  freeUntil: Date;
+  freeUntilReason: 'BETA' | 'FIRST_YEAR' | null;
+  unitRateNaira: number;
+}
+
+export interface AssessmentsUsageView {
+  month: string;
+  totalAttempts: number;
+  totalUnits: number;
+  nominalAmountKobo: number;
+  waivedAmountKobo: number;
+  chargeableAmountKobo: number;
+  byAssignment: Array<{
+    quizAssignmentId: string;
+    attempts: number;
+    units: number;
+    nominalAmountKobo: number;
+  }>;
+}
+
+@Injectable()
+export class QuizBillingService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getSettings(userId: string): Promise<AssessmentsSettingsView> {
+    const schoolId = await this.requireSchoolId(userId);
+    const school = await this.prisma.school.findUnique({
+      where: { id: schoolId },
+      select: {
+        createdAt: true,
+        assessmentsEnabled: true,
+        assessmentsEnabledAt: true,
+        assessmentsEnabledById: true,
+      },
+    });
+    if (!school) throw new NotFoundException('School not found');
+
+    let enabledByName: string | null = null;
+    if (school.assessmentsEnabledById) {
+      const u = await this.prisma.user.findUnique({
+        where: { id: school.assessmentsEnabledById },
+        select: { firstName: true, lastName: true },
+      });
+      if (u) enabledByName = `${u.firstName} ${u.lastName}`.trim();
+    }
+
+    const fu = freeUntil(school.createdAt);
+    return {
+      assessmentsEnabled: school.assessmentsEnabled,
+      assessmentsEnabledAt: school.assessmentsEnabledAt,
+      assessmentsEnabledByName: enabledByName,
+      freeUntil: fu.date,
+      freeUntilReason: fu.reason,
+      unitRateNaira: UNIT_RATE_NAIRA,
+    };
+  }
+
+  async toggleSettings(userId: string, enabled: boolean): Promise<AssessmentsSettingsView> {
+    const schoolId = await this.requireSchoolId(userId);
+    const now = new Date();
+    await this.prisma.school.update({
+      where: { id: schoolId },
+      data: enabled
+        ? {
+            assessmentsEnabled: true,
+            assessmentsEnabledAt: now,
+            assessmentsEnabledById: userId,
+            assessmentsDisabledAt: null,
+          }
+        : {
+            assessmentsEnabled: false,
+            assessmentsDisabledAt: now,
+          },
+    });
+    return this.getSettings(userId);
+  }
+
+  async getUsage(userId: string, monthInput?: string): Promise<AssessmentsUsageView> {
+    const schoolId = await this.requireSchoolId(userId);
+    const { start, end, month } = monthRange(monthInput);
+
+    const events = await this.prisma.quizUsageEvent.findMany({
+      where: {
+        schoolId,
+        recordedAt: { gte: start, lt: end },
+      },
+      select: {
+        quizAssignmentId: true,
+        chargeableUnits: true,
+        amountKobo: true,
+        isWaived: true,
+      },
+    });
+
+    const totals = events.reduce(
+      (acc, e) => {
+        const units = Number(e.chargeableUnits.toString());
+        acc.totalAttempts += 1;
+        acc.totalUnits += units;
+        acc.nominalAmountKobo += e.amountKobo;
+        if (e.isWaived) acc.waivedAmountKobo += e.amountKobo;
+        else acc.chargeableAmountKobo += e.amountKobo;
+        return acc;
+      },
+      {
+        totalAttempts: 0,
+        totalUnits: 0,
+        nominalAmountKobo: 0,
+        waivedAmountKobo: 0,
+        chargeableAmountKobo: 0,
+      },
+    );
+
+    const byMap = new Map<
+      string,
+      { attempts: number; units: number; nominalAmountKobo: number }
+    >();
+    for (const e of events) {
+      const cur = byMap.get(e.quizAssignmentId) ?? {
+        attempts: 0,
+        units: 0,
+        nominalAmountKobo: 0,
+      };
+      cur.attempts += 1;
+      cur.units += Number(e.chargeableUnits.toString());
+      cur.nominalAmountKobo += e.amountKobo;
+      byMap.set(e.quizAssignmentId, cur);
+    }
+    const byAssignment = Array.from(byMap.entries()).map(([quizAssignmentId, v]) => ({
+      quizAssignmentId,
+      ...v,
+    }));
+
+    return {
+      month,
+      totalAttempts: totals.totalAttempts,
+      totalUnits: round2(totals.totalUnits),
+      nominalAmountKobo: totals.nominalAmountKobo,
+      waivedAmountKobo: totals.waivedAmountKobo,
+      chargeableAmountKobo: totals.chargeableAmountKobo,
+      byAssignment,
+    };
+  }
+
+  private async requireSchoolId(userId: string): Promise<string> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { schoolId: true },
+    });
+    if (!user?.schoolId) {
+      throw new ForbiddenException('User is not associated with a school');
+    }
+    return user.schoolId;
+  }
+}
+
+export function monthRange(input?: string): { start: Date; end: Date; month: string } {
+  const now = new Date();
+  let year = now.getUTCFullYear();
+  let monthIdx = now.getUTCMonth();
+  if (input !== undefined) {
+    if (!/^\d{4}-\d{2}$/.test(input)) {
+      throw new BadRequestException('month must be in YYYY-MM format');
+    }
+    const [y, m] = input.split('-').map((p) => parseInt(p, 10));
+    if (m < 1 || m > 12) {
+      throw new BadRequestException('month must be between 01 and 12');
+    }
+    if (y < 2024 || y > 2100) {
+      throw new BadRequestException('year is out of range');
+    }
+    year = y;
+    monthIdx = m - 1;
+  }
+  const start = new Date(Date.UTC(year, monthIdx, 1));
+  const end = new Date(Date.UTC(year, monthIdx + 1, 1));
+  const month = `${year}-${String(monthIdx + 1).padStart(2, '0')}`;
+  return { start, end, month };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/components/quizzes/dto/attach-questions.dto.ts
+++ b/src/components/quizzes/dto/attach-questions.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsUUID,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class QuizQuestionAttachmentDto {
+  @ApiProperty()
+  @IsUUID()
+  questionId: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Display order. If omitted, appended after the current last order.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'Per-quiz weight override. If null/undefined, uses Question.weight.',
+  })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Max(99999.99)
+  weightOverride?: number;
+}
+
+export class AttachQuestionsDto {
+  @ApiProperty({ type: [QuizQuestionAttachmentDto], description: 'Questions to attach (preserves order)' })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => QuizQuestionAttachmentDto)
+  questions: QuizQuestionAttachmentDto[];
+}

--- a/src/components/quizzes/dto/create-quiz.dto.ts
+++ b/src/components/quizzes/dto/create-quiz.dto.ts
@@ -1,0 +1,122 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { QuestionDifficulty, QuizStatus } from '@prisma/client';
+
+import { QuizDefaultSettingsDto } from './quiz-default-settings.dto';
+
+export class CreateQuizDto {
+  @ApiProperty()
+  @IsString()
+  @MaxLength(200)
+  title: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false, description: 'Long-form student instructions shown before the quiz' })
+  @IsOptional()
+  @IsString()
+  instructions?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'School-scoped subject id. Required for TEACHER_AUTHORED, must be null for SCHOS_CURATED.',
+  })
+  @IsOptional()
+  @IsUUID()
+  subjectId?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'School-scoped level id. Required for TEACHER_AUTHORED, must be null for SCHOS_CURATED.',
+  })
+  @IsOptional()
+  @IsUUID()
+  levelId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  defaultTermId?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Canonical subject name. Required for SCHOS_CURATED. Auto-derived from subject.name on create for TEACHER_AUTHORED if not provided.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  canonicalSubjectName?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Canonical level code. Required for SCHOS_CURATED. Auto-derived from level.code on create for TEACHER_AUTHORED if not provided.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  canonicalLevelCode?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  canonicalTermName?: string;
+
+  @ApiProperty({ required: false, enum: QuizStatus, default: QuizStatus.DRAFT })
+  @IsOptional()
+  @IsEnum(QuizStatus)
+  status?: QuizStatus;
+
+  @ApiProperty({ required: false, description: 'Estimated duration in minutes' })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(600)
+  estimatedMinutes?: number;
+
+  @ApiProperty({ required: false, description: 'Pass mark as a percentage (0-100)' })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Max(100)
+  passMarkPercent?: number;
+
+  @ApiProperty({ required: false, enum: QuestionDifficulty })
+  @IsOptional()
+  @IsEnum(QuestionDifficulty)
+  difficulty?: QuestionDifficulty;
+
+  @ApiProperty({ required: false, type: QuizDefaultSettingsDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => QuizDefaultSettingsDto)
+  defaultSettings?: QuizDefaultSettingsDto;
+
+  @ApiProperty({
+    required: false,
+    type: [String],
+    description: 'Topic ids to tag this quiz with',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  topicIds?: string[];
+}

--- a/src/components/quizzes/dto/index.ts
+++ b/src/components/quizzes/dto/index.ts
@@ -1,0 +1,6 @@
+export * from './create-quiz.dto';
+export * from './update-quiz.dto';
+export * from './quiz-query.dto';
+export * from './quiz-default-settings.dto';
+export * from './attach-questions.dto';
+export * from './reorder-questions.dto';

--- a/src/components/quizzes/dto/quiz-default-settings.dto.ts
+++ b/src/components/quizzes/dto/quiz-default-settings.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+/**
+ * Quiz-level defaults. A QuizAssignment can override `showResultsImmediately`
+ * and `showCorrectAnswers` per assignment.
+ */
+export class QuizDefaultSettingsDto {
+  @ApiProperty({ required: false, description: 'Shuffle question order on each attempt' })
+  @IsOptional()
+  @IsBoolean()
+  shuffleQuestions?: boolean;
+
+  @ApiProperty({ required: false, description: 'Shuffle MCQ option order on each attempt' })
+  @IsOptional()
+  @IsBoolean()
+  shuffleOptions?: boolean;
+
+  @ApiProperty({
+    required: false,
+    description: 'Show results to students immediately on submit (overridable per assignment)',
+  })
+  @IsOptional()
+  @IsBoolean()
+  showResultsImmediately?: boolean;
+
+  @ApiProperty({ required: false, description: 'Let students review their submitted attempt' })
+  @IsOptional()
+  @IsBoolean()
+  allowReview?: boolean;
+
+  @ApiProperty({
+    required: false,
+    description: 'Reveal correct answers in the review (only relevant if allowReview)',
+  })
+  @IsOptional()
+  @IsBoolean()
+  showCorrectAnswers?: boolean;
+}

--- a/src/components/quizzes/dto/quiz-query.dto.ts
+++ b/src/components/quizzes/dto/quiz-query.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsEnum, IsInt, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { QuestionDifficulty, QuizStatus } from '@prisma/client';
+
+export class QuizQueryDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  subjectId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  levelId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  canonicalSubjectName?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  canonicalLevelCode?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  canonicalTermName?: string;
+
+  @ApiProperty({ required: false, type: [String], description: 'Filter to quizzes tagged with ANY of these topic ids' })
+  @IsOptional()
+  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
+  @IsArray()
+  @IsUUID('4', { each: true })
+  topicIds?: string[];
+
+  @ApiProperty({ required: false, enum: QuestionDifficulty })
+  @IsOptional()
+  @IsEnum(QuestionDifficulty)
+  difficulty?: QuestionDifficulty;
+
+  @ApiProperty({ required: false, enum: QuizStatus })
+  @IsOptional()
+  @IsEnum(QuizStatus)
+  status?: QuizStatus;
+
+  @ApiProperty({ required: false, description: 'Free-text search on title (case-insensitive contains)' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({ required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ required: false, default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/components/quizzes/dto/reorder-questions.dto.ts
+++ b/src/components/quizzes/dto/reorder-questions.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class QuizQuestionOrderDto {
+  @ApiProperty()
+  @IsUUID()
+  questionId: string;
+
+  @ApiProperty({ minimum: 0 })
+  @IsInt()
+  @Min(0)
+  order: number;
+}
+
+export class ReorderQuestionsDto {
+  @ApiProperty({
+    type: [QuizQuestionOrderDto],
+    description:
+      'Full new ordering. Must include EVERY currently-attached question; partial reorders are rejected.',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => QuizQuestionOrderDto)
+  orderings: QuizQuestionOrderDto[];
+}

--- a/src/components/quizzes/dto/update-quiz.dto.ts
+++ b/src/components/quizzes/dto/update-quiz.dto.ts
@@ -1,0 +1,10 @@
+import { PartialType } from '@nestjs/swagger';
+
+import { CreateQuizDto } from './create-quiz.dto';
+
+/**
+ * All fields optional. When provided, replaces topicIds wholesale.
+ * Bumps Quiz.version on every update so QuizAssignment snapshots remain
+ * faithful to the version they were assigned with.
+ */
+export class UpdateQuizDto extends PartialType(CreateQuizDto) {}

--- a/src/components/quizzes/quizzes.controller.ts
+++ b/src/components/quizzes/quizzes.controller.ts
@@ -1,0 +1,143 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import {
+  AttachQuestionsDto,
+  CreateQuizDto,
+  QuizQueryDto,
+  ReorderQuestionsDto,
+  UpdateQuizDto,
+} from './dto';
+import { QuizzesService } from './quizzes.service';
+import {
+  AttachQuestionsSwagger,
+  CloneQuizSwagger,
+  CreateQuizSwagger,
+  DeleteQuizSwagger,
+  DetachQuestionSwagger,
+  GetQuizSwagger,
+  ListLibraryQuizzesSwagger,
+  ListMyQuizzesSwagger,
+  ReorderQuestionsSwagger,
+  UpdateQuizSwagger,
+} from './quizzes.swagger';
+import {
+  CloneQuizResult,
+  CreateQuizResult,
+  DeleteQuizResult,
+  QuizDetailResult,
+  QuizSummaryResult,
+  QuizzesListResult,
+  UpdateQuizResult,
+} from './results/quiz.result';
+
+@Controller('quizzes')
+@ApiTags('Quizzes')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class QuizzesController {
+  constructor(private readonly quizzesService: QuizzesService) {}
+
+  @Post()
+  @CreateQuizSwagger()
+  async create(@GetCurrentUserId() userId: string, @Body() dto: CreateQuizDto) {
+    const quiz = await this.quizzesService.create(userId, dto);
+    return new CreateQuizResult(new QuizDetailResult(quiz));
+  }
+
+  @Get('mine')
+  @ListMyQuizzesSwagger()
+  async listMine(@GetCurrentUserId() userId: string, @Query() query: QuizQueryDto) {
+    const { items, total, page, limit } = await this.quizzesService.list(userId, 'mine', query);
+    return new QuizzesListResult(items.map((q) => new QuizSummaryResult(q)), total, page, limit);
+  }
+
+  @Get('library')
+  @ListLibraryQuizzesSwagger()
+  async listLibrary(@GetCurrentUserId() userId: string, @Query() query: QuizQueryDto) {
+    const { items, total, page, limit } = await this.quizzesService.list(userId, 'library', query);
+    return new QuizzesListResult(items.map((q) => new QuizSummaryResult(q)), total, page, limit);
+  }
+
+  @Get(':id')
+  @GetQuizSwagger()
+  async findById(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const quiz = await this.quizzesService.findById(userId, id);
+    return new QuizDetailResult(quiz);
+  }
+
+  @Patch(':id')
+  @UpdateQuizSwagger()
+  async update(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: UpdateQuizDto,
+  ) {
+    const quiz = await this.quizzesService.update(userId, id, dto);
+    return new UpdateQuizResult(new QuizDetailResult(quiz));
+  }
+
+  @Delete(':id')
+  @DeleteQuizSwagger()
+  async delete(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    await this.quizzesService.softDelete(userId, id);
+    return new DeleteQuizResult();
+  }
+
+  @Post(':id/clone')
+  @HttpCode(HttpStatus.CREATED)
+  @CloneQuizSwagger()
+  async clone(@GetCurrentUserId() userId: string, @Param('id') id: string) {
+    const quiz = await this.quizzesService.clone(userId, id);
+    return new CloneQuizResult(new QuizDetailResult(quiz));
+  }
+
+  @Post(':id/questions')
+  @HttpCode(HttpStatus.OK)
+  @AttachQuestionsSwagger()
+  async attachQuestions(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: AttachQuestionsDto,
+  ) {
+    const quiz = await this.quizzesService.attachQuestions(userId, id, dto);
+    return new UpdateQuizResult(new QuizDetailResult(quiz));
+  }
+
+  @Delete(':id/questions/:questionId')
+  @DetachQuestionSwagger()
+  async detachQuestion(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Param('questionId') questionId: string,
+  ) {
+    const quiz = await this.quizzesService.detachQuestion(userId, id, questionId);
+    return new UpdateQuizResult(new QuizDetailResult(quiz));
+  }
+
+  @Patch(':id/questions/reorder')
+  @ReorderQuestionsSwagger()
+  async reorderQuestions(
+    @GetCurrentUserId() userId: string,
+    @Param('id') id: string,
+    @Body() dto: ReorderQuestionsDto,
+  ) {
+    const quiz = await this.quizzesService.reorderQuestions(userId, id, dto);
+    return new UpdateQuizResult(new QuizDetailResult(quiz));
+  }
+}

--- a/src/components/quizzes/quizzes.module.ts
+++ b/src/components/quizzes/quizzes.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { QuizzesController } from './quizzes.controller';
+import { QuizzesService } from './quizzes.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [QuizzesController],
+  providers: [QuizzesService, Encryptor],
+  exports: [QuizzesService],
+})
+export class QuizzesModule {}

--- a/src/components/quizzes/quizzes.service.ts
+++ b/src/components/quizzes/quizzes.service.ts
@@ -1,0 +1,576 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  Prisma,
+  QuestionOwnerType,
+  QuizAssignmentStatus,
+  QuizOwnerType,
+  QuizStatus,
+} from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { UserTypes } from '../users/constants';
+import {
+  AttachQuestionsDto,
+  CreateQuizDto,
+  QuizQueryDto,
+  ReorderQuestionsDto,
+  UpdateQuizDto,
+} from './dto';
+
+const QUESTION_INCLUDE = {
+  options: true,
+  topics: { include: { topic: true } },
+  popularExams: { include: { popularExam: true } },
+  _count: { select: { quizUses: true } },
+} as const;
+
+const QUIZ_DETAIL_INCLUDE = {
+  topics: { include: { topic: true } },
+  questions: {
+    include: { question: { include: QUESTION_INCLUDE } },
+    orderBy: { order: 'asc' },
+  },
+  _count: { select: { questions: true, assignments: true } },
+} as const satisfies Prisma.QuizInclude;
+
+const QUIZ_SUMMARY_INCLUDE = {
+  topics: { include: { topic: true } },
+  questions: {
+    select: {
+      weightOverride: true,
+      question: { select: { weight: true } },
+    },
+  },
+  _count: { select: { questions: true, assignments: true } },
+} as const satisfies Prisma.QuizInclude;
+
+interface CallerContext {
+  userId: string;
+  type: string;
+  schoolId: string | null;
+}
+
+@Injectable()
+export class QuizzesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(callerUserId: string, scope: 'mine' | 'library', query: QuizQueryDto) {
+    const caller = await this.getCallerContext(callerUserId);
+
+    const where: Prisma.QuizWhereInput = { deletedAt: null };
+
+    if (scope === 'mine') {
+      if (caller.type !== UserTypes.TEACHER) {
+        return { items: [], total: 0, page: query.page ?? 1, limit: query.limit ?? 20 };
+      }
+      where.ownerType = QuizOwnerType.TEACHER_AUTHORED;
+      where.schoolId = caller.schoolId;
+      where.authorUserId = callerUserId;
+    } else {
+      where.ownerType = QuizOwnerType.SCHOS_CURATED;
+    }
+
+    if (query.subjectId) where.subjectId = query.subjectId;
+    if (query.levelId) where.levelId = query.levelId;
+    if (query.canonicalSubjectName) {
+      where.canonicalSubjectName = { equals: query.canonicalSubjectName, mode: 'insensitive' };
+    }
+    if (query.canonicalLevelCode) {
+      where.canonicalLevelCode = { equals: query.canonicalLevelCode, mode: 'insensitive' };
+    }
+    if (query.canonicalTermName) {
+      where.canonicalTermName = { equals: query.canonicalTermName, mode: 'insensitive' };
+    }
+    if (query.difficulty) where.difficulty = query.difficulty;
+    if (query.status) where.status = query.status;
+    if (query.search) where.title = { contains: query.search, mode: 'insensitive' };
+    if (query.topicIds?.length) {
+      where.topics = { some: { topicId: { in: query.topicIds } } };
+    }
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+
+    const [items, total] = await Promise.all([
+      this.prisma.quiz.findMany({
+        where,
+        include: QUIZ_SUMMARY_INCLUDE,
+        orderBy: [{ updatedAt: 'desc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.quiz.count({ where }),
+    ]);
+
+    return { items, total, page, limit };
+  }
+
+  async findById(callerUserId: string, id: string) {
+    const caller = await this.getCallerContext(callerUserId);
+    const quiz = await this.prisma.quiz.findFirst({
+      where: { id, deletedAt: null },
+      include: QUIZ_DETAIL_INCLUDE,
+    });
+    if (!quiz) throw new NotFoundException('Quiz not found');
+
+    const isCurated = quiz.ownerType === QuizOwnerType.SCHOS_CURATED;
+    const isOwn =
+      quiz.ownerType === QuizOwnerType.TEACHER_AUTHORED &&
+      quiz.authorUserId === callerUserId &&
+      quiz.schoolId === caller.schoolId;
+    if (!isCurated && !isOwn) {
+      throw new NotFoundException('Quiz not found');
+    }
+
+    return quiz;
+  }
+
+  async create(callerUserId: string, dto: CreateQuizDto) {
+    const caller = await this.getCallerContext(callerUserId);
+    const { ownerType, schoolId } = this.resolveOwnership(caller);
+
+    let canonicalSubjectName = dto.canonicalSubjectName ?? null;
+    let canonicalLevelCode = dto.canonicalLevelCode ?? null;
+    let canonicalTermName = dto.canonicalTermName ?? null;
+
+    if (ownerType === QuizOwnerType.TEACHER_AUTHORED) {
+      if (!dto.subjectId || !dto.levelId) {
+        throw new BadRequestException(
+          'subjectId and levelId are required for teacher-authored quizzes',
+        );
+      }
+      const refs = await this.fetchSchoolRefs(
+        schoolId!,
+        dto.subjectId,
+        dto.levelId,
+        dto.defaultTermId,
+      );
+      canonicalSubjectName ??= refs.subject.name;
+      canonicalLevelCode ??= refs.level.code;
+      canonicalTermName ??= refs.term?.name ?? null;
+    } else {
+      if (dto.subjectId || dto.levelId || dto.defaultTermId) {
+        throw new BadRequestException(
+          'Curated quizzes must not bind to a school subject/level/term — use canonical fields instead',
+        );
+      }
+      if (!canonicalSubjectName || !canonicalLevelCode) {
+        throw new BadRequestException(
+          'Curated quizzes require canonicalSubjectName and canonicalLevelCode so they are filterable in the library',
+        );
+      }
+    }
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      const quiz = await tx.quiz.create({
+        data: {
+          ownerType,
+          schoolId,
+          authorUserId: callerUserId,
+          title: dto.title,
+          description: dto.description,
+          instructions: dto.instructions,
+          subjectId: dto.subjectId ?? null,
+          levelId: dto.levelId ?? null,
+          defaultTermId: dto.defaultTermId ?? null,
+          canonicalSubjectName,
+          canonicalLevelCode,
+          canonicalTermName,
+          status: dto.status ?? QuizStatus.DRAFT,
+          estimatedMinutes: dto.estimatedMinutes,
+          passMarkPercent: dto.passMarkPercent,
+          difficulty: dto.difficulty,
+          defaultSettings: (dto.defaultSettings ?? null) as Prisma.InputJsonValue,
+        },
+      });
+      await this.replaceTopicTags(tx, quiz.id, dto.topicIds);
+      return quiz;
+    });
+
+    return this.fetchById(created.id);
+  }
+
+  async update(callerUserId: string, id: string, dto: UpdateQuizDto) {
+    const existing = await this.findOwnedOrCurated(callerUserId, id);
+
+    if (dto.subjectId !== undefined || dto.levelId !== undefined || dto.defaultTermId !== undefined) {
+      if (existing.ownerType === QuizOwnerType.SCHOS_CURATED) {
+        throw new BadRequestException('Curated quizzes cannot bind to a school subject/level/term');
+      }
+    }
+    if (dto.subjectId && dto.levelId && existing.schoolId) {
+      await this.fetchSchoolRefs(existing.schoolId, dto.subjectId, dto.levelId, dto.defaultTermId);
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.quiz.update({
+        where: { id },
+        data: {
+          ...(dto.title !== undefined && { title: dto.title }),
+          ...(dto.description !== undefined && { description: dto.description }),
+          ...(dto.instructions !== undefined && { instructions: dto.instructions }),
+          ...(dto.subjectId !== undefined && { subjectId: dto.subjectId }),
+          ...(dto.levelId !== undefined && { levelId: dto.levelId }),
+          ...(dto.defaultTermId !== undefined && { defaultTermId: dto.defaultTermId }),
+          ...(dto.canonicalSubjectName !== undefined && {
+            canonicalSubjectName: dto.canonicalSubjectName,
+          }),
+          ...(dto.canonicalLevelCode !== undefined && {
+            canonicalLevelCode: dto.canonicalLevelCode,
+          }),
+          ...(dto.canonicalTermName !== undefined && { canonicalTermName: dto.canonicalTermName }),
+          ...(dto.status !== undefined && { status: dto.status }),
+          ...(dto.estimatedMinutes !== undefined && { estimatedMinutes: dto.estimatedMinutes }),
+          ...(dto.passMarkPercent !== undefined && { passMarkPercent: dto.passMarkPercent }),
+          ...(dto.difficulty !== undefined && { difficulty: dto.difficulty }),
+          ...(dto.defaultSettings !== undefined && {
+            defaultSettings: dto.defaultSettings as Prisma.InputJsonValue,
+          }),
+          version: { increment: 1 },
+        },
+      });
+      if (dto.topicIds !== undefined) {
+        await tx.quizTopic.deleteMany({ where: { quizId: id } });
+        await this.replaceTopicTags(tx, id, dto.topicIds);
+      }
+    });
+
+    return this.fetchById(id);
+  }
+
+  async softDelete(callerUserId: string, id: string) {
+    await this.findOwnedOrCurated(callerUserId, id);
+
+    const activeAssignments = await this.prisma.quizAssignment.count({
+      where: {
+        quizId: id,
+        deletedAt: null,
+        status: { not: QuizAssignmentStatus.ARCHIVED },
+      },
+    });
+    if (activeAssignments > 0) {
+      throw new ConflictException(
+        `Cannot archive: ${activeAssignments} non-archived assignment(s) still reference this quiz. Close them first.`,
+      );
+    }
+
+    await this.prisma.quiz.update({
+      where: { id },
+      data: { deletedAt: new Date(), status: QuizStatus.ARCHIVED },
+    });
+  }
+
+  async clone(callerUserId: string, id: string) {
+    const caller = await this.getCallerContext(callerUserId);
+    if (caller.type !== UserTypes.TEACHER) {
+      throw new ForbiddenException('Only teachers can clone curated quizzes');
+    }
+    if (!caller.schoolId) {
+      throw new BadRequestException('Caller has no schoolId');
+    }
+
+    const source = await this.prisma.quiz.findFirst({
+      where: { id, deletedAt: null, ownerType: QuizOwnerType.SCHOS_CURATED },
+      include: {
+        questions: { orderBy: { order: 'asc' } },
+        topics: true,
+      },
+    });
+    if (!source) {
+      throw new NotFoundException(
+        'Curated quiz not found (only SCHOS_CURATED quizzes can be cloned)',
+      );
+    }
+
+    const cloned = await this.prisma.$transaction(async (tx) => {
+      const q = await tx.quiz.create({
+        data: {
+          ownerType: QuizOwnerType.TEACHER_AUTHORED,
+          schoolId: caller.schoolId,
+          authorUserId: callerUserId,
+          title: `${source.title} (copy)`,
+          description: source.description,
+          instructions: source.instructions,
+          subjectId: null,
+          levelId: null,
+          defaultTermId: null,
+          canonicalSubjectName: source.canonicalSubjectName,
+          canonicalLevelCode: source.canonicalLevelCode,
+          canonicalTermName: source.canonicalTermName,
+          status: QuizStatus.DRAFT,
+          estimatedMinutes: source.estimatedMinutes,
+          passMarkPercent: source.passMarkPercent,
+          difficulty: source.difficulty,
+          defaultSettings: (source.defaultSettings ?? null) as Prisma.InputJsonValue,
+          sourceQuizId: source.id,
+        },
+      });
+
+      if (source.questions.length > 0) {
+        await tx.quizQuestion.createMany({
+          data: source.questions.map((qq) => ({
+            quizId: q.id,
+            questionId: qq.questionId,
+            order: qq.order,
+            weightOverride: qq.weightOverride,
+          })),
+        });
+      }
+
+      if (source.topics.length > 0) {
+        await tx.quizTopic.createMany({
+          data: source.topics.map((t) => ({ quizId: q.id, topicId: t.topicId })),
+        });
+      }
+
+      return q;
+    });
+
+    return this.fetchById(cloned.id);
+  }
+
+  async attachQuestions(callerUserId: string, quizId: string, dto: AttachQuestionsDto) {
+    const quiz = await this.findOwnedOrCurated(callerUserId, quizId);
+
+    const questionIds = dto.questions.map((q) => q.questionId);
+    if (new Set(questionIds).size !== questionIds.length) {
+      throw new BadRequestException('Duplicate questionIds in payload');
+    }
+
+    const existingAttachments = await this.prisma.quizQuestion.findMany({
+      where: { quizId, questionId: { in: questionIds } },
+      select: { questionId: true },
+    });
+    if (existingAttachments.length > 0) {
+      throw new ConflictException(
+        `Question(s) already attached: ${existingAttachments.map((e) => e.questionId).join(', ')}`,
+      );
+    }
+
+    const questions = await this.prisma.question.findMany({
+      where: { id: { in: questionIds }, deletedAt: null },
+      select: { id: true, ownerType: true, schoolId: true, authorUserId: true },
+    });
+    if (questions.length !== questionIds.length) {
+      const found = new Set(questions.map((q) => q.id));
+      const missing = questionIds.filter((id) => !found.has(id));
+      throw new NotFoundException(`Question(s) not found: ${missing.join(', ')}`);
+    }
+    const caller = await this.getCallerContext(callerUserId);
+    for (const q of questions) {
+      const isCurated = q.ownerType === QuestionOwnerType.SCHOS_CURATED;
+      const isOwnTeacherQuestion =
+        q.ownerType === QuestionOwnerType.TEACHER_AUTHORED &&
+        q.authorUserId === callerUserId &&
+        q.schoolId === caller.schoolId;
+      if (!isCurated && !isOwnTeacherQuestion) {
+        throw new ForbiddenException(
+          `Cannot attach question ${q.id}: not curated and not owned by you`,
+        );
+      }
+      if (quiz.ownerType === QuizOwnerType.SCHOS_CURATED && !isCurated) {
+        throw new BadRequestException(
+          `Curated quizzes can only contain curated questions; question ${q.id} is teacher-authored`,
+        );
+      }
+    }
+
+    const last = await this.prisma.quizQuestion.findFirst({
+      where: { quizId },
+      orderBy: { order: 'desc' },
+      select: { order: true },
+    });
+    let nextOrder = (last?.order ?? -1) + 1;
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const entry of dto.questions) {
+        await tx.quizQuestion.create({
+          data: {
+            quizId,
+            questionId: entry.questionId,
+            order: entry.order ?? nextOrder++,
+            weightOverride: entry.weightOverride,
+          },
+        });
+      }
+      await tx.quiz.update({
+        where: { id: quizId },
+        data: { version: { increment: 1 } },
+      });
+    });
+
+    return this.fetchById(quizId);
+  }
+
+  async detachQuestion(callerUserId: string, quizId: string, questionId: string) {
+    await this.findOwnedOrCurated(callerUserId, quizId);
+
+    const attachment = await this.prisma.quizQuestion.findUnique({
+      where: { quizId_questionId: { quizId, questionId } },
+    });
+    if (!attachment) throw new NotFoundException('Question is not attached to this quiz');
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.quizQuestion.delete({
+        where: { quizId_questionId: { quizId, questionId } },
+      });
+      await tx.quiz.update({ where: { id: quizId }, data: { version: { increment: 1 } } });
+    });
+
+    return this.fetchById(quizId);
+  }
+
+  async reorderQuestions(callerUserId: string, quizId: string, dto: ReorderQuestionsDto) {
+    await this.findOwnedOrCurated(callerUserId, quizId);
+
+    const ids = dto.orderings.map((o) => o.questionId);
+    if (new Set(ids).size !== ids.length) {
+      throw new BadRequestException('Duplicate questionIds in orderings');
+    }
+    const orders = dto.orderings.map((o) => o.order);
+    if (new Set(orders).size !== orders.length) {
+      throw new BadRequestException('Duplicate order values in orderings');
+    }
+
+    const attached = await this.prisma.quizQuestion.findMany({
+      where: { quizId },
+      select: { questionId: true },
+    });
+    const attachedIds = new Set(attached.map((a) => a.questionId));
+    const providedIds = new Set(ids);
+    if (
+      attachedIds.size !== providedIds.size ||
+      [...attachedIds].some((id) => !providedIds.has(id))
+    ) {
+      throw new BadRequestException(
+        'Reorder must include EVERY currently-attached question exactly once',
+      );
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      // Two-phase update to dodge the (quizId, order) unique constraint:
+      // phase 1 sets all orders to negative offsets so nothing collides,
+      // phase 2 sets them to the requested final values.
+      for (let i = 0; i < ids.length; i++) {
+        await tx.quizQuestion.update({
+          where: { quizId_questionId: { quizId, questionId: ids[i] } },
+          data: { order: -(i + 1) },
+        });
+      }
+      for (const { questionId, order } of dto.orderings) {
+        await tx.quizQuestion.update({
+          where: { quizId_questionId: { quizId, questionId } },
+          data: { order },
+        });
+      }
+      await tx.quiz.update({ where: { id: quizId }, data: { version: { increment: 1 } } });
+    });
+
+    return this.fetchById(quizId);
+  }
+
+  // ---- internals ----
+
+  private async fetchById(id: string) {
+    const q = await this.prisma.quiz.findUnique({
+      where: { id },
+      include: QUIZ_DETAIL_INCLUDE,
+    });
+    if (!q) throw new NotFoundException('Quiz not found');
+    return q;
+  }
+
+  private async findOwnedOrCurated(callerUserId: string, id: string) {
+    const caller = await this.getCallerContext(callerUserId);
+    const quiz = await this.prisma.quiz.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!quiz) throw new NotFoundException('Quiz not found');
+
+    if (caller.type === UserTypes.TEACHER) {
+      if (
+        quiz.ownerType !== QuizOwnerType.TEACHER_AUTHORED ||
+        quiz.authorUserId !== callerUserId ||
+        quiz.schoolId !== caller.schoolId
+      ) {
+        throw new ForbiddenException('You can only modify your own quizzes');
+      }
+    } else if (caller.type === UserTypes.SYSTEM_ADMIN) {
+      if (quiz.ownerType !== QuizOwnerType.SCHOS_CURATED) {
+        throw new ForbiddenException('System admins can only modify curated quizzes');
+      }
+    } else {
+      throw new ForbiddenException('Not authorized to modify quizzes');
+    }
+
+    return quiz;
+  }
+
+  private async getCallerContext(userId: string): Promise<CallerContext> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, type: true, schoolId: true },
+    });
+    if (!user) throw new ForbiddenException('Caller not found');
+    return { userId: user.id, type: user.type, schoolId: user.schoolId };
+  }
+
+  private resolveOwnership(caller: CallerContext) {
+    if (caller.type === UserTypes.TEACHER) {
+      if (!caller.schoolId) {
+        throw new BadRequestException('Teacher has no schoolId');
+      }
+      return { ownerType: QuizOwnerType.TEACHER_AUTHORED, schoolId: caller.schoolId };
+    }
+    if (caller.type === UserTypes.SYSTEM_ADMIN) {
+      return { ownerType: QuizOwnerType.SCHOS_CURATED, schoolId: null as string | null };
+    }
+    throw new ForbiddenException('Only teachers and system admins can author quizzes');
+  }
+
+  private async fetchSchoolRefs(
+    schoolId: string,
+    subjectId: string,
+    levelId: string,
+    termId: string | undefined,
+  ) {
+    const [subject, level, term] = await Promise.all([
+      this.prisma.subject.findFirst({
+        where: { id: subjectId, schoolId, deletedAt: null },
+        select: { id: true, name: true },
+      }),
+      this.prisma.level.findFirst({
+        where: { id: levelId, schoolId, deletedAt: null },
+        select: { id: true, code: true },
+      }),
+      termId
+        ? this.prisma.term.findFirst({
+            where: { id: termId, deletedAt: null },
+            select: { id: true, name: true },
+          })
+        : Promise.resolve(null),
+    ]);
+    if (!subject) throw new BadRequestException('Subject not found in your school');
+    if (!level) throw new BadRequestException('Level not found in your school');
+    if (termId && !term) throw new BadRequestException('Term not found');
+    return { subject, level, term };
+  }
+
+  private async replaceTopicTags(
+    tx: Prisma.TransactionClient,
+    quizId: string,
+    topicIds: string[] | undefined,
+  ) {
+    if (!topicIds?.length) return;
+    await tx.quizTopic.createMany({
+      data: topicIds.map((topicId) => ({ quizId, topicId })),
+      skipDuplicates: true,
+    });
+  }
+}

--- a/src/components/quizzes/quizzes.swagger.ts
+++ b/src/components/quizzes/quizzes.swagger.ts
@@ -1,0 +1,130 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+import {
+  AttachQuestionsDto,
+  CreateQuizDto,
+  ReorderQuestionsDto,
+  UpdateQuizDto,
+} from './dto';
+import {
+  CloneQuizResult,
+  CreateQuizResult,
+  DeleteQuizResult,
+  QuizDetailResult,
+  QuizzesListResult,
+  UpdateQuizResult,
+} from './results/quiz.result';
+
+export function CreateQuizSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Create a quiz (teacher → TEACHER_AUTHORED, system admin → SCHOS_CURATED)',
+    }),
+    ApiBody({ type: CreateQuizDto }),
+    ApiResponse({ status: 201, type: CreateQuizResult }),
+    ApiResponse({ status: 400, description: 'Validation failed (subject/level mismatch with owner)' }),
+    ApiResponse({ status: 403, description: 'User type not allowed to author quizzes' }),
+  );
+}
+
+export function ListMyQuizzesSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: "List the calling teacher's quizzes (filterable, paginated)" }),
+    ApiResponse({ status: 200, type: QuizzesListResult }),
+  );
+}
+
+export function ListLibraryQuizzesSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Browse the schos curated quiz library (filterable, paginated)' }),
+    ApiResponse({ status: 200, type: QuizzesListResult }),
+  );
+}
+
+export function GetQuizSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get a quiz by id with full questions list (visible if curated or owned by caller)',
+    }),
+    ApiParam({ name: 'id', description: 'Quiz id' }),
+    ApiResponse({ status: 200, type: QuizDetailResult }),
+    ApiResponse({ status: 404, description: 'Not found or not visible' }),
+  );
+}
+
+export function UpdateQuizSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Update quiz metadata. Bumps version. Existing assignments stay pinned to the version they were assigned with.',
+    }),
+    ApiParam({ name: 'id', description: 'Quiz id' }),
+    ApiBody({ type: UpdateQuizDto }),
+    ApiResponse({ status: 200, type: UpdateQuizResult }),
+    ApiResponse({ status: 403, description: 'You can only modify your own quizzes' }),
+  );
+}
+
+export function DeleteQuizSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Soft-archive a quiz. Rejected if any non-archived assignment still references it.',
+    }),
+    ApiParam({ name: 'id', description: 'Quiz id' }),
+    ApiResponse({ status: 200, type: DeleteQuizResult }),
+    ApiResponse({ status: 409, description: 'Quiz has active assignments' }),
+  );
+}
+
+export function CloneQuizSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        "Clone a curated (SCHOS_CURATED) quiz into the calling teacher's school as DRAFT. References the same curated questions; clone individual questions separately to customize them.",
+    }),
+    ApiParam({ name: 'id', description: 'Curated quiz id' }),
+    ApiResponse({ status: 201, type: CloneQuizResult }),
+    ApiResponse({ status: 403, description: 'Only teachers can clone' }),
+    ApiResponse({ status: 404, description: 'Curated quiz not found' }),
+  );
+}
+
+export function AttachQuestionsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Attach existing questions from the bank with order + optional weightOverride. Caller must own the quiz; questions must be curated or owned by caller. Curated quizzes accept curated questions only.',
+    }),
+    ApiParam({ name: 'id', description: 'Quiz id' }),
+    ApiBody({ type: AttachQuestionsDto }),
+    ApiResponse({ status: 200, type: UpdateQuizResult }),
+    ApiResponse({ status: 403, description: 'Cannot attach a question you do not own' }),
+    ApiResponse({ status: 409, description: 'Question already attached to this quiz' }),
+  );
+}
+
+export function DetachQuestionSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Detach a question from this quiz. Does NOT delete the underlying question.',
+    }),
+    ApiParam({ name: 'id', description: 'Quiz id' }),
+    ApiParam({ name: 'questionId', description: 'Question id' }),
+    ApiResponse({ status: 200, type: UpdateQuizResult }),
+    ApiResponse({ status: 404, description: 'Question is not attached to this quiz' }),
+  );
+}
+
+export function ReorderQuestionsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Bulk reorder. Payload must include EVERY currently-attached question exactly once.',
+    }),
+    ApiParam({ name: 'id', description: 'Quiz id' }),
+    ApiBody({ type: ReorderQuestionsDto }),
+    ApiResponse({ status: 200, type: UpdateQuizResult }),
+    ApiResponse({ status: 400, description: 'Reorder payload is incomplete or has duplicates' }),
+  );
+}

--- a/src/components/quizzes/results/index.ts
+++ b/src/components/quizzes/results/index.ts
@@ -1,0 +1,1 @@
+export * from './quiz.result';

--- a/src/components/quizzes/results/quiz.result.ts
+++ b/src/components/quizzes/results/quiz.result.ts
@@ -1,0 +1,231 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  PartialCreditMode,
+  PopularExam,
+  Question,
+  QuestionDifficulty,
+  QuestionOption,
+  QuestionOwnerType,
+  QuestionPopularExam,
+  QuestionStatus,
+  QuestionTopic,
+  QuestionType,
+  Quiz,
+  QuizOwnerType,
+  QuizQuestion,
+  QuizStatus,
+  QuizTopic,
+  Topic,
+} from '@prisma/client';
+
+import {
+  QuestionResult,
+} from '../../questions/results/question.result';
+
+type QuestionForQuiz = Question & {
+  options: QuestionOption[];
+  topics: (QuestionTopic & { topic: Topic })[];
+  popularExams: (QuestionPopularExam & { popularExam: PopularExam })[];
+  _count?: { quizUses: number };
+};
+
+type QuizQuestionWithQuestion = QuizQuestion & { question: QuestionForQuiz };
+
+type QuizWithRelations = Quiz & {
+  topics: (QuizTopic & { topic: Topic })[];
+  questions: QuizQuestionWithQuestion[];
+  _count?: { questions: number; assignments: number };
+};
+
+type QuizListItem = Quiz & {
+  topics: (QuizTopic & { topic: Topic })[];
+  questions: { weightOverride: unknown; question: { weight: unknown } }[];
+  _count?: { questions: number; assignments: number };
+};
+
+export class QuizTopicTagResult {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() slug: string;
+
+  constructor(t: Topic) {
+    this.id = t.id;
+    this.name = t.name;
+    this.slug = t.slug;
+  }
+}
+
+export class QuizQuestionEntryResult {
+  @ApiProperty() questionId: string;
+  @ApiProperty() order: number;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal as string' })
+  weightOverride: string | null;
+  @ApiProperty({ description: 'weightOverride ?? question.weight' })
+  effectiveWeight: string;
+  @ApiProperty({ type: QuestionResult }) question: QuestionResult;
+
+  constructor(qq: QuizQuestionWithQuestion) {
+    this.questionId = qq.questionId;
+    this.order = qq.order;
+    this.weightOverride = qq.weightOverride !== null ? qq.weightOverride.toString() : null;
+    this.effectiveWeight = (qq.weightOverride ?? qq.question.weight).toString();
+    this.question = new QuestionResult(qq.question);
+  }
+}
+
+abstract class QuizBase {
+  @ApiProperty() id: string;
+  @ApiProperty({ enum: QuizOwnerType }) ownerType: QuizOwnerType;
+  @ApiProperty({ required: false, nullable: true }) schoolId: string | null;
+  @ApiProperty() authorUserId: string;
+  @ApiProperty() title: string;
+  @ApiProperty({ required: false, nullable: true }) description: string | null;
+  @ApiProperty({ required: false, nullable: true }) instructions: string | null;
+  @ApiProperty({ required: false, nullable: true }) subjectId: string | null;
+  @ApiProperty({ required: false, nullable: true }) levelId: string | null;
+  @ApiProperty({ required: false, nullable: true }) defaultTermId: string | null;
+  @ApiProperty({ required: false, nullable: true }) canonicalSubjectName: string | null;
+  @ApiProperty({ required: false, nullable: true }) canonicalLevelCode: string | null;
+  @ApiProperty({ required: false, nullable: true }) canonicalTermName: string | null;
+  @ApiProperty({ enum: QuizStatus }) status: QuizStatus;
+  @ApiProperty({ required: false, nullable: true }) estimatedMinutes: number | null;
+  @ApiProperty({ required: false, nullable: true, description: 'Decimal as string' })
+  passMarkPercent: string | null;
+  @ApiProperty({ enum: QuestionDifficulty, required: false, nullable: true })
+  difficulty: QuestionDifficulty | null;
+  @ApiProperty({ required: false, nullable: true, description: 'Default delivery settings (JSON)' })
+  defaultSettings: unknown;
+  @ApiProperty({ required: false, nullable: true }) sourceQuizId: string | null;
+  @ApiProperty() version: number;
+  @ApiProperty({ type: [QuizTopicTagResult] }) topics: QuizTopicTagResult[];
+  @ApiProperty({ description: 'Number of questions in this quiz' }) questionCount: number;
+  @ApiProperty({ description: 'Number of QuizAssignments referencing this quiz' })
+  assignmentCount: number;
+  @ApiProperty({ description: 'Sum of effective weights across all attached questions, as string' })
+  totalWeight: string;
+  @ApiProperty() createdAt: Date;
+  @ApiProperty() updatedAt: Date;
+
+  constructor(q: QuizWithRelations | QuizListItem, totalWeight: string) {
+    this.id = q.id;
+    this.ownerType = q.ownerType;
+    this.schoolId = q.schoolId;
+    this.authorUserId = q.authorUserId;
+    this.title = q.title;
+    this.description = q.description;
+    this.instructions = q.instructions;
+    this.subjectId = q.subjectId;
+    this.levelId = q.levelId;
+    this.defaultTermId = q.defaultTermId;
+    this.canonicalSubjectName = q.canonicalSubjectName;
+    this.canonicalLevelCode = q.canonicalLevelCode;
+    this.canonicalTermName = q.canonicalTermName;
+    this.status = q.status;
+    this.estimatedMinutes = q.estimatedMinutes;
+    this.passMarkPercent = q.passMarkPercent !== null ? q.passMarkPercent.toString() : null;
+    this.difficulty = q.difficulty;
+    this.defaultSettings = q.defaultSettings;
+    this.sourceQuizId = q.sourceQuizId;
+    this.version = q.version;
+    this.topics = q.topics.map((t) => new QuizTopicTagResult(t.topic));
+    this.questionCount = q._count?.questions ?? 0;
+    this.assignmentCount = q._count?.assignments ?? 0;
+    this.totalWeight = totalWeight;
+    this.createdAt = q.createdAt;
+    this.updatedAt = q.updatedAt;
+  }
+}
+
+/** Lightweight summary used in list endpoints. */
+export class QuizSummaryResult extends QuizBase {
+  constructor(q: QuizListItem) {
+    const total = q.questions.reduce((sum, qq) => {
+      const weight = (qq.weightOverride as { toString(): string } | null) ?? (qq.question.weight as { toString(): string });
+      return sum + Number(weight.toString());
+    }, 0);
+    super(q, total.toFixed(2));
+  }
+}
+
+/** Full detail used by GET /:id including each composed question. */
+export class QuizDetailResult extends QuizBase {
+  @ApiProperty({ type: [QuizQuestionEntryResult] }) questions: QuizQuestionEntryResult[];
+
+  constructor(q: QuizWithRelations) {
+    const sorted = [...q.questions].sort((a, b) => a.order - b.order);
+    const totalWeight = sorted
+      .reduce((sum, qq) => {
+        const w = (qq.weightOverride ?? qq.question.weight) as { toString(): string };
+        return sum + Number(w.toString());
+      }, 0)
+      .toFixed(2);
+    super(q, totalWeight);
+    this.questions = sorted.map((qq) => new QuizQuestionEntryResult(qq));
+  }
+}
+
+export class QuizzesListResult {
+  @ApiProperty({ type: [QuizSummaryResult] }) items: QuizSummaryResult[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+
+  constructor(items: QuizSummaryResult[], total: number, page: number, limit: number) {
+    this.items = items;
+    this.total = total;
+    this.page = page;
+    this.limit = limit;
+  }
+}
+
+export class CreateQuizResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuizDetailResult }) quiz: QuizDetailResult;
+
+  constructor(quiz: QuizDetailResult) {
+    this.success = true;
+    this.message = 'Quiz created successfully';
+    this.quiz = quiz;
+  }
+}
+
+export class UpdateQuizResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuizDetailResult }) quiz: QuizDetailResult;
+
+  constructor(quiz: QuizDetailResult) {
+    this.success = true;
+    this.message = 'Quiz updated successfully';
+    this.quiz = quiz;
+  }
+}
+
+export class DeleteQuizResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+
+  constructor() {
+    this.success = true;
+    this.message = 'Quiz archived successfully';
+  }
+}
+
+export class CloneQuizResult {
+  @ApiProperty({ default: true }) success: boolean;
+  @ApiProperty() message: string;
+  @ApiProperty({ type: QuizDetailResult }) quiz: QuizDetailResult;
+
+  constructor(quiz: QuizDetailResult) {
+    this.success = true;
+    this.message = 'Quiz cloned successfully';
+    this.quiz = quiz;
+  }
+}
+
+// suppress unused enum imports
+void QuestionType;
+void QuestionStatus;
+void QuestionOwnerType;
+void PartialCreditMode;

--- a/src/components/topics/dto/create-topic.dto.ts
+++ b/src/components/topics/dto/create-topic.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+export class CreateTopicDto {
+  @ApiProperty({
+    description: 'Display name (e.g. "Newton\'s Laws of Motion")',
+    example: "Newton's Laws of Motion",
+  })
+  @IsString()
+  @MaxLength(200)
+  name: string;
+
+  @ApiProperty({
+    description: 'Globally-unique URL slug. Lowercase letters, digits, hyphens.',
+    example: 'physics-ss2-newtons-laws',
+  })
+  @IsString()
+  @Matches(/^[a-z0-9]+(-[a-z0-9]+)*$/, {
+    message: 'slug must be lowercase, alphanumeric with hyphens (e.g. my-topic-name)',
+  })
+  @MaxLength(120)
+  slug: string;
+
+  @ApiProperty({
+    description: 'Canonical subject name (case-insensitive matched against School.Subject.name)',
+    example: 'Physics',
+  })
+  @IsString()
+  @MaxLength(100)
+  canonicalSubjectName: string;
+
+  @ApiProperty({
+    description: 'Canonical level code matched against School.Level.code',
+    example: 'SS2',
+  })
+  @IsString()
+  @MaxLength(20)
+  canonicalLevelCode: string;
+
+  @ApiProperty({ required: false, description: 'Parent topic id for subtopics' })
+  @IsOptional()
+  @IsUUID()
+  parentTopicId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false, default: 0, description: 'Display order among siblings' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number;
+}

--- a/src/components/topics/dto/index.ts
+++ b/src/components/topics/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './create-topic.dto';
+export * from './update-topic.dto';
+export * from './topic-query.dto';

--- a/src/components/topics/dto/topic-query.dto.ts
+++ b/src/components/topics/dto/topic-query.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class TopicQueryDto {
+  @ApiProperty({ required: false, description: 'Filter to topics for this subject (case-insensitive)' })
+  @IsOptional()
+  @IsString()
+  canonicalSubjectName?: string;
+
+  @ApiProperty({ required: false, description: 'Filter to topics for this level code' })
+  @IsOptional()
+  @IsString()
+  canonicalLevelCode?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Filter to direct children of this topic. Pass an id, or "root" to get top-level topics only.',
+  })
+  @IsOptional()
+  @IsString()
+  parentTopicId?: string;
+
+  @ApiProperty({ required: false, description: 'Free-text search on name' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({ required: false, default: false, description: 'If true, also include soft-deleted topics' })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  includeDeleted?: boolean;
+}

--- a/src/components/topics/dto/update-topic.dto.ts
+++ b/src/components/topics/dto/update-topic.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, IsUUID, MaxLength, Min } from 'class-validator';
+
+/**
+ * `slug`, `canonicalSubjectName`, and `canonicalLevelCode` are intentionally
+ * omitted — they are part of the topic's identity. To re-tag, archive and
+ * recreate.
+ */
+export class UpdateTopicDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  name?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false, description: 'Move to a different parent (or null to make root)' })
+  @IsOptional()
+  @IsUUID()
+  parentTopicId?: string | null;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number;
+}

--- a/src/components/topics/results/index.ts
+++ b/src/components/topics/results/index.ts
@@ -1,0 +1,1 @@
+export * from './topic.result';

--- a/src/components/topics/results/topic.result.ts
+++ b/src/components/topics/results/topic.result.ts
@@ -1,0 +1,113 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TopicResult {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @ApiProperty({ example: "Newton's Laws of Motion" })
+  name: string;
+
+  @ApiProperty({ example: 'physics-ss2-newtons-laws' })
+  slug: string;
+
+  @ApiProperty({ nullable: true })
+  description: string | null;
+
+  @ApiProperty({ nullable: true, example: null })
+  parentTopicId: string | null;
+
+  @ApiProperty({ example: 0 })
+  order: number;
+
+  @ApiProperty({ example: 'Physics' })
+  canonicalSubjectName: string;
+
+  @ApiProperty({ example: 'SS2' })
+  canonicalLevelCode: string;
+
+  @ApiProperty({ example: '2026-04-25T00:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2026-04-25T00:00:00.000Z' })
+  updatedAt: Date;
+
+  constructor(topic: {
+    id: string;
+    name: string;
+    slug: string;
+    description: string | null;
+    parentTopicId: string | null;
+    order: number;
+    canonicalSubjectName: string;
+    canonicalLevelCode: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = topic.id;
+    this.name = topic.name;
+    this.slug = topic.slug;
+    this.description = topic.description;
+    this.parentTopicId = topic.parentTopicId;
+    this.order = topic.order;
+    this.canonicalSubjectName = topic.canonicalSubjectName;
+    this.canonicalLevelCode = topic.canonicalLevelCode;
+    this.createdAt = topic.createdAt;
+    this.updatedAt = topic.updatedAt;
+  }
+}
+
+export class TopicsListResult {
+  @ApiProperty({ type: [TopicResult] })
+  topics: TopicResult[];
+
+  constructor(topics: TopicResult[]) {
+    this.topics = topics;
+  }
+}
+
+export class CreateTopicResult {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Topic created successfully' })
+  message: string;
+
+  @ApiProperty({ type: TopicResult })
+  topic: TopicResult;
+
+  constructor(topic: TopicResult) {
+    this.success = true;
+    this.message = 'Topic created successfully';
+    this.topic = topic;
+  }
+}
+
+export class UpdateTopicResult {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Topic updated successfully' })
+  message: string;
+
+  @ApiProperty({ type: TopicResult })
+  topic: TopicResult;
+
+  constructor(topic: TopicResult) {
+    this.success = true;
+    this.message = 'Topic updated successfully';
+    this.topic = topic;
+  }
+}
+
+export class DeleteTopicResult {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Topic deleted successfully' })
+  message: string;
+
+  constructor() {
+    this.success = true;
+    this.message = 'Topic deleted successfully';
+  }
+}

--- a/src/components/topics/topics.controller.ts
+++ b/src/components/topics/topics.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { SystemAdminGuard } from '../../common/guards';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { CreateTopicDto, TopicQueryDto, UpdateTopicDto } from './dto';
+import {
+  CreateTopicResult,
+  DeleteTopicResult,
+  TopicResult,
+  TopicsListResult,
+  UpdateTopicResult,
+} from './results/topic.result';
+import { TopicsService } from './topics.service';
+import {
+  CreateTopicSwagger,
+  DeleteTopicSwagger,
+  GetTopicSwagger,
+  ListTopicsSwagger,
+  UpdateTopicSwagger,
+} from './topics.swagger';
+
+@Controller('topics')
+@ApiTags('Topics')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class TopicsController {
+  constructor(private readonly topicsService: TopicsService) {}
+
+  @Get()
+  @ListTopicsSwagger()
+  async list(@Query() query: TopicQueryDto) {
+    const topics = await this.topicsService.list(query);
+    return new TopicsListResult(topics.map((t) => new TopicResult(t)));
+  }
+
+  @Get(':id')
+  @GetTopicSwagger()
+  async findById(@Param('id') id: string) {
+    const topic = await this.topicsService.findById(id);
+    return new TopicResult(topic);
+  }
+
+  @Post()
+  @UseGuards(SystemAdminGuard)
+  @CreateTopicSwagger()
+  async create(@Body() dto: CreateTopicDto) {
+    const topic = await this.topicsService.create(dto);
+    return new CreateTopicResult(new TopicResult(topic));
+  }
+
+  @Patch(':id')
+  @UseGuards(SystemAdminGuard)
+  @UpdateTopicSwagger()
+  async update(@Param('id') id: string, @Body() dto: UpdateTopicDto) {
+    const topic = await this.topicsService.update(id, dto);
+    return new UpdateTopicResult(new TopicResult(topic));
+  }
+
+  @Delete(':id')
+  @UseGuards(SystemAdminGuard)
+  @DeleteTopicSwagger()
+  async delete(@Param('id') id: string) {
+    await this.topicsService.softDelete(id);
+    return new DeleteTopicResult();
+  }
+}

--- a/src/components/topics/topics.module.ts
+++ b/src/components/topics/topics.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { TopicsController } from './topics.controller';
+import { TopicsService } from './topics.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [TopicsController],
+  providers: [TopicsService, Encryptor],
+  exports: [TopicsService],
+})
+export class TopicsModule {}

--- a/src/components/topics/topics.service.ts
+++ b/src/components/topics/topics.service.ts
@@ -1,0 +1,168 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateTopicDto, TopicQueryDto, UpdateTopicDto } from './dto';
+
+@Injectable()
+export class TopicsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(query: TopicQueryDto) {
+    const where: Prisma.TopicWhereInput = {};
+
+    if (!query.includeDeleted) where.deletedAt = null;
+
+    if (query.canonicalSubjectName) {
+      where.canonicalSubjectName = {
+        equals: query.canonicalSubjectName,
+        mode: 'insensitive',
+      };
+    }
+    if (query.canonicalLevelCode) {
+      where.canonicalLevelCode = {
+        equals: query.canonicalLevelCode,
+        mode: 'insensitive',
+      };
+    }
+
+    if (query.parentTopicId !== undefined) {
+      where.parentTopicId = query.parentTopicId === 'root' ? null : query.parentTopicId;
+    }
+
+    if (query.search) {
+      where.name = { contains: query.search, mode: 'insensitive' };
+    }
+
+    return this.prisma.topic.findMany({
+      where,
+      orderBy: [{ canonicalSubjectName: 'asc' }, { canonicalLevelCode: 'asc' }, { order: 'asc' }, { name: 'asc' }],
+    });
+  }
+
+  async findById(id: string) {
+    const topic = await this.prisma.topic.findFirst({
+      where: { id, deletedAt: null },
+    });
+    if (!topic) throw new NotFoundException('Topic not found');
+    return topic;
+  }
+
+  async create(dto: CreateTopicDto) {
+    const existingSlug = await this.prisma.topic.findUnique({ where: { slug: dto.slug } });
+    if (existingSlug) {
+      throw new ConflictException(`Topic with slug '${dto.slug}' already exists`);
+    }
+
+    if (dto.parentTopicId) {
+      const parent = await this.findById(dto.parentTopicId);
+      if (
+        parent.canonicalSubjectName.toLowerCase() !== dto.canonicalSubjectName.toLowerCase() ||
+        parent.canonicalLevelCode.toLowerCase() !== dto.canonicalLevelCode.toLowerCase()
+      ) {
+        throw new BadRequestException(
+          'Subtopic must share parent\'s canonicalSubjectName and canonicalLevelCode',
+        );
+      }
+    }
+
+    return this.prisma.topic.create({
+      data: {
+        name: dto.name,
+        slug: dto.slug,
+        description: dto.description,
+        parentTopicId: dto.parentTopicId,
+        order: dto.order ?? 0,
+        canonicalSubjectName: dto.canonicalSubjectName,
+        canonicalLevelCode: dto.canonicalLevelCode,
+      },
+    });
+  }
+
+  async update(id: string, dto: UpdateTopicDto) {
+    const existing = await this.findById(id);
+
+    if (dto.parentTopicId !== undefined && dto.parentTopicId !== null) {
+      if (dto.parentTopicId === id) {
+        throw new BadRequestException('A topic cannot be its own parent');
+      }
+      const parent = await this.findById(dto.parentTopicId);
+      if (
+        parent.canonicalSubjectName.toLowerCase() !== existing.canonicalSubjectName.toLowerCase() ||
+        parent.canonicalLevelCode.toLowerCase() !== existing.canonicalLevelCode.toLowerCase()
+      ) {
+        throw new BadRequestException(
+          'New parent must share this topic\'s canonicalSubjectName and canonicalLevelCode',
+        );
+      }
+      await this.assertNotDescendant(id, dto.parentTopicId);
+    }
+
+    return this.prisma.topic.update({
+      where: { id },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.parentTopicId !== undefined && { parentTopicId: dto.parentTopicId }),
+        ...(dto.order !== undefined && { order: dto.order }),
+      },
+    });
+  }
+
+  async softDelete(id: string) {
+    await this.findById(id);
+
+    const childCount = await this.prisma.topic.count({
+      where: { parentTopicId: id, deletedAt: null },
+    });
+    if (childCount > 0) {
+      throw new ConflictException(
+        `Cannot delete: ${childCount} subtopic(s) exist. Delete or reparent them first.`,
+      );
+    }
+
+    const [questionTagCount, quizTagCount] = await Promise.all([
+      this.prisma.questionTopic.count({ where: { topicId: id } }),
+      this.prisma.quizTopic.count({ where: { topicId: id } }),
+    ]);
+    const refs = questionTagCount + quizTagCount;
+    if (refs > 0) {
+      throw new ConflictException(
+        `Cannot delete: topic is referenced by ${questionTagCount} question(s) and ${quizTagCount} quiz(zes).`,
+      );
+    }
+
+    await this.prisma.topic.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  /**
+   * Walk up from `candidateAncestorId` and ensure we never hit `id` — i.e.
+   * setting candidateAncestorId as id's parent would NOT create a cycle.
+   */
+  private async assertNotDescendant(id: string, candidateAncestorId: string): Promise<void> {
+    let cursor: string | null = candidateAncestorId;
+    const seen = new Set<string>();
+    while (cursor) {
+      if (seen.has(cursor)) return;
+      seen.add(cursor);
+      if (cursor === id) {
+        throw new BadRequestException(
+          'Cannot move: candidate parent is a descendant of this topic (would create a cycle)',
+        );
+      }
+      const next = await this.prisma.topic.findUnique({
+        where: { id: cursor },
+        select: { parentTopicId: true },
+      });
+      cursor = next?.parentTopicId ?? null;
+    }
+  }
+}

--- a/src/components/topics/topics.swagger.ts
+++ b/src/components/topics/topics.swagger.ts
@@ -1,0 +1,63 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+
+import { CreateTopicDto, UpdateTopicDto } from './dto';
+import {
+  CreateTopicResult,
+  DeleteTopicResult,
+  TopicResult,
+  TopicsListResult,
+  UpdateTopicResult,
+} from './results/topic.result';
+
+export function ListTopicsSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'List topics. Filter by subject, level, parent, search.',
+      description: 'Pass parentTopicId="root" to fetch top-level topics only.',
+    }),
+    ApiResponse({ status: 200, type: TopicsListResult }),
+  );
+}
+
+export function GetTopicSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get a single topic by id' }),
+    ApiParam({ name: 'id', description: 'Topic id' }),
+    ApiResponse({ status: 200, type: TopicResult }),
+    ApiResponse({ status: 404, description: 'Not found' }),
+  );
+}
+
+export function CreateTopicSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a topic (system admin only)' }),
+    ApiBody({ type: CreateTopicDto }),
+    ApiResponse({ status: 201, type: CreateTopicResult }),
+    ApiResponse({ status: 409, description: 'Slug already in use' }),
+    ApiResponse({ status: 400, description: 'Subtopic subject/level mismatch with parent' }),
+  );
+}
+
+export function UpdateTopicSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update a topic (system admin only)' }),
+    ApiParam({ name: 'id', description: 'Topic id' }),
+    ApiBody({ type: UpdateTopicDto }),
+    ApiResponse({ status: 200, type: UpdateTopicResult }),
+    ApiResponse({ status: 400, description: 'Cycle detected or subject/level mismatch with new parent' }),
+    ApiResponse({ status: 404, description: 'Not found' }),
+  );
+}
+
+export function DeleteTopicSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Soft-delete a topic (system admin only). Rejects if it has subtopics or referencing questions/quizzes.',
+    }),
+    ApiParam({ name: 'id', description: 'Topic id' }),
+    ApiResponse({ status: 200, type: DeleteTopicResult }),
+    ApiResponse({ status: 404, description: 'Not found' }),
+    ApiResponse({ status: 409, description: 'Topic has subtopics or is referenced' }),
+  );
+}

--- a/src/shared/services/pdf.service.ts
+++ b/src/shared/services/pdf.service.ts
@@ -148,14 +148,16 @@ export class PdfService implements OnModuleInit, OnModuleDestroy {
       return this.templateCache.get(templateId)!;
     }
 
-    // Try multiple paths: ts-node/dev (__dirname relative), then production paths
-    // In dev: __dirname = src/shared/services → ../templates works
-    // In prod: __dirname = dist/src/shared/services → need to go up further
+    // Try multiple paths: ts-node/dev (__dirname relative), production dist paths,
+    // then a final fallback that reads directly from the checked-out src/ folder.
+    // The src/ fallback covers the case where `nest build` didn't copy assets
+    // (intermittent on the Lightsail deploy) — the repo is still on disk.
     const candidates = [
       join(__dirname, '..', 'templates', 'results', `${templateId}.hbs`),
       join(__dirname, '..', '..', '..', 'shared', 'templates', 'results', `${templateId}.hbs`),
       join(process.cwd(), 'dist', 'shared', 'templates', 'results', `${templateId}.hbs`),
       join(process.cwd(), 'dist', 'src', 'shared', 'templates', 'results', `${templateId}.hbs`),
+      join(process.cwd(), 'src', 'shared', 'templates', 'results', `${templateId}.hbs`),
     ];
     const templatePath = candidates.find((p) => existsSync(p));
     if (!templatePath) {


### PR DESCRIPTION
* feat(quiz): add Prisma schema for quiz/assessment system

Foundational data model for a first-class question bank, reusable quizzes, live assignments with auto-grading, and aggregation back into the existing AssessmentStructureTemplate gradebook.

New tables (15):
- Topic, PopularExam — schos-managed taxonomies
- Question, QuestionOption, QuestionTopic, QuestionPopularExam — reusable question bank with weight (default 1), topic + popular-exam (with year) tagging, version-on-edit
- Quiz, QuizQuestion, QuizTopic — quiz composition with per-quiz weight overrides
- QuizAssignment, QuizAttemptOverride — class scheduling with OPEN_WINDOW / SYNC_START modes and per-student retry/extension
- QuizAttempt, QuestionResponse — student attempts with snapshot weights so grading stays stable across question edits
- QuizScoreAggregation, QuizScoreAggregationItem — merge multiple quizzes into one ClassArmStudentAssessment slot

New enums (14): question/quiz owner types, question type and status, quiz delivery mode/status, attempt + override types, aggregation method, missing-attempt policy.

Back-references added (purely additive) to User, Teacher, School, Subject, Level, Term, ClassArmSubject, Student.

No backend services or seed data yet — those follow in subsequent commits on this branch.
EOF

* feat(quiz): add topics and popular-exams taxonomy modules

Reference data for the question bank. Reads are open to authenticated users; writes are restricted to SYSTEM_ADMIN (which includes PLATFORM_ADMIN since User.type='SYSTEM_ADMIN' is the broad gate).

PopularExamsModule:
- GET /popular-exams (filter by active, country)
- POST/PATCH/DELETE /popular-exams[/:id] (system admin)
- Soft-delete blocked when questions reference the exam

TopicsModule:
- GET /topics (filter by canonicalSubjectName, canonicalLevelCode, parentTopicId='root', search)
- GET /topics/:id
- POST/PATCH/DELETE /topics[/:id] (system admin)
- Subtopics must share parent's subject + level
- Move-to-new-parent walks ancestors to prevent cycles
- Delete blocked if subtopics or referencing questions/quizzes exist

Adds SystemAdminGuard mirroring SuperAdminGuard but checking User.type === 'SYSTEM_ADMIN'. Documented to never inspect SystemAdmin.role, so PLATFORM_ADMIN keeps satisfying every gate.

Seeds 13 popular exams idempotently from prisma/seed.ts: WAEC, NECO, JAMB, NABTEB, BECE, COMMON_ENTRANCE, IGCSE, CHECKPOINT, A_LEVELS, O_LEVELS, SAT, TOEFL, IELTS.

* feat(quiz): add questions module with canonical taxonomy fields

QuestionsModule — first-class question bank with type-specific config, weight (default 1), topic + popular-exam tagging, and clone-from-curated.

Endpoints (all /questions, AccessTokenGuard):
- POST    /questions               create (owner derived from user.type)
- GET     /questions/mine          calling teacher's bank, paginated
- GET     /questions/library       schos curated bank, paginated
- GET     /questions/:id           visible if curated or owned
- PATCH   /questions/:id           owner-only edit; bumps version
- DELETE  /questions/:id           soft-archive; blocked if quiz refs
- POST    /questions/:id/clone     teacher clones a curated question

Filters: subjectId, levelId, canonicalSubjectName, canonicalLevelCode, canonicalTermName, topicIds[], popularExamId, examYear, type, difficulty, status, search (promptPlainText contains, case-insensitive), page, limit.

Authoring rules:
- TEACHER (TEACHER_AUTHORED): subjectId+levelId required, defaultTermId optional; school FKs validated against caller's school. Canonical fields auto-derived from subject.name / level.code / term.name on create if not provided so teacher questions are also discoverable in cross-school flows.
- SYSTEM_ADMIN/PLATFORM_ADMIN (SCHOS_CURATED): school FKs forbidden; canonicalSubjectName + canonicalLevelCode required so the library is filterable by level/grade/term/subject.

Edit protection: editing a PUBLISHED question that is referenced by any PUBLISHED quiz is rejected with the blocking quiz titles in the error — caller is told to clone instead.

Type-specific validation in service:
- MCQ_SINGLE: >=2 options, exactly 1 correct
- MCQ_MULTI : >=2 options, >=1 correct, partialCreditMode allowed
- TRUE_FALSE: no options; config.correctAnswer (boolean)
- NUMERIC  : no options; config.{correctAnswer:number, tolerance:number>=0, toleranceMode:'ABSOLUTE'|'PERCENT', unit?:string}
- SHORT_ANSWER: no options; config.acceptedAnswers (non-empty string array), caseSensitive, normalizeWhitespace

Schema migration add_canonical_taxonomy_fields adds three nullable columns + a (canonicalSubjectName, canonicalLevelCode) index to both questions and quizzes. The Quiz fields are added now so step 4 (QuizzesModule) can use them without an extra migration.

Tag handling on update is replace-all (delete junctions + recreate) inside a transaction with the question update, so partial tag edits don't leave stale junction rows.

* feat(quiz): add quizzes module with composition endpoints

QuizzesModule — quiz CRUD plus QuizQuestion composition (attach, detach, reorder). Same owner-derivation as questions: teacher creates TEACHER_AUTHORED in their school, system admin / platform admin creates SCHOS_CURATED. Canonical taxonomy fields (subject/level/term) follow the same auto-derive-for-teacher / require-for-curated rule.

Endpoints (all /quizzes, AccessTokenGuard):
- POST    /quizzes                                create
- GET     /quizzes/mine                           teacher's bank, paged
- GET     /quizzes/library                        curated bank, paged
- GET     /quizzes/:id                            full detail
- PATCH   /quizzes/:id                            owner-only metadata edit
- DELETE  /quizzes/:id                            soft-archive
- POST    /quizzes/:id/clone                      teacher clones curated
- POST    /quizzes/:id/questions                  bulk attach
- DELETE  /quizzes/:id/questions/:questionId      detach
- PATCH   /quizzes/:id/questions/reorder          bulk reorder

List endpoints return summary stats only (questionCount, totalWeight, assignmentCount). GET /quizzes/:id returns each composed question fully embedded with order, weightOverride, and effectiveWeight.

Filters: subjectId, levelId, canonicalSubjectName, canonicalLevelCode, canonicalTermName, topicIds[], difficulty, status, search (title contains, case-insensitive), page, limit.

Composition rules:
- Caller must own the quiz to attach/detach/reorder.
- Attach validates each question is either SCHOS_CURATED or owned by the caller (TEACHER_AUTHORED + same school + same author).
- Curated quizzes accept curated questions only — teacher questions cannot leak into curated content.
- Clone copies the quiz + QuizQuestion junctions referencing the same curated questions; teachers clone individual questions separately if they need to customize them.
- Reorder uses a two-phase update (negative temp orders, then final values) to dodge the (quizId, order) unique constraint.

Edit / delete protection:
- Every metadata edit and every composition change bumps Quiz.version. Existing QuizAssignments stay pinned to the version they snapshotted on assignment, so historical attempts remain stable.
- Delete is rejected if any non-archived QuizAssignment still references the quiz.

defaultSettings (JSON column) carries the quiz-level delivery defaults: shuffleQuestions, shuffleOptions, showResultsImmediately, allowReview, showCorrectAnswers. QuizAssignment (step 5) will be able to override result-visibility per assignment.

* feat(quiz): add quiz-assignments module (scheduling + overrides)

QuizAssignmentsModule — teachers schedule a published quiz to a class arm subject with mode/window/duration/maxAttempts and optional result-visibility overrides. Synchronous slice; quiz-attempts and grading processor follow in the next commit.

Endpoints (all /quiz-assignments, AccessTokenGuard):
- POST   /quiz-assignments                          create (snapshots quiz.version)
- GET    /quiz-assignments                          teacher list (own + taught)
- GET    /quiz-assignments/mine                     student list (active enrolments)
- GET    /quiz-assignments/:id                      detail (auto-routes by role)
- PATCH  /quiz-assignments/:id                      edit window/duration/settings
- DELETE /quiz-assignments/:id                      cancel (no attempts started)
- POST   /quiz-assignments/:id/overrides            grant per-student exception
- POST   /quiz-assignments/:id/release-results      release held results
- GET    /quiz-assignments/:id/monitor              live student-status board
- GET    /quiz-assignments/:id/results              graded scores per student

Authorization:
- Teacher write/manage: must be the assignedByTeacher OR currently teaching the classArmSubject (via ClassArmSubjectTeacher).
- Student read: must have an active ClassArmStudent enrolment for the assignment's classArm.
- GET /:id auto-detects role: tries the teacher path first and falls back to the student path on Forbidden/NotFound.

Validation:
- Quiz must be PUBLISHED and visible (SCHOS_CURATED or same school) before it can be assigned. quiz.version is snapshotted onto the assignment so future quiz edits don't perturb in-flight delivery.
- windowClosesAt > windowOpensAt; durationMinutes must fit inside the window for both modes (avoids cut-off late joiners).
- Edits permitted only while now < windowOpensAt (status SCHEDULED); quizId / classArmSubjectId / termId are immutable.
- Cancel rejected once any attempt exists.
- Overrides validated per type:
  RETRY         requires extraAttempts >= 1
  EXTRA_TIME    requires extraMinutes >= 1
  EXTEND_WINDOW requires newWindowClosesAt > current windowClosesAt
  All overrides require a reason (audit trail).
- Release-results idempotent; rejected if showResultsImmediately is
  explicitly true (nothing to release).

Status:
- Stored status is only meaningful for ARCHIVED (manual cancel).
- effectiveStatus is computed on read from window times so we don't need a cron to keep SCHEDULED -> OPEN -> CLOSED transitions fresh. UI gating uses effectiveStatus.

Monitor groups attempts by student and returns NOT_STARTED counts alongside the IN_PROGRESS / SUBMITTED / GRADING / GRADED breakdown for the dashboard summary tile.

* feat(quiz): add quiz-attempts module with BullMQ grading + auto-submit

QuizAttemptsModule — student-facing attempt lifecycle with server-authoritative timer, async grading, and a repeatable cron tick that auto-submits attempts past dueAt. Completes the v1 backend slice: assignment -> attempt -> grading -> results gating.

Endpoints (all /quiz-attempts, AccessTokenGuard, student-only):
- POST   /quiz-attempts/start                start or resume (refresh-resilient)
- GET    /quiz-attempts/mine                 paged list of own attempts
- GET    /quiz-attempts/:id                  detail (visibility-aware)
- PATCH  /quiz-attempts/:id/responses        autosave; returns dueAt
- POST   /quiz-attempts/:id/submit           manual submit; enqueues grading
- POST   /quiz-attempts/:id/page-event       anti-cheat trace

BullMQ (queue: quiz-attempts-queue):
- GRADE_ATTEMPT — one-off, attempts=3 with exponential backoff. Fired on submit. Inline grading fallback if enqueue fails so a Redis blip cannot strand students.
- AUTO_SUBMIT_TICK — repeatable every 60s, singleton jobId so only one tick runs across the cluster. Scans up to 100 IN_PROGRESS attempts past dueAt per tick, marks autoSubmitted=true, enqueues grading.

Graders (pure, per-type fraction in [0, 1]) — pointsAwarded = response.weight x fraction:
- MCQ_SINGLE  : exact match
- MCQ_MULTI   : (correct - incorrect) / totalCorrect floor 0 when
                PROPORTIONAL; else all-or-nothing
- TRUE_FALSE  : direct boolean match
- NUMERIC     : tolerance ABSOLUTE or PERCENT; optional unit match
- SHORT_ANSWER: normalize whitespace + casefold per config; any
                acceptedAnswer matches

Bad/missing responses return 0 (no exception) so a single malformed answer cannot poison the rest of the attempt.

Lifecycle:
- start() pre-creates one QuestionResponse per attached question with weight snapshotted from QuizQuestion.weightOverride ?? Question.weight so grading stays stable even if weights change later.
- dueAt computed at start, capped by EXTEND_WINDOW overrides and extended by EXTRA_TIME overrides. SYNC_START locks dueAt to windowOpensAt + duration; late joiners within syncGracePeriodSeconds start now but share the global dueAt.
- saveResponses re-checks ownership + IN_PROGRESS + now < dueAt every call; past dueAt it auto-submits and rejects with 409 (server is the timer, not the client).
- submit marks SUBMITTED, sets autoSubmitted if past dueAt, enqueues grading. Refreshing /start returns the existing IN_PROGRESS attempt rather than burning another attempt.
- page-event appends { event, clientTs, serverTs } to pageVisibilityEvents JSON.

Visibility resolution (single source of truth):
- resultsVisible = showResultsImmediately || resultsReleasedAt != null, where showResultsImmediately falls through assignment overrides -> quiz.defaultSettings -> false.
- showCorrectAnswers same fallthrough.
- AttemptResult redacts in three tiers: in-progress (no scores, no correct flags, no explanations, NUMERIC config keeps only `unit`); graded-but-held (same redaction); released (full scores + correct flags + explanation when showCorrectAnswers).

Override application:
- RETRY        : sum extraAttempts onto effectiveMaxAttempts.
- EXTRA_TIME   : sum extraMinutes onto dueAt.
- EXTEND_WINDOW: max(newWindowClosesAt) raises the cap.

Module registers BullModule.registerQueue locally so the project's existing forRootAsync Redis connection is reused.

* feat(quiz): add quiz-aggregations module — bridge to legacy gradebook

QuizAggregationsModule — merges N quiz scores into a single slot of the existing AssessmentStructureTemplate so quiz outcomes flow through the legacy results / broadsheet UIs unchanged. Closes the v1 backend loop: assignment -> attempt -> grading -> aggregation -> existing ClassArmStudentAssessment row.

Endpoints (all /quiz-aggregations, AccessTokenGuard, teacher-only):
- POST   /quiz-aggregations                  create DRAFT
- GET    /quiz-aggregations                  list for caller's taught subjects
- GET    /quiz-aggregations/:id              detail with items
- PATCH  /quiz-aggregations/:id              edit DRAFT (items replace-all)
- DELETE /quiz-aggregations/:id              delete DRAFT only
- POST   /quiz-aggregations/:id/preview      per-student compute, no persist
- POST   /quiz-aggregations/:id/finalize     transactional upsert into gradebook

Pure compute (compute.ts):
- AVERAGE  : equal-weighted mean of item percentages * rescale
- WEIGHTED : item.weight-weighted mean of percentages * rescale
- SUM      : mass-weighted by maxScore — Sigma totalScore / Sigma maxScore * rescale
- BEST_OF_N: top N percentages averaged * rescale (n clamped)

Missing attempts:
- TREAT_AS_ZERO            student counted with 0% on missing items
- EXCLUDE_FROM_DENOMINATOR student skipped from denominator on missing items

Best-attempt selection: when a student has multiple GRADED attempts for one item, the HIGHEST-percentage attempt counts (matches typical retry-for-better-score pedagogy).

Validation:
- Items list rejects duplicates and any quizAssignment that does not share the aggregation's classArmSubjectId + termId.
- assessmentTemplateEntryId must resolve in the school's active AssessmentStructureTemplate for the term's academic session.
- BEST_OF_N requires bestOfN.
- DRAFT-only edits / deletes; FINALIZED rejects both.

Finalize is synchronous and transactional:
1. Re-look-up the slot so the latest slot.name + slot.isExam are used.
2. Recompute every active student in the class arm.
3. Upsert ClassArmStudentAssessment keyed on (classArmSubjectId, studentId, termId, name) — name = slot.name so the score lands in the correct gradebook column. assessmentTypeId = slot.id; score rounded to integer; maxScore = rescaleToMaxScore.
4. Flip status to FINALIZED, set finalizedAt + finalizedByTeacherId. Idempotent — re-finalizing re-runs compute and re-upserts (handy after grading additional retries).

This is purely additive at the gradebook layer: existing results / broadsheet / report-card endpoints see the aggregated row as a normal ClassArmStudentAssessment, no UI changes required.

Closes the backend v1 slice. Frontend (TipTap/KaTeX shared package, then teacher-portal, student-portal, admin-portal) follows.

* feat(quiz): canonical reference taxonomies + rename paperReference

Adds three schos-managed reference tables that authoring forms use to populate dropdowns when curating cross-school content:

- CanonicalSubject  (id, name, slug, description, active)
- CanonicalLevel    (id, code, name, group, order, active)
- CanonicalTerm     (id, name, order, active)

Seed populates the initial Nigerian-curriculum default set:
- 37 subjects (Mathematics, Physics, Chemistry, English Language, Yoruba/Igbo/Hausa, Christian/Islamic Religious Studies, ...)
- 26 levels grouped by PRIMARY (PRY1-6), JUNIOR_SECONDARY (JSS1-3), SENIOR_SECONDARY (SSS1-3), INTL_GRADE (Grade 1-12), BRITISH (O_LEVEL, A_LEVEL)
- 3 terms (First / Second / Third) All seeders are idempotent (upsert keyed on slug / code / name).

New CanonicalReferencesModule exposes read-only list endpoints:
- GET /api/canonical-references/subjects
- GET /api/canonical-references/levels   (?group= filter)
- GET /api/canonical-references/terms

Reads are open to any authenticated user. Writes are deferred to admin-portal in a later step; for now system admins can edit directly via SQL or seeds.

Schema rename: QuestionPopularExam.paperReference -> questionNumber. Clearer field name and lets the form ask for "Question #" explicitly instead of free-text "Paper ref". Service + DTO + result class are all migrated. Migration is drop+add (no production data to preserve on this branch); the single test row's paperReference value was nullified before the migration ran.

Also: minor formatter pass on quiz-aggregations.controller.ts (collapsed multi-line import).

* feat(teacher-bff): add curriculum endpoint for authoring dropdowns

GET /api/teacher/curriculum returns the calling teacher's school's subjects, levels, and current-academic-session terms — all with IDs — so the question / quiz authoring forms can render proper Select dropdowns instead of asking the teacher to paste UUIDs.

Response shape:
  {
    subjects: [{ id, name }],
    levels:   [{ id, code, name }],
    terms:    [{ id, name }],
    currentTermId: string | null
  }

Subjects + levels are pulled from the teacher's school regardless of which classes they actively teach — matches the backend's question / quiz authoring rule that any school subject + level is valid for TEACHER_AUTHORED content.

Terms are scoped to the school's current academic session (via currentTermService). currentTermId is included so the form can default-select it.

Returns empty arrays for an unschooled caller rather than 401/403, so the form can degrade gracefully to a "no curriculum loaded" state without throwing.

Powers the SchoolBoundFields dropdowns in QuestionEditor and QuizEditor on the frontend (use-teacher-curriculum hook).

* feat(teacher-bff): expose classArmSubjectId on subject assignments

GET /api/teacher/subject-assignments now includes classArmSubjectId on each entry — the FK target for QuizAssignment.classArmSubjectId. The quiz-assignment scheduler in teacher-portal needs this to target a class arm subject when creating an assignment.

Optional on the type because the sibling endpoint /teacher/classes (class-teacher entries — whole-class, no subject) doesn't have one; that endpoint omits the field. The TeacherClassesResult shape and the TeacherClassInfo type both flag it as optional.

Backwards-compatible: existing consumers that don't read the new field are unaffected.

* feat(teacher): expose currentAcademicSessionId in curriculum

Lets the teacher-portal aggregation form fetch assessment slots without a separate round-trip.

* fix(quiz): correctness fixes from code review

- SUM aggregation: use the assignment's actual maxScore for missing attempts instead of a 1-point placeholder. Previously a missed 10-point quiz only added 1 to the denominator, badly inflating the computed percentage. Source the value from any peer attempt's stored maxScore (deterministic across students), falling back to summing question weights from the assignment's quiz when no peers exist.

- NUMERIC grader: reject infinite/NaN correctAnswer or tolerance so a bad question config can't silently grade everything wrong.

- Aggregation finalize: batch student upserts into 50-row transactions instead of one giant transaction. Partial failure re-runs idempotently on the unique key; status flips to FINALIZED only after the full sweep completes.

- Auto-submit tick: bound retry by a 24h recovery window. Older stuck attempts go through a force-submit path (raw status flip + best-effort grading enqueue) so a permanently failing attempt stops polluting the tick.

- markSubmittedAndEnqueue: handle queue-down + inline-grading-failed case explicitly. Logs the failure and re-enqueues best-effort so the attempt can recover later instead of being stuck SUBMITTED-but-ungraded.

- AttemptResult: expose computed showCorrectAnswers as an explicit boolean so the frontend doesn't need to infer it from payload shape.

* feat(canonical-refs): platform-admin CRUD for subjects, levels, terms

Adds POST/PATCH/DELETE endpoints (gated by SystemAdminGuard) for the three canonical reference taxonomies. Previously these were read-only and could only be changed by re-seeding. Now platform admins can add subjects, levels, or terms at runtime via the platform portal.

Service handles auto-slug derivation for subjects, code uppercasing for levels, and translates Prisma P2002 unique-violation errors into 409 ConflictExceptions with a useful message. Soft-delete via deletedAt + active=false so existing tags pointing at retired entities aren't orphaned. List endpoints accept ?includeInactive=true for admin views.

* fix(pdf): add src/ fallback path for result template resolution

Covers the case where `nest build` skips asset copy on the Lightsail deploy — the repo is still on disk so reading templates straight from src/shared/templates is a safe last resort.

* feat(assessments): add premium-beta gate, usage metering, and billing waiver

Reframes the existing quiz feature as an opt-in premium beta. Schools default to disabled; admins self-serve enable via a new BFF endpoint. Each QuizAttempt start writes a metered QuizUsageEvent with nominal amount and an isWaived flag — events are waived during the global Beta period AND during each school's first 365 days, then become billable.

- School: assessmentsEnabled + audit fields (enabledAt/By, disabledAt)
- New QuizUsageEvent model with @unique on quizAttemptId for idempotency
- AssessmentsFeatureGuard on POST /quiz-attempts/start and POST /quiz-assignments only — submit/save remain ungated so in-flight attempts complete safely if admin disables mid-session
- /bff/admin/assessments-settings (GET/PATCH) and /assessments-usage (GET) with Result classes + Swagger decorators
- Pricing constants (duration tier × question tier × ₦/unit) with resolveWaiver/freeUntil helpers and 19 unit tests covering tier boundaries and BETA/FIRST_YEAR/no-waiver state transitions