### PR TITLE
feat(content): equation/symbol libraries, curated questions and quizzes, seed runner UI

### DIFF
--- a/prisma/migrations/20260429212856_add_equation_library/migration.sql
+++ b/prisma/migrations/20260429212856_add_equation_library/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "equation_library_items" (
+    "id" TEXT NOT NULL,
+    "canonicalSubjectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "latex" TEXT NOT NULL,
+    "tags" TEXT[],
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "equation_library_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "equation_library_items_canonicalSubjectId_isActive_order_idx" ON "equation_library_items"("canonicalSubjectId", "isActive", "order");
+
+-- CreateIndex
+CREATE INDEX "equation_library_items_isActive_idx" ON "equation_library_items"("isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "equation_library_items_canonicalSubjectId_name_key" ON "equation_library_items"("canonicalSubjectId", "name");
+
+-- AddForeignKey
+ALTER TABLE "equation_library_items" ADD CONSTRAINT "equation_library_items_canonicalSubjectId_fkey" FOREIGN KEY ("canonicalSubjectId") REFERENCES "canonical_subjects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260429221839_add_symbol_library_and_seed_runs/migration.sql
+++ b/prisma/migrations/20260429221839_add_symbol_library_and_seed_runs/migration.sql
@@ -1,0 +1,52 @@
+-- CreateEnum
+CREATE TYPE "SeedRunStatus" AS ENUM ('RUNNING', 'SUCCEEDED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "symbol_library_items" (
+    "id" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "latex" TEXT NOT NULL,
+    "tags" TEXT[],
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "symbol_library_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "seed_runs" (
+    "id" TEXT NOT NULL,
+    "seedSlug" TEXT NOT NULL,
+    "status" "SeedRunStatus" NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" TIMESTAMP(3),
+    "upserted" INTEGER NOT NULL DEFAULT 0,
+    "skipped" INTEGER NOT NULL DEFAULT 0,
+    "durationMs" INTEGER,
+    "notes" TEXT,
+    "errorMessage" TEXT,
+    "triggeredById" TEXT,
+
+    CONSTRAINT "seed_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "symbol_library_items_category_isActive_order_idx" ON "symbol_library_items"("category", "isActive", "order");
+
+-- CreateIndex
+CREATE INDEX "symbol_library_items_isActive_idx" ON "symbol_library_items"("isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "symbol_library_items_category_name_key" ON "symbol_library_items"("category", "name");
+
+-- CreateIndex
+CREATE INDEX "seed_runs_seedSlug_startedAt_idx" ON "seed_runs"("seedSlug", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "seed_runs_status_idx" ON "seed_runs"("status");
+
+-- AddForeignKey
+ALTER TABLE "seed_runs" ADD CONSTRAINT "seed_runs_triggeredById_fkey" FOREIGN KEY ("triggeredById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -426,6 +426,7 @@ model User {
   schoolDeletionsCancelled SchoolDeletionRequest[] @relation("SchoolDeletionCancelledBy")
   authoredQuestions        Question[]              @relation("QuestionAuthor")
   authoredQuizzes          Quiz[]                  @relation("QuizAuthor")
+  triggeredSeedRuns        SeedRun[]               @relation("SeedRunTriggeredBy")
 
   @@map("users")
 }
@@ -1650,7 +1651,93 @@ model CanonicalSubject {
   updatedAt   DateTime  @updatedAt
   deletedAt   DateTime?
 
+  equationLibraryItems EquationLibraryItem[]
+
   @@map("canonical_subjects")
+}
+
+/// *
+/// * EquationLibraryItem
+/// * -------------------
+/// * Platform-curated library of common equations teachers can pick into the
+/// * "Insert math" dialog. Stored as raw LaTeX so the existing TipTap MathInline
+/// * extension can consume it unchanged. Subject-keyed via CanonicalSubject so
+/// * a school's Subject (per-tenant) doesn't bleed into curated content.
+model EquationLibraryItem {
+  id                 String           @id @default(uuid())
+  canonicalSubjectId String
+  canonicalSubject   CanonicalSubject @relation(fields: [canonicalSubjectId], references: [id])
+  name               String
+  description        String?
+  latex              String
+  tags               String[]
+  order              Int              @default(0)
+  isActive           Boolean          @default(true)
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+
+  @@unique([canonicalSubjectId, name])
+  @@index([canonicalSubjectId, isActive, order])
+  @@index([isActive])
+  @@map("equation_library_items")
+}
+
+/// *
+/// * SymbolLibraryItem
+/// * -----------------
+/// * Platform-curated palette of single-glyph LaTeX tokens (Greek letters,
+/// * operators, calculus symbols, etc.) that teachers can drop into a math
+/// * expression at the cursor position. Decoupled from CanonicalSubject —
+/// * symbols are subject-agnostic. Categorised via a string `category` field
+/// * (kept as String rather than enum so platform admins can add new
+/// * categories via seed without a migration).
+model SymbolLibraryItem {
+  id        String   @id @default(uuid())
+  category  String
+  name      String
+  latex     String
+  tags      String[]
+  order     Int      @default(0)
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([category, name])
+  @@index([category, isActive, order])
+  @@index([isActive])
+  @@map("symbol_library_items")
+}
+
+/// *
+/// * SeedRun
+/// * -------
+/// * Audit row for every platform seed-script execution kicked off via the
+/// * platform-portal seed-runner. Used to show "last run by" / "last run at"
+/// * on the seeds page and to trace bad seed deploys after the fact. Status
+/// * lifecycles: RUNNING -> SUCCEEDED | FAILED.
+model SeedRun {
+  id           String          @id @default(uuid())
+  seedSlug     String
+  status       SeedRunStatus
+  startedAt    DateTime        @default(now())
+  finishedAt   DateTime?
+  upserted     Int             @default(0)
+  skipped      Int             @default(0)
+  durationMs   Int?
+  notes        String?
+  errorMessage String?
+  triggeredById String?
+  triggeredBy  User?           @relation("SeedRunTriggeredBy", fields: [triggeredById], references: [id])
+
+  @@index([seedSlug, startedAt])
+  @@index([status])
+  @@map("seed_runs")
+}
+
+enum SeedRunStatus {
+  RUNNING
+  SUCCEEDED
+  FAILED
 }
 
 /// *

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,6 +12,14 @@ import {
   getDefaultAssessmentStructure,
   getAssessmentStructureForSeeding,
 } from '../src/utils/assessment-structure';
+import { seedCanonicalLevels } from './seeds/canonical-levels';
+import { seedCanonicalSubjects } from './seeds/canonical-subjects';
+import { seedCanonicalTerms } from './seeds/canonical-terms';
+import { seedCuratedQuestions } from './seeds/curated-questions';
+import { seedCuratedQuizzes } from './seeds/curated-quizzes';
+import { seedEquationLibrary } from './seeds/equation-library';
+import { seedPopularExams } from './seeds/popular-exams';
+import { seedSymbolLibrary } from './seeds/symbol-library';
 
 const prisma = new PrismaClient();
 const passwordHasher = new PasswordHasher();
@@ -85,6 +93,10 @@ async function main() {
     const studentCount = await prisma.student.count();
 
     if (existingSchool && studentCount > 0) {
+      // Always re-run canonical/global content seeding so additions land on
+      // dev DBs that already have school data — these helpers are idempotent
+      // upserts.
+      await runCanonicalContentSeeds();
       console.log(`School and ${studentCount} students already exist. Seed completed.`);
       return;
     }
@@ -1053,179 +1065,32 @@ async function main() {
   console.log(`✅ Created ${paymentStructures.length} payment structures`);
   console.log(`✅ Generated ${studentPayments.length} student payments`);
 
-  await seedPopularExams();
-  await seedCanonicalSubjects();
-  await seedCanonicalLevels();
-  await seedCanonicalTerms();
+  await runCanonicalContentSeeds();
 
   console.log('✅ School seed data generated successfully!');
 }
 
-const POPULAR_EXAMS: ReadonlyArray<{
-  code: string;
-  name: string;
-  country: string;
-  description: string;
-}> = [
-  { code: 'WAEC', name: 'West African Examinations Council', country: 'NG', description: 'Senior School Certificate Examination administered across West Africa.' },
-  { code: 'NECO', name: 'National Examinations Council', country: 'NG', description: 'Nigerian senior secondary certificate examination.' },
-  { code: 'JAMB', name: 'Joint Admissions and Matriculation Board', country: 'NG', description: 'Nigerian university matriculation examination (UTME).' },
-  { code: 'NABTEB', name: 'National Business and Technical Examinations Board', country: 'NG', description: 'Nigerian technical and business education certificate.' },
-  { code: 'BECE', name: 'Basic Education Certificate Examination', country: 'NG', description: 'Junior secondary school exit examination in Nigeria.' },
-  { code: 'COMMON_ENTRANCE', name: 'National Common Entrance Examination', country: 'NG', description: 'Entry examination for federal unity colleges.' },
-  { code: 'IGCSE', name: 'International General Certificate of Secondary Education', country: 'INTL', description: 'Cambridge international secondary qualification.' },
-  { code: 'CHECKPOINT', name: 'Cambridge Lower Secondary Checkpoint', country: 'INTL', description: 'Cambridge end-of-stage assessment for lower secondary.' },
-  { code: 'A_LEVELS', name: 'GCE Advanced Level', country: 'INTL', description: 'Cambridge / Edexcel pre-university qualification.' },
-  { code: 'O_LEVELS', name: 'GCE Ordinary Level', country: 'INTL', description: 'Cambridge / Edexcel ordinary-level qualification.' },
-  { code: 'SAT', name: 'Scholastic Assessment Test', country: 'INTL', description: 'College Board standardized university admissions test.' },
-  { code: 'TOEFL', name: 'Test of English as a Foreign Language', country: 'INTL', description: 'English-language proficiency test for non-native speakers.' },
-  { code: 'IELTS', name: 'International English Language Testing System', country: 'INTL', description: 'English-language proficiency test for study, work, migration.' },
-];
-
-const CANONICAL_SUBJECTS: ReadonlyArray<{ name: string; slug: string; description?: string }> = [
-  { name: 'Mathematics', slug: 'mathematics' },
-  { name: 'Further Mathematics', slug: 'further-mathematics' },
-  { name: 'English Language', slug: 'english-language' },
-  { name: 'Literature in English', slug: 'literature-in-english' },
-  { name: 'Physics', slug: 'physics' },
-  { name: 'Chemistry', slug: 'chemistry' },
-  { name: 'Biology', slug: 'biology' },
-  { name: 'Agricultural Science', slug: 'agricultural-science' },
-  { name: 'Geography', slug: 'geography' },
-  { name: 'Economics', slug: 'economics' },
-  { name: 'Government', slug: 'government' },
-  { name: 'History', slug: 'history' },
-  { name: 'Civic Education', slug: 'civic-education' },
-  { name: 'Christian Religious Studies', slug: 'christian-religious-studies' },
-  { name: 'Islamic Religious Studies', slug: 'islamic-religious-studies' },
-  { name: 'Commerce', slug: 'commerce' },
-  { name: 'Financial Accounting', slug: 'financial-accounting' },
-  { name: 'Business Studies', slug: 'business-studies' },
-  { name: 'Office Practice', slug: 'office-practice' },
-  { name: 'Marketing', slug: 'marketing' },
-  { name: 'Computer Science', slug: 'computer-science' },
-  { name: 'Information Communication Technology', slug: 'ict' },
-  { name: 'Basic Science', slug: 'basic-science' },
-  { name: 'Basic Technology', slug: 'basic-technology' },
-  { name: 'Social Studies', slug: 'social-studies' },
-  { name: 'Cultural and Creative Arts', slug: 'cultural-and-creative-arts' },
-  { name: 'Visual Arts', slug: 'visual-arts' },
-  { name: 'Music', slug: 'music' },
-  { name: 'Home Economics', slug: 'home-economics' },
-  { name: 'Food and Nutrition', slug: 'food-and-nutrition' },
-  { name: 'Physical and Health Education', slug: 'physical-and-health-education' },
-  { name: 'French', slug: 'french' },
-  { name: 'Yoruba', slug: 'yoruba' },
-  { name: 'Igbo', slug: 'igbo' },
-  { name: 'Hausa', slug: 'hausa' },
-  { name: 'Verbal Reasoning', slug: 'verbal-reasoning' },
-  { name: 'Quantitative Reasoning', slug: 'quantitative-reasoning' },
-];
-
-const CANONICAL_LEVELS: ReadonlyArray<{
-  code: string;
-  name: string;
-  group: string;
-  order: number;
-}> = [
-  // Nigerian primary
-  { code: 'PRY1', name: 'Primary 1', group: 'PRIMARY', order: 1 },
-  { code: 'PRY2', name: 'Primary 2', group: 'PRIMARY', order: 2 },
-  { code: 'PRY3', name: 'Primary 3', group: 'PRIMARY', order: 3 },
-  { code: 'PRY4', name: 'Primary 4', group: 'PRIMARY', order: 4 },
-  { code: 'PRY5', name: 'Primary 5', group: 'PRIMARY', order: 5 },
-  { code: 'PRY6', name: 'Primary 6', group: 'PRIMARY', order: 6 },
-  // Nigerian junior secondary
-  { code: 'JSS1', name: 'Junior Secondary 1', group: 'JUNIOR_SECONDARY', order: 7 },
-  { code: 'JSS2', name: 'Junior Secondary 2', group: 'JUNIOR_SECONDARY', order: 8 },
-  { code: 'JSS3', name: 'Junior Secondary 3', group: 'JUNIOR_SECONDARY', order: 9 },
-  // Nigerian senior secondary
-  { code: 'SSS1', name: 'Senior Secondary 1', group: 'SENIOR_SECONDARY', order: 10 },
-  { code: 'SSS2', name: 'Senior Secondary 2', group: 'SENIOR_SECONDARY', order: 11 },
-  { code: 'SSS3', name: 'Senior Secondary 3', group: 'SENIOR_SECONDARY', order: 12 },
-  // International grade system (US/IB)
-  { code: 'GRADE_1', name: 'Grade 1', group: 'INTL_GRADE', order: 1 },
-  { code: 'GRADE_2', name: 'Grade 2', group: 'INTL_GRADE', order: 2 },
-  { code: 'GRADE_3', name: 'Grade 3', group: 'INTL_GRADE', order: 3 },
-  { code: 'GRADE_4', name: 'Grade 4', group: 'INTL_GRADE', order: 4 },
-  { code: 'GRADE_5', name: 'Grade 5', group: 'INTL_GRADE', order: 5 },
-  { code: 'GRADE_6', name: 'Grade 6', group: 'INTL_GRADE', order: 6 },
-  { code: 'GRADE_7', name: 'Grade 7', group: 'INTL_GRADE', order: 7 },
-  { code: 'GRADE_8', name: 'Grade 8', group: 'INTL_GRADE', order: 8 },
-  { code: 'GRADE_9', name: 'Grade 9', group: 'INTL_GRADE', order: 9 },
-  { code: 'GRADE_10', name: 'Grade 10', group: 'INTL_GRADE', order: 10 },
-  { code: 'GRADE_11', name: 'Grade 11', group: 'INTL_GRADE', order: 11 },
-  { code: 'GRADE_12', name: 'Grade 12', group: 'INTL_GRADE', order: 12 },
-  // British / Cambridge pre-university
-  { code: 'O_LEVEL', name: 'O Level', group: 'BRITISH', order: 1 },
-  { code: 'A_LEVEL', name: 'A Level', group: 'BRITISH', order: 2 },
-];
-
-const CANONICAL_TERMS: ReadonlyArray<{ name: string; order: number }> = [
-  { name: 'First Term', order: 1 },
-  { name: 'Second Term', order: 2 },
-  { name: 'Third Term', order: 3 },
-];
-
-async function seedCanonicalSubjects() {
-  console.log('Seeding canonical subjects...');
-  for (const s of CANONICAL_SUBJECTS) {
-    await prisma.canonicalSubject.upsert({
-      where: { slug: s.slug },
-      update: { name: s.name, description: s.description },
-      create: { name: s.name, slug: s.slug, description: s.description, active: true },
-    });
-  }
-  console.log(`✅ Seeded ${CANONICAL_SUBJECTS.length} canonical subjects`);
-}
-
-async function seedCanonicalLevels() {
-  console.log('Seeding canonical levels...');
-  for (const l of CANONICAL_LEVELS) {
-    await prisma.canonicalLevel.upsert({
-      where: { code: l.code },
-      update: { name: l.name, group: l.group, order: l.order },
-      create: { code: l.code, name: l.name, group: l.group, order: l.order, active: true },
-    });
-  }
-  console.log(`✅ Seeded ${CANONICAL_LEVELS.length} canonical levels`);
-}
-
-async function seedCanonicalTerms() {
-  console.log('Seeding canonical terms...');
-  for (const t of CANONICAL_TERMS) {
-    await prisma.canonicalTerm.upsert({
-      where: { name: t.name },
-      update: { order: t.order },
-      create: { name: t.name, order: t.order, active: true },
-    });
-  }
-  console.log(`✅ Seeded ${CANONICAL_TERMS.length} canonical terms`);
-}
-
 /**
- * Idempotent: upserts the canonical PopularExam reference list. Safe to re-run.
+ * Runs every platform-content seed in dependency order. Used by `prisma db
+ * seed` and is also the same set the platform-portal seed-runner exposes —
+ * any changes here flow through to both.
  */
-async function seedPopularExams() {
-  console.log('Seeding popular exams...');
-  for (const exam of POPULAR_EXAMS) {
-    await prisma.popularExam.upsert({
-      where: { code: exam.code },
-      update: {
-        name: exam.name,
-        country: exam.country,
-        description: exam.description,
-      },
-      create: {
-        code: exam.code,
-        name: exam.name,
-        country: exam.country,
-        description: exam.description,
-        active: true,
-      },
-    });
-  }
-  console.log(`✅ Seeded ${POPULAR_EXAMS.length} popular exams`);
+async function runCanonicalContentSeeds() {
+  await runOne('canonical-subjects', () => seedCanonicalSubjects(prisma));
+  await runOne('canonical-levels', () => seedCanonicalLevels(prisma));
+  await runOne('canonical-terms', () => seedCanonicalTerms(prisma));
+  await runOne('popular-exams', () => seedPopularExams(prisma));
+  await runOne('equation-library', () => seedEquationLibrary(prisma));
+  await runOne('symbol-library', () => seedSymbolLibrary(prisma));
+  await runOne('curated-questions', () => seedCuratedQuestions(prisma));
+  await runOne('curated-quizzes', () => seedCuratedQuizzes(prisma));
+}
+
+async function runOne(slug: string, run: () => Promise<{ upserted: number; skipped: number; notes?: string }>) {
+  console.log(`Seeding ${slug}…`);
+  const result = await run();
+  const note = result.notes ? ` (${result.notes})` : '';
+  console.log(`✅ ${slug}: ${result.upserted} upserted, ${result.skipped} skipped${note}`);
 }
 
 main()

--- a/prisma/seeds/canonical-levels.ts
+++ b/prisma/seeds/canonical-levels.ts
@@ -1,0 +1,58 @@
+import { PrismaClient } from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface CanonicalLevelSeed {
+  code: string;
+  name: string;
+  group: string;
+  order: number;
+}
+
+const CANONICAL_LEVELS: ReadonlyArray<CanonicalLevelSeed> = [
+  // Nigerian primary
+  { code: 'PRY1', name: 'Primary 1', group: 'PRIMARY', order: 1 },
+  { code: 'PRY2', name: 'Primary 2', group: 'PRIMARY', order: 2 },
+  { code: 'PRY3', name: 'Primary 3', group: 'PRIMARY', order: 3 },
+  { code: 'PRY4', name: 'Primary 4', group: 'PRIMARY', order: 4 },
+  { code: 'PRY5', name: 'Primary 5', group: 'PRIMARY', order: 5 },
+  { code: 'PRY6', name: 'Primary 6', group: 'PRIMARY', order: 6 },
+  // Nigerian junior secondary
+  { code: 'JSS1', name: 'Junior Secondary 1', group: 'JUNIOR_SECONDARY', order: 7 },
+  { code: 'JSS2', name: 'Junior Secondary 2', group: 'JUNIOR_SECONDARY', order: 8 },
+  { code: 'JSS3', name: 'Junior Secondary 3', group: 'JUNIOR_SECONDARY', order: 9 },
+  // Nigerian senior secondary
+  { code: 'SSS1', name: 'Senior Secondary 1', group: 'SENIOR_SECONDARY', order: 10 },
+  { code: 'SSS2', name: 'Senior Secondary 2', group: 'SENIOR_SECONDARY', order: 11 },
+  { code: 'SSS3', name: 'Senior Secondary 3', group: 'SENIOR_SECONDARY', order: 12 },
+  // International grade system (US/IB)
+  { code: 'GRADE_1', name: 'Grade 1', group: 'INTL_GRADE', order: 1 },
+  { code: 'GRADE_2', name: 'Grade 2', group: 'INTL_GRADE', order: 2 },
+  { code: 'GRADE_3', name: 'Grade 3', group: 'INTL_GRADE', order: 3 },
+  { code: 'GRADE_4', name: 'Grade 4', group: 'INTL_GRADE', order: 4 },
+  { code: 'GRADE_5', name: 'Grade 5', group: 'INTL_GRADE', order: 5 },
+  { code: 'GRADE_6', name: 'Grade 6', group: 'INTL_GRADE', order: 6 },
+  { code: 'GRADE_7', name: 'Grade 7', group: 'INTL_GRADE', order: 7 },
+  { code: 'GRADE_8', name: 'Grade 8', group: 'INTL_GRADE', order: 8 },
+  { code: 'GRADE_9', name: 'Grade 9', group: 'INTL_GRADE', order: 9 },
+  { code: 'GRADE_10', name: 'Grade 10', group: 'INTL_GRADE', order: 10 },
+  { code: 'GRADE_11', name: 'Grade 11', group: 'INTL_GRADE', order: 11 },
+  { code: 'GRADE_12', name: 'Grade 12', group: 'INTL_GRADE', order: 12 },
+  // British / Cambridge pre-university
+  { code: 'O_LEVEL', name: 'O Level', group: 'BRITISH', order: 1 },
+  { code: 'A_LEVEL', name: 'A Level', group: 'BRITISH', order: 2 },
+];
+
+export async function seedCanonicalLevels(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+  let upserted = 0;
+  for (const l of CANONICAL_LEVELS) {
+    await prisma.canonicalLevel.upsert({
+      where: { code: l.code },
+      update: { name: l.name, group: l.group, order: l.order },
+      create: { code: l.code, name: l.name, group: l.group, order: l.order, active: true },
+    });
+    upserted += 1;
+  }
+  return { upserted, skipped: 0, durationMs: Date.now() - startedAt };
+}

--- a/prisma/seeds/canonical-subjects.ts
+++ b/prisma/seeds/canonical-subjects.ts
@@ -1,0 +1,81 @@
+import { PrismaClient } from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface CanonicalSubjectSeed {
+  name: string;
+  slug: string;
+  description?: string;
+}
+
+const CANONICAL_SUBJECTS: ReadonlyArray<CanonicalSubjectSeed> = [
+  { name: 'Mathematics', slug: 'mathematics' },
+  { name: 'Further Mathematics', slug: 'further-mathematics' },
+  { name: 'English Language', slug: 'english-language' },
+  { name: 'Literature in English', slug: 'literature-in-english' },
+  { name: 'Physics', slug: 'physics' },
+  { name: 'Chemistry', slug: 'chemistry' },
+  { name: 'Biology', slug: 'biology' },
+  { name: 'Agricultural Science', slug: 'agricultural-science' },
+  { name: 'Geography', slug: 'geography' },
+  { name: 'Economics', slug: 'economics' },
+  { name: 'Government', slug: 'government' },
+  { name: 'History', slug: 'history' },
+  { name: 'Civic Education', slug: 'civic-education' },
+  { name: 'Christian Religious Studies', slug: 'christian-religious-studies' },
+  { name: 'Islamic Religious Studies', slug: 'islamic-religious-studies' },
+  { name: 'Commerce', slug: 'commerce' },
+  { name: 'Financial Accounting', slug: 'financial-accounting' },
+  { name: 'Business Studies', slug: 'business-studies' },
+  { name: 'Office Practice', slug: 'office-practice' },
+  { name: 'Marketing', slug: 'marketing' },
+  { name: 'Computer Science', slug: 'computer-science' },
+  { name: 'Information Communication Technology', slug: 'ict' },
+  { name: 'Basic Science', slug: 'basic-science' },
+  { name: 'Basic Technology', slug: 'basic-technology' },
+  { name: 'Social Studies', slug: 'social-studies' },
+  { name: 'Cultural and Creative Arts', slug: 'cultural-and-creative-arts' },
+  { name: 'Visual Arts', slug: 'visual-arts' },
+  { name: 'Music', slug: 'music' },
+  { name: 'Home Economics', slug: 'home-economics' },
+  { name: 'Food and Nutrition', slug: 'food-and-nutrition' },
+  { name: 'Physical and Health Education', slug: 'physical-and-health-education' },
+  { name: 'French', slug: 'french' },
+  { name: 'Yoruba', slug: 'yoruba' },
+  { name: 'Igbo', slug: 'igbo' },
+  { name: 'Hausa', slug: 'hausa' },
+  { name: 'Verbal Reasoning', slug: 'verbal-reasoning' },
+  { name: 'Quantitative Reasoning', slug: 'quantitative-reasoning' },
+  // Test-prep / cross-cutting
+  {
+    name: 'General Knowledge',
+    slug: 'general-knowledge',
+    description:
+      'Current affairs, civic facts and broad-knowledge questions used for entrance and aptitude tests.',
+  },
+  { name: 'Data Processing', slug: 'data-processing' },
+  // Technical / vocational (WAEC paper subjects)
+  { name: 'Technical Drawing', slug: 'technical-drawing' },
+  { name: 'Auto Mechanics', slug: 'auto-mechanics' },
+  { name: 'Building Construction', slug: 'building-construction' },
+  { name: 'Electrical Installation and Maintenance Work', slug: 'electrical-installation' },
+  { name: 'Animal Husbandry', slug: 'animal-husbandry' },
+  { name: 'Book Keeping', slug: 'book-keeping' },
+  { name: 'Catering Craft Practice', slug: 'catering-craft-practice' },
+  { name: 'Garment Making', slug: 'garment-making' },
+  { name: 'Tie and Dye', slug: 'tie-and-dye' },
+];
+
+export async function seedCanonicalSubjects(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+  let upserted = 0;
+  for (const s of CANONICAL_SUBJECTS) {
+    await prisma.canonicalSubject.upsert({
+      where: { slug: s.slug },
+      update: { name: s.name, description: s.description },
+      create: { name: s.name, slug: s.slug, description: s.description, active: true },
+    });
+    upserted += 1;
+  }
+  return { upserted, skipped: 0, durationMs: Date.now() - startedAt };
+}

--- a/prisma/seeds/canonical-terms.ts
+++ b/prisma/seeds/canonical-terms.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface CanonicalTermSeed {
+  name: string;
+  order: number;
+}
+
+const CANONICAL_TERMS: ReadonlyArray<CanonicalTermSeed> = [
+  { name: 'First Term', order: 1 },
+  { name: 'Second Term', order: 2 },
+  { name: 'Third Term', order: 3 },
+];
+
+export async function seedCanonicalTerms(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+  let upserted = 0;
+  for (const t of CANONICAL_TERMS) {
+    await prisma.canonicalTerm.upsert({
+      where: { name: t.name },
+      update: { order: t.order },
+      create: { name: t.name, order: t.order, active: true },
+    });
+    upserted += 1;
+  }
+  return { upserted, skipped: 0, durationMs: Date.now() - startedAt };
+}

--- a/prisma/seeds/curated-questions.ts
+++ b/prisma/seeds/curated-questions.ts
@@ -1,0 +1,705 @@
+/**
+ * Sample SCHOS_CURATED starter questions across subjects. Owned by the
+ * platform (schoolId = null), authored by the bootstrap PLATFORM_ADMIN user.
+ * Seeded as DRAFT status so platform staff can review + publish via the
+ * curator UI before they appear in /questions/library for teachers.
+ *
+ * Idempotency: each row carries a stable `seedKey` (e.g. "math-quad-roots")
+ * used to look up an existing curated question whose promptPlainText starts
+ * with the seed-key marker line. Re-running the seed updates existing rows
+ * (prompt body, options, weights) but never duplicates.
+ *
+ * LaTeX: math is embedded as TipTap MathInline nodes; raw `\\frac{...}` etc
+ * is fine since it lives inside a JSON string (no shell escaping concerns).
+ */
+
+import {
+  PartialCreditMode,
+  Prisma,
+  PrismaClient,
+  QuestionDifficulty,
+  QuestionStatus,
+  QuestionType,
+} from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface CuratedOption {
+  text: string; // plain text, will be wrapped in TipTap JSON
+  isCorrect: boolean;
+}
+
+interface CuratedQuestionSeed {
+  seedKey: string;
+  canonicalSubjectName: string;
+  canonicalLevelCode: string;
+  canonicalTermName?: string;
+  type: QuestionType;
+  prompt: string; // plain text — will be wrapped in TipTap JSON
+  weight?: number;
+  difficulty?: QuestionDifficulty;
+  options?: CuratedOption[]; // for MCQ_*
+  config?: Record<string, unknown>; // for NUMERIC / SHORT_ANSWER / TRUE_FALSE
+  partialCreditMode?: PartialCreditMode;
+}
+
+// Helper: minimal TipTap JSON document with one paragraph.
+function tipTapDoc(text: string): Prisma.InputJsonValue {
+  return {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: text ? [{ type: 'text', text }] : [],
+      },
+    ],
+  };
+}
+
+// First line of promptPlainText is a hidden anchor used for idempotent lookup.
+// We strip it before display by storing the actual question on subsequent
+// lines and treating the anchor as machine metadata only.
+const ANCHOR_PREFIX = '[seed:';
+
+function buildPromptPlainText(seedKey: string, prompt: string): string {
+  return `${ANCHOR_PREFIX}${seedKey}]\n${prompt}`;
+}
+
+// Visible prompt text for promptPlainText is the prompt itself; the anchor
+// lives in a separate metadata channel. After review we discovered Question
+// has no metadata column — so we keep the anchor on the FIRST line of the
+// promptPlainText (cheap), but the TipTap prompt JSON only contains the
+// real prompt so users see clean text in the UI.
+//
+// Trade-off: search/filter against promptPlainText could match the anchor
+// fragment. Mitigation: the anchor uses square brackets with a `seed:`
+// prefix that's unlikely to appear in a normal question.
+
+const QUESTIONS: CuratedQuestionSeed[] = [
+  // ─── Mathematics ──────────────────────────────────────────────────────────
+  {
+    seedKey: 'math-quad-roots',
+    canonicalSubjectName: 'Mathematics',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'What are the roots of x² − 5x + 6 = 0?',
+    weight: 1,
+    difficulty: 'EASY',
+    options: [
+      { text: '1 and 6', isCorrect: false },
+      { text: '2 and 3', isCorrect: true },
+      { text: '−2 and −3', isCorrect: false },
+      { text: '5 and 6', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'math-pyth',
+    canonicalSubjectName: 'Mathematics',
+    canonicalLevelCode: 'JSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'A right triangle has legs of length 3 and 4. What is the length of the hypotenuse?',
+    difficulty: 'EASY',
+    options: [
+      { text: '5', isCorrect: true },
+      { text: '6', isCorrect: false },
+      { text: '7', isCorrect: false },
+      { text: '12', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'math-circle-area',
+    canonicalSubjectName: 'Mathematics',
+    canonicalLevelCode: 'SSS1',
+    type: 'NUMERIC',
+    prompt: 'A circle has radius 7 cm. What is its area in cm² (use π ≈ 22/7)?',
+    difficulty: 'EASY',
+    config: { correctAnswer: 154, tolerance: 0.5, toleranceMode: 'ABSOLUTE', unit: 'cm²' },
+  },
+  {
+    seedKey: 'math-derivative',
+    canonicalSubjectName: 'Mathematics',
+    canonicalLevelCode: 'SSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'What is the derivative of f(x) = 3x² + 2x + 5?',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: '6x + 2', isCorrect: true },
+      { text: '3x + 2', isCorrect: false },
+      { text: '6x² + 2', isCorrect: false },
+      { text: '6x', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'math-mean',
+    canonicalSubjectName: 'Mathematics',
+    canonicalLevelCode: 'SSS1',
+    type: 'NUMERIC',
+    prompt: 'Find the mean of 4, 8, 12, 16, 20.',
+    difficulty: 'EASY',
+    config: { correctAnswer: 12, tolerance: 0, toleranceMode: 'ABSOLUTE' },
+  },
+  {
+    seedKey: 'math-trig-identity',
+    canonicalSubjectName: 'Mathematics',
+    canonicalLevelCode: 'SSS2',
+    type: 'TRUE_FALSE',
+    prompt: 'sin²(θ) + cos²(θ) = 1 holds for every real θ.',
+    difficulty: 'EASY',
+    config: { correctAnswer: true },
+  },
+
+  // ─── Physics ──────────────────────────────────────────────────────────────
+  {
+    seedKey: 'phys-newton-2nd',
+    canonicalSubjectName: 'Physics',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'A 5 kg object accelerates at 4 m/s². What net force acts on it?',
+    difficulty: 'EASY',
+    options: [
+      { text: '9 N', isCorrect: false },
+      { text: '20 N', isCorrect: true },
+      { text: '1.25 N', isCorrect: false },
+      { text: '40 N', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'phys-ohm',
+    canonicalSubjectName: 'Physics',
+    canonicalLevelCode: 'SSS3',
+    type: 'NUMERIC',
+    prompt: 'A 12 V battery drives a current of 0.5 A through a resistor. What is the resistance in ohms?',
+    difficulty: 'EASY',
+    config: { correctAnswer: 24, tolerance: 0, toleranceMode: 'ABSOLUTE', unit: 'Ω' },
+  },
+  {
+    seedKey: 'phys-kinematic',
+    canonicalSubjectName: 'Physics',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'A car starts from rest and accelerates uniformly at 2 m/s² for 5 seconds. How far has it travelled?',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: '10 m', isCorrect: false },
+      { text: '25 m', isCorrect: true },
+      { text: '50 m', isCorrect: false },
+      { text: '5 m', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'phys-kinetic-energy',
+    canonicalSubjectName: 'Physics',
+    canonicalLevelCode: 'SSS3',
+    type: 'NUMERIC',
+    prompt: 'A 2 kg ball moves at 3 m/s. What is its kinetic energy in joules?',
+    difficulty: 'EASY',
+    config: { correctAnswer: 9, tolerance: 0, toleranceMode: 'ABSOLUTE', unit: 'J' },
+  },
+
+  // ─── Chemistry ────────────────────────────────────────────────────────────
+  {
+    seedKey: 'chem-ph',
+    canonicalSubjectName: 'Chemistry',
+    canonicalLevelCode: 'SSS3',
+    type: 'NUMERIC',
+    prompt: 'What is the pH of a solution with [H⁺] = 1 × 10⁻⁴ M?',
+    difficulty: 'EASY',
+    config: { correctAnswer: 4, tolerance: 0, toleranceMode: 'ABSOLUTE' },
+  },
+  {
+    seedKey: 'chem-mol',
+    canonicalSubjectName: 'Chemistry',
+    canonicalLevelCode: 'SSS2',
+    type: 'NUMERIC',
+    prompt: 'How many moles are in 18 g of water (molar mass 18 g/mol)?',
+    difficulty: 'EASY',
+    config: { correctAnswer: 1, tolerance: 0.01, toleranceMode: 'ABSOLUTE', unit: 'mol' },
+  },
+  {
+    seedKey: 'chem-ideal-gas',
+    canonicalSubjectName: 'Chemistry',
+    canonicalLevelCode: 'SSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'Which equation correctly relates the pressure, volume, moles, and temperature of an ideal gas?',
+    difficulty: 'EASY',
+    options: [
+      { text: 'P + V = nRT', isCorrect: false },
+      { text: 'PV = nRT', isCorrect: true },
+      { text: 'P/V = nRT', isCorrect: false },
+      { text: 'V = nRT/P²', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'chem-balance-1',
+    canonicalSubjectName: 'Chemistry',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Balance: __ H₂ + __ O₂ → __ H₂O. The smallest set of whole-number coefficients is:',
+    difficulty: 'EASY',
+    options: [
+      { text: '1, 1, 1', isCorrect: false },
+      { text: '2, 1, 2', isCorrect: true },
+      { text: '1, 2, 2', isCorrect: false },
+      { text: '2, 2, 1', isCorrect: false },
+    ],
+  },
+
+  // ─── Biology ──────────────────────────────────────────────────────────────
+  {
+    seedKey: 'bio-mitosis',
+    canonicalSubjectName: 'Biology',
+    canonicalLevelCode: 'SSS1',
+    type: 'MCQ_SINGLE',
+    prompt: 'Which phase of mitosis is characterized by chromosomes lining up at the cell equator?',
+    difficulty: 'EASY',
+    options: [
+      { text: 'Prophase', isCorrect: false },
+      { text: 'Metaphase', isCorrect: true },
+      { text: 'Anaphase', isCorrect: false },
+      { text: 'Telophase', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'bio-photosynthesis',
+    canonicalSubjectName: 'Biology',
+    canonicalLevelCode: 'JSS3',
+    type: 'SHORT_ANSWER',
+    prompt: 'Name the green pigment in plants that absorbs light energy for photosynthesis.',
+    difficulty: 'EASY',
+    config: {
+      acceptedAnswers: ['chlorophyll'],
+      caseSensitive: false,
+      normalizeWhitespace: true,
+    },
+  },
+
+  // ─── English Language ─────────────────────────────────────────────────────
+  // 20 questions, used together by the curated-quizzes seed to assemble the
+  // "Generic English Language Quiz". Mix of vocabulary, grammar, concord,
+  // voice, tense, punctuation, idiom and figurative-language items at JSS/SSS
+  // level — WAEC/JAMB flavoured.
+  {
+    seedKey: 'eng-tense',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Choose the sentence in correct past tense:',
+    difficulty: 'EASY',
+    options: [
+      { text: 'She go to the market yesterday.', isCorrect: false },
+      { text: 'She went to the market yesterday.', isCorrect: true },
+      { text: 'She goes to the market yesterday.', isCorrect: false },
+      { text: 'She gone to the market yesterday.', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-synonym',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS1',
+    type: 'MCQ_SINGLE',
+    prompt: "Which word is closest in meaning to 'benevolent'?",
+    difficulty: 'EASY',
+    options: [
+      { text: 'cruel', isCorrect: false },
+      { text: 'kind', isCorrect: true },
+      { text: 'lazy', isCorrect: false },
+      { text: 'serious', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-antonym-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS1',
+    type: 'MCQ_SINGLE',
+    prompt: "Which word is the OPPOSITE of 'abundant'?",
+    difficulty: 'EASY',
+    options: [
+      { text: 'plentiful', isCorrect: false },
+      { text: 'scarce', isCorrect: true },
+      { text: 'enormous', isCorrect: false },
+      { text: 'common', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-concord-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'Choose the option that completes the sentence correctly: "The list of names ___ on the noticeboard."',
+    difficulty: 'EASY',
+    options: [
+      { text: 'are', isCorrect: false },
+      { text: 'is', isCorrect: true },
+      { text: 'were', isCorrect: false },
+      { text: 'have been', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-concord-2',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS1',
+    type: 'MCQ_SINGLE',
+    prompt: 'Pick the grammatically correct sentence:',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'Neither the captain nor the players was at the meeting.', isCorrect: false },
+      { text: 'Neither the captain nor the players were at the meeting.', isCorrect: true },
+      { text: 'Neither the captain nor the players is at the meeting.', isCorrect: false },
+      { text: 'Neither the captain nor the players has been at the meeting.', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-passive-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Convert to the passive voice: "The chef cooked the rice."',
+    difficulty: 'EASY',
+    options: [
+      { text: 'The rice was cooked by the chef.', isCorrect: true },
+      { text: 'The rice cooked the chef.', isCorrect: false },
+      { text: 'The rice has been cooking by the chef.', isCorrect: false },
+      { text: 'The rice is cooked by the chef.', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-active-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Convert to the active voice: "The cake was eaten by the children."',
+    difficulty: 'EASY',
+    options: [
+      { text: 'The children eat the cake.', isCorrect: false },
+      { text: 'The children ate the cake.', isCorrect: true },
+      { text: 'The children were eating the cake.', isCorrect: false },
+      { text: 'The cake was eaten the children.', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-tense-future',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'Choose the sentence in the future continuous tense:',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'I will travel to Lagos.', isCorrect: false },
+      { text: 'I am travelling to Lagos.', isCorrect: false },
+      { text: 'I will be travelling to Lagos at noon.', isCorrect: true },
+      { text: 'I have travelled to Lagos.', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-vocab-context',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'In the sentence "The lawyer presented a cogent argument", the word "cogent" most nearly means:',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'lengthy', isCorrect: false },
+      { text: 'persuasive', isCorrect: true },
+      { text: 'confusing', isCorrect: false },
+      { text: 'humorous', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-spelling-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Which word is spelled correctly?',
+    difficulty: 'EASY',
+    options: [
+      { text: 'recieve', isCorrect: false },
+      { text: 'receive', isCorrect: true },
+      { text: 'receeve', isCorrect: false },
+      { text: 'receve', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-punct-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS3',
+    type: 'MCQ_SINGLE',
+    prompt: "Which sentence uses the apostrophe correctly?",
+    difficulty: 'EASY',
+    options: [
+      { text: "The boy's books are on the table.", isCorrect: true },
+      { text: "The boys book's are on the table.", isCorrect: false },
+      { text: "The boys' book's are on the table.", isCorrect: false },
+      { text: "The boys books are on the table'.", isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-reported-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS1',
+    type: 'MCQ_SINGLE',
+    prompt: 'Convert to reported speech: She said, "I am writing a letter."',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'She said that she is writing a letter.', isCorrect: false },
+      { text: 'She said that she was writing a letter.', isCorrect: true },
+      { text: 'She said that I am writing a letter.', isCorrect: false },
+      { text: 'She said that she had written a letter.', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-idiom-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: "What does the idiom 'to bite the bullet' mean?",
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'to act recklessly', isCorrect: false },
+      { text: 'to endure something painful with courage', isCorrect: true },
+      { text: 'to lose a fight', isCorrect: false },
+      { text: 'to refuse to listen', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-stress-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: "In the word 'photographer', the primary stress falls on which syllable?",
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'pho', isCorrect: false },
+      { text: 'tog', isCorrect: true },
+      { text: 'ra', isCorrect: false },
+      { text: 'pher', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-comparative-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Choose the correct comparative form: "This problem is ___ than the last one."',
+    difficulty: 'EASY',
+    options: [
+      { text: 'difficulter', isCorrect: false },
+      { text: 'more difficult', isCorrect: true },
+      { text: 'most difficult', isCorrect: false },
+      { text: 'difficultest', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-prep-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'Choose the correct preposition: "She has been waiting ___ Monday."',
+    difficulty: 'EASY',
+    options: [
+      { text: 'for', isCorrect: false },
+      { text: 'since', isCorrect: true },
+      { text: 'from', isCorrect: false },
+      { text: 'on', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-figure-speech-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Identify the figure of speech in: "The wind whispered through the trees."',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'simile', isCorrect: false },
+      { text: 'metaphor', isCorrect: false },
+      { text: 'personification', isCorrect: true },
+      { text: 'hyperbole', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-pronoun-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'JSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'Choose the correct pronoun: "Each of the boys must bring ___ own pen."',
+    difficulty: 'EASY',
+    options: [
+      { text: 'their', isCorrect: false },
+      { text: 'his', isCorrect: true },
+      { text: 'them', isCorrect: false },
+      { text: 'theirs', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-conditional-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'Complete the third-conditional sentence: "If she ___ harder, she would have passed."',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'studies', isCorrect: false },
+      { text: 'studied', isCorrect: false },
+      { text: 'had studied', isCorrect: true },
+      { text: 'would study', isCorrect: false },
+    ],
+  },
+  {
+    seedKey: 'eng-phrase-meaning-1',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS3',
+    type: 'MCQ_SINGLE',
+    prompt: "What does 'a stitch in time saves nine' mean?",
+    difficulty: 'EASY',
+    options: [
+      { text: 'sewing on time prevents tearing', isCorrect: false },
+      { text: 'addressing a problem early prevents bigger trouble later', isCorrect: true },
+      { text: 'time heals all wounds', isCorrect: false },
+      { text: 'nine is greater than one', isCorrect: false },
+    ],
+  },
+
+  // ─── Economics ────────────────────────────────────────────────────────────
+  {
+    seedKey: 'econ-elasticity',
+    canonicalSubjectName: 'Economics',
+    canonicalLevelCode: 'SSS2',
+    type: 'MCQ_SINGLE',
+    prompt: 'When a 10% rise in price causes a 20% fall in quantity demanded, demand is:',
+    difficulty: 'MEDIUM',
+    options: [
+      { text: 'Inelastic', isCorrect: false },
+      { text: 'Unit elastic', isCorrect: false },
+      { text: 'Elastic', isCorrect: true },
+      { text: 'Perfectly inelastic', isCorrect: false },
+    ],
+  },
+
+  // ─── Computer Science ─────────────────────────────────────────────────────
+  {
+    seedKey: 'cs-bigo-binsearch',
+    canonicalSubjectName: 'Computer Science',
+    canonicalLevelCode: 'SSS3',
+    type: 'MCQ_SINGLE',
+    prompt: 'What is the worst-case time complexity of binary search on a sorted array of n elements?',
+    difficulty: 'EASY',
+    options: [
+      { text: 'O(1)', isCorrect: false },
+      { text: 'O(log n)', isCorrect: true },
+      { text: 'O(n)', isCorrect: false },
+      { text: 'O(n log n)', isCorrect: false },
+    ],
+  },
+];
+
+/**
+ * Looks up the bootstrap PLATFORM_ADMIN user by their SystemAdmin role.
+ * Throws if none exists — curated questions need an authorUserId.
+ */
+async function findPlatformAdminUserId(prisma: PrismaClient): Promise<string | null> {
+  const sa = await prisma.systemAdmin.findFirst({
+    where: { role: 'PLATFORM_ADMIN' },
+    select: { user: { select: { id: true } } },
+  });
+  return sa?.user?.id ?? null;
+}
+
+export async function seedCuratedQuestions(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+  const authorUserId = await findPlatformAdminUserId(prisma);
+  if (!authorUserId) {
+    return {
+      upserted: 0,
+      skipped: QUESTIONS.length,
+      durationMs: Date.now() - startedAt,
+      notes:
+        'Skipped — no PLATFORM_ADMIN user found. Run the main seed first to bootstrap the system admin.',
+    };
+  }
+
+  let upserted = 0;
+  let skipped = 0;
+
+  for (const q of QUESTIONS) {
+    const promptPlainText = buildPromptPlainText(q.seedKey, q.prompt);
+    const promptJson = tipTapDoc(q.prompt);
+
+    // Idempotent lookup: find existing SCHOS_CURATED question whose
+    // promptPlainText starts with our anchor for this seedKey.
+    const anchorLine = `${ANCHOR_PREFIX}${q.seedKey}]`;
+    const existing = await prisma.question.findFirst({
+      where: {
+        ownerType: 'SCHOS_CURATED',
+        deletedAt: null,
+        promptPlainText: { startsWith: anchorLine },
+      },
+      select: { id: true },
+    });
+
+    const sharedFields = {
+      canonicalSubjectName: q.canonicalSubjectName,
+      canonicalLevelCode: q.canonicalLevelCode,
+      canonicalTermName: q.canonicalTermName ?? null,
+      type: q.type,
+      prompt: promptJson,
+      promptPlainText,
+      weight: q.weight ?? 1,
+      difficulty: q.difficulty ?? null,
+      partialCreditMode: q.partialCreditMode ?? null,
+      config: q.config ? (q.config as Prisma.InputJsonValue) : Prisma.JsonNull,
+      status: QuestionStatus.DRAFT,
+    };
+
+    if (existing) {
+      await prisma.$transaction(async (tx) => {
+        await tx.question.update({ where: { id: existing.id }, data: sharedFields });
+        if (q.options && q.options.length > 0) {
+          // Replace options in-place to keep them in sync with the seed.
+          await tx.questionOption.deleteMany({ where: { questionId: existing.id } });
+          await tx.questionOption.createMany({
+            data: q.options.map((opt, idx) => ({
+              questionId: existing.id,
+              order: idx,
+              label: tipTapDoc(opt.text) as object,
+              labelPlainText: opt.text,
+              isCorrect: opt.isCorrect,
+            })),
+          });
+        }
+      });
+      upserted += 1;
+      continue;
+    }
+
+    await prisma.$transaction(async (tx) => {
+      const created = await tx.question.create({
+        data: {
+          ...sharedFields,
+          ownerType: 'SCHOS_CURATED',
+          schoolId: null,
+          authorUserId,
+        },
+      });
+      if (q.options && q.options.length > 0) {
+        await tx.questionOption.createMany({
+          data: q.options.map((opt, idx) => ({
+            questionId: created.id,
+            order: idx,
+            label: tipTapDoc(opt.text) as object,
+            labelPlainText: opt.text,
+            isCorrect: opt.isCorrect,
+          })),
+        });
+      }
+    });
+    upserted += 1;
+  }
+
+  return {
+    upserted,
+    skipped,
+    durationMs: Date.now() - startedAt,
+    notes:
+      'Created/updated as DRAFT. Review and publish via the platform-portal /questions area before they appear in /questions/library.',
+  };
+}

--- a/prisma/seeds/curated-quizzes.ts
+++ b/prisma/seeds/curated-quizzes.ts
@@ -1,0 +1,241 @@
+/**
+ * Sample SCHOS_CURATED quizzes that bundle previously-seeded curated
+ * questions into ready-to-publish quiz objects. Owned by the platform
+ * (schoolId = null), authored by the bootstrap PLATFORM_ADMIN, status
+ * DRAFT — staff review and publish via the platform-portal /quizzes UI
+ * before they appear in /quizzes/library for teachers to clone.
+ *
+ * Idempotency: each quiz seed carries a stable `seedKey`. We anchor it
+ * on the FIRST line of the `description` (mirrors the trick used for
+ * curated-questions promptPlainText) and look up by that anchor on
+ * re-runs. QuizQuestion rows are fully replaced on update so the linked
+ * question set always matches the seed's `questionSeedKeys` list.
+ *
+ * Run order: this seed depends on `curated-questions` because it looks
+ * up each linked question by the seedKey anchor inside its
+ * promptPlainText. The SeedRunner UI surfaces the dependency.
+ */
+
+import {
+  Prisma,
+  PrismaClient,
+  QuestionDifficulty,
+  QuizOwnerType,
+  QuizStatus,
+} from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface QuizSeed {
+  seedKey: string;
+  title: string;
+  shortDescription: string;
+  instructions?: string;
+  canonicalSubjectName: string;
+  canonicalLevelCode: string;
+  canonicalTermName?: string;
+  estimatedMinutes: number;
+  passMarkPercent: number;
+  difficulty?: QuestionDifficulty;
+  defaultSettings?: Record<string, unknown>;
+  /**
+   * Stable seed keys of the curated questions to bundle into this quiz, in
+   * order. Each must match a row created by the `curated-questions` seed.
+   */
+  questionSeedKeys: string[];
+}
+
+const ANCHOR_PREFIX = '[seed:';
+const QUESTION_ANCHOR_PREFIX = '[seed:';
+
+function buildDescription(seedKey: string, shortDescription: string): string {
+  // First line is a machine-readable anchor; everything below is human-facing.
+  return `${ANCHOR_PREFIX}${seedKey}]\n${shortDescription}`;
+}
+
+const QUIZZES: QuizSeed[] = [
+  {
+    seedKey: 'eng-generic-quiz',
+    title: 'Generic English Language Quiz',
+    shortDescription:
+      'A 20-question English Language quiz covering vocabulary, grammar, concord, voice, tense, punctuation, idiom and figurative language. WAEC/JAMB-flavoured at SSS level.',
+    instructions:
+      'Read each question carefully. Select the single best answer. You have 30 minutes. The pass mark is 50%.',
+    canonicalSubjectName: 'English Language',
+    canonicalLevelCode: 'SSS3',
+    estimatedMinutes: 30,
+    passMarkPercent: 50,
+    difficulty: QuestionDifficulty.MEDIUM,
+    defaultSettings: {
+      shuffleQuestions: true,
+      shuffleOptions: true,
+      showResultsImmediately: true,
+      showCorrectAnswers: true,
+    },
+    questionSeedKeys: [
+      'eng-tense',
+      'eng-synonym',
+      'eng-antonym-1',
+      'eng-concord-1',
+      'eng-concord-2',
+      'eng-passive-1',
+      'eng-active-1',
+      'eng-tense-future',
+      'eng-vocab-context',
+      'eng-spelling-1',
+      'eng-punct-1',
+      'eng-reported-1',
+      'eng-idiom-1',
+      'eng-stress-1',
+      'eng-comparative-1',
+      'eng-prep-1',
+      'eng-figure-speech-1',
+      'eng-pronoun-1',
+      'eng-conditional-1',
+      'eng-phrase-meaning-1',
+    ],
+  },
+];
+
+async function findPlatformAdminUserId(prisma: PrismaClient): Promise<string | null> {
+  const sa = await prisma.systemAdmin.findFirst({
+    where: { role: 'PLATFORM_ADMIN' },
+    select: { user: { select: { id: true } } },
+  });
+  return sa?.user?.id ?? null;
+}
+
+/**
+ * Resolve question seedKeys to actual Question.id values by matching the
+ * anchor line we wrote into promptPlainText in the curated-questions seed.
+ * Returns a map keyed by seedKey; missing keys are silently absent so the
+ * caller can decide whether to skip the quiz or fail loudly.
+ */
+async function resolveQuestionIds(
+  prisma: PrismaClient,
+  seedKeys: string[],
+): Promise<Map<string, string>> {
+  const found = new Map<string, string>();
+  for (const seedKey of seedKeys) {
+    const anchor = `${QUESTION_ANCHOR_PREFIX}${seedKey}]`;
+    const q = await prisma.question.findFirst({
+      where: {
+        ownerType: 'SCHOS_CURATED',
+        deletedAt: null,
+        promptPlainText: { startsWith: anchor },
+      },
+      select: { id: true },
+    });
+    if (q) found.set(seedKey, q.id);
+  }
+  return found;
+}
+
+export async function seedCuratedQuizzes(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+  const authorUserId = await findPlatformAdminUserId(prisma);
+  if (!authorUserId) {
+    return {
+      upserted: 0,
+      skipped: QUIZZES.length,
+      durationMs: Date.now() - startedAt,
+      notes:
+        'Skipped — no PLATFORM_ADMIN user found. Run the main seed first to bootstrap the system admin.',
+    };
+  }
+
+  let upserted = 0;
+  let skipped = 0;
+  const missingQuestionsByQuiz: Record<string, string[]> = {};
+
+  for (const q of QUIZZES) {
+    const idMap = await resolveQuestionIds(prisma, q.questionSeedKeys);
+    const missing = q.questionSeedKeys.filter((k) => !idMap.has(k));
+    if (missing.length > 0) {
+      missingQuestionsByQuiz[q.seedKey] = missing;
+    }
+    if (idMap.size === 0) {
+      // No questions resolved — the curated-questions seed hasn't been run.
+      // Skip this quiz entirely; partial-resolution case below still creates
+      // the quiz but flags the missing pieces in the notes.
+      skipped += 1;
+      continue;
+    }
+
+    const description = buildDescription(q.seedKey, q.shortDescription);
+    const anchorLine = `${ANCHOR_PREFIX}${q.seedKey}]`;
+    const existing = await prisma.quiz.findFirst({
+      where: {
+        ownerType: 'SCHOS_CURATED',
+        deletedAt: null,
+        description: { startsWith: anchorLine },
+      },
+      select: { id: true },
+    });
+
+    const sharedFields = {
+      title: q.title,
+      description,
+      instructions: q.instructions ?? null,
+      canonicalSubjectName: q.canonicalSubjectName,
+      canonicalLevelCode: q.canonicalLevelCode,
+      canonicalTermName: q.canonicalTermName ?? null,
+      estimatedMinutes: q.estimatedMinutes,
+      passMarkPercent: new Prisma.Decimal(q.passMarkPercent),
+      difficulty: q.difficulty ?? null,
+      defaultSettings: (q.defaultSettings as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+      status: QuizStatus.DRAFT,
+    };
+
+    const orderedIds = q.questionSeedKeys
+      .map((k) => idMap.get(k))
+      .filter((id): id is string => Boolean(id));
+
+    if (existing) {
+      await prisma.$transaction(async (tx) => {
+        await tx.quiz.update({ where: { id: existing.id }, data: sharedFields });
+        await tx.quizQuestion.deleteMany({ where: { quizId: existing.id } });
+        await tx.quizQuestion.createMany({
+          data: orderedIds.map((questionId, idx) => ({
+            quizId: existing.id,
+            questionId,
+            order: idx,
+          })),
+        });
+      });
+    } else {
+      await prisma.$transaction(async (tx) => {
+        const created = await tx.quiz.create({
+          data: {
+            ...sharedFields,
+            ownerType: QuizOwnerType.SCHOS_CURATED,
+            schoolId: null,
+            authorUserId,
+          },
+        });
+        await tx.quizQuestion.createMany({
+          data: orderedIds.map((questionId, idx) => ({
+            quizId: created.id,
+            questionId,
+            order: idx,
+          })),
+        });
+      });
+    }
+    upserted += 1;
+  }
+
+  const missingNotes = Object.entries(missingQuestionsByQuiz)
+    .map(([k, ids]) => `${k}: missing ${ids.join(', ')}`)
+    .join('; ');
+
+  return {
+    upserted,
+    skipped,
+    durationMs: Date.now() - startedAt,
+    notes:
+      missingNotes.length > 0
+        ? `Some questions were not yet seeded — run curated-questions first. (${missingNotes})`
+        : 'Quizzes created/updated as DRAFT. Review and publish via /quizzes before they appear in the curated library for teachers.',
+  };
+}

--- a/prisma/seeds/equation-library.ts
+++ b/prisma/seeds/equation-library.ts
@@ -1,0 +1,1023 @@
+/**
+ * Curated equation library — platform-owned, exposed via /equation-library to
+ * teachers in the question-authoring "Insert math" dialog.
+ *
+ * IMPORTANT — LaTeX escaping:
+ *   In TS string literals, every backslash must be doubled. Use `\\frac{a}{b}`
+ *   not `\frac{a}{b}`. Single-backslash content will be silently mangled.
+ *
+ * IMPORTANT — keying:
+ *   Each row is upserted by (canonicalSubjectSlug, name). Renaming an existing
+ *   entry creates a new row instead of updating the existing one — pick the
+ *   final name first, then prefer to edit `latex`/`description`/`tags`/`order`.
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface EquationSeed {
+  subjectSlug: string;
+  name: string;
+  description?: string;
+  latex: string;
+  tags: string[];
+  order: number;
+}
+
+const EQUATIONS: EquationSeed[] = [
+  // ─── Mathematics ──────────────────────────────────────────────────────────
+  {
+    subjectSlug: 'mathematics',
+    name: 'Quadratic Formula',
+    description: 'Solves ax² + bx + c = 0 for x',
+    latex: 'x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}',
+    tags: ['algebra', 'roots', 'polynomial'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Pythagoras Theorem',
+    description: 'Right-angled triangle side relationship',
+    latex: 'a^2 + b^2 = c^2',
+    tags: ['geometry', 'triangle'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Distance Formula',
+    description: 'Distance between two points (x₁, y₁) and (x₂, y₂)',
+    latex: 'd = \\sqrt{(x_2 - x_1)^2 + (y_2 - y_1)^2}',
+    tags: ['geometry', 'coordinates'],
+    order: 30,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Slope of a Line',
+    description: 'Slope between two points',
+    latex: 'm = \\frac{y_2 - y_1}{x_2 - x_1}',
+    tags: ['algebra', 'coordinates', 'lines'],
+    order: 40,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Slope-Intercept Form',
+    description: 'Linear equation with slope m and y-intercept c',
+    latex: 'y = mx + c',
+    tags: ['algebra', 'lines'],
+    order: 50,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Area of a Circle',
+    latex: 'A = \\pi r^2',
+    tags: ['geometry', 'circle', 'area'],
+    order: 60,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Circumference of a Circle',
+    latex: 'C = 2 \\pi r',
+    tags: ['geometry', 'circle'],
+    order: 70,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Area of a Triangle',
+    description: 'Base × height ÷ 2',
+    latex: 'A = \\tfrac{1}{2} b h',
+    tags: ['geometry', 'triangle', 'area'],
+    order: 80,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Volume of a Sphere',
+    latex: 'V = \\tfrac{4}{3} \\pi r^3',
+    tags: ['geometry', 'sphere', 'volume'],
+    order: 90,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Volume of a Cylinder',
+    latex: 'V = \\pi r^2 h',
+    tags: ['geometry', 'cylinder', 'volume'],
+    order: 100,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Sum of Arithmetic Series',
+    description: 'Sum of the first n terms of an arithmetic progression',
+    latex: 'S_n = \\tfrac{n}{2}\\bigl(2a + (n - 1)d\\bigr)',
+    tags: ['algebra', 'series', 'sequences'],
+    order: 110,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Sum of Geometric Series',
+    description: 'Sum of the first n terms of a geometric progression (r ≠ 1)',
+    latex: 'S_n = \\frac{a(1 - r^n)}{1 - r}',
+    tags: ['algebra', 'series', 'sequences'],
+    order: 120,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Binomial Theorem',
+    latex: '(a + b)^n = \\sum_{k=0}^{n} \\binom{n}{k} a^{n-k} b^{k}',
+    tags: ['algebra', 'series'],
+    order: 130,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Definite Integral',
+    description: 'Fundamental theorem of calculus',
+    latex: '\\int_{a}^{b} f(x)\\,dx = F(b) - F(a)',
+    tags: ['calculus', 'integral'],
+    order: 140,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Power Rule (Derivative)',
+    latex: '\\frac{d}{dx} x^n = n x^{n-1}',
+    tags: ['calculus', 'derivative'],
+    order: 150,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Mean (Average)',
+    description: 'Arithmetic mean of n values',
+    latex: '\\bar{x} = \\frac{1}{n} \\sum_{i=1}^{n} x_i',
+    tags: ['statistics', 'average'],
+    order: 200,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Variance',
+    description: 'Population variance',
+    latex: '\\sigma^2 = \\frac{1}{n} \\sum_{i=1}^{n} (x_i - \\bar{x})^2',
+    tags: ['statistics', 'spread'],
+    order: 210,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Standard Deviation',
+    description: 'Population standard deviation',
+    latex: '\\sigma = \\sqrt{\\frac{1}{n} \\sum_{i=1}^{n} (x_i - \\bar{x})^2}',
+    tags: ['statistics', 'spread'],
+    order: 220,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Z-Score',
+    description: 'Number of standard deviations from the mean',
+    latex: 'z = \\frac{x - \\mu}{\\sigma}',
+    tags: ['statistics', 'normal-distribution'],
+    order: 230,
+  },
+
+  // ─── Physics ──────────────────────────────────────────────────────────────
+  {
+    subjectSlug: 'physics',
+    name: "Newton's Second Law",
+    description: 'Net force equals mass times acceleration',
+    latex: 'F = ma',
+    tags: ['mechanics', 'force'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Kinematic Equation (v = u + at)',
+    description: 'Final velocity from initial velocity, acceleration, and time',
+    latex: 'v = u + at',
+    tags: ['kinematics', 'motion'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Kinematic Equation (s = ut + ½at²)',
+    description: 'Displacement under constant acceleration',
+    latex: 's = ut + \\tfrac{1}{2} a t^2',
+    tags: ['kinematics', 'motion'],
+    order: 30,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Kinematic Equation (v² = u² + 2as)',
+    description: 'Velocity-displacement relation under constant acceleration',
+    latex: 'v^2 = u^2 + 2as',
+    tags: ['kinematics', 'motion'],
+    order: 40,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Kinetic Energy',
+    latex: 'E_k = \\tfrac{1}{2} m v^2',
+    tags: ['energy', 'mechanics'],
+    order: 50,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Gravitational Potential Energy',
+    description: 'Energy of a mass at height h in gravity g',
+    latex: 'E_p = mgh',
+    tags: ['energy', 'gravity'],
+    order: 60,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Work Done',
+    description: 'Force times displacement in the direction of force',
+    latex: 'W = F d \\cos\\theta',
+    tags: ['energy', 'mechanics'],
+    order: 70,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Newton’s Law of Gravitation',
+    latex: 'F = G \\frac{m_1 m_2}{r^2}',
+    tags: ['gravity', 'mechanics'],
+    order: 80,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Momentum',
+    latex: 'p = mv',
+    tags: ['mechanics', 'momentum'],
+    order: 90,
+  },
+  {
+    subjectSlug: 'physics',
+    name: "Ohm's Law",
+    description: 'Voltage equals current times resistance',
+    latex: 'V = IR',
+    tags: ['electricity', 'circuits'],
+    order: 100,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Electrical Power',
+    latex: 'P = VI',
+    tags: ['electricity', 'power'],
+    order: 110,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Wave Equation',
+    description: 'Wave speed equals frequency times wavelength',
+    latex: 'v = f \\lambda',
+    tags: ['waves', 'frequency'],
+    order: 120,
+  },
+
+  // ─── Chemistry ────────────────────────────────────────────────────────────
+  {
+    subjectSlug: 'chemistry',
+    name: 'pH Definition',
+    description: 'pH as negative log of hydrogen ion concentration',
+    latex: '\\mathrm{pH} = -\\log_{10} [\\mathrm{H}^+]',
+    tags: ['acid-base', 'equilibrium'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Molarity',
+    description: 'Moles of solute per litre of solution',
+    latex: 'M = \\frac{n}{V}',
+    tags: ['solutions', 'concentration'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Ideal Gas Law',
+    latex: 'PV = nRT',
+    tags: ['gases', 'thermodynamics'],
+    order: 30,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Number of Moles',
+    description: 'Moles from mass and molar mass',
+    latex: 'n = \\frac{m}{M}',
+    tags: ['stoichiometry', 'moles'],
+    order: 40,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Dilution Equation',
+    description: 'Conservation of moles on dilution',
+    latex: 'M_1 V_1 = M_2 V_2',
+    tags: ['solutions', 'dilution'],
+    order: 50,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Heat Energy',
+    description: 'Specific heat capacity equation',
+    latex: 'Q = mc\\Delta T',
+    tags: ['thermodynamics', 'energy'],
+    order: 60,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Equilibrium Constant (Kc)',
+    description: 'For the reaction aA + bB ⇌ cC + dD',
+    latex: 'K_c = \\frac{[\\mathrm{C}]^c [\\mathrm{D}]^d}{[\\mathrm{A}]^a [\\mathrm{B}]^b}',
+    tags: ['equilibrium', 'kinetics'],
+    order: 70,
+  },
+
+  // ─── Economics ────────────────────────────────────────────────────────────
+  {
+    subjectSlug: 'economics',
+    name: 'Price Elasticity of Demand',
+    description: 'Percentage change in quantity demanded over percentage change in price',
+    latex: 'E_d = \\frac{\\% \\Delta Q_d}{\\% \\Delta P}',
+    tags: ['demand', 'elasticity'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'economics',
+    name: 'Simple Interest',
+    latex: 'I = P r t',
+    tags: ['interest', 'finance'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'economics',
+    name: 'Compound Interest',
+    description: 'Future value of P compounded n times per period at rate r',
+    latex: 'A = P \\left(1 + \\frac{r}{n}\\right)^{nt}',
+    tags: ['interest', 'finance'],
+    order: 30,
+  },
+  {
+    subjectSlug: 'economics',
+    name: 'Gross Domestic Product (Expenditure)',
+    description: 'GDP by expenditure components',
+    latex: 'GDP = C + I + G + (X - M)',
+    tags: ['macro', 'gdp'],
+    order: 40,
+  },
+  {
+    subjectSlug: 'economics',
+    name: 'Marginal Propensity to Consume',
+    description: 'Change in consumption divided by change in income',
+    latex: 'MPC = \\frac{\\Delta C}{\\Delta Y}',
+    tags: ['macro', 'consumption'],
+    order: 50,
+  },
+  {
+    subjectSlug: 'economics',
+    name: 'Multiplier (Simple Keynesian)',
+    description: 'Income multiplier for an increase in autonomous spending',
+    latex: 'k = \\frac{1}{1 - MPC}',
+    tags: ['macro', 'multiplier'],
+    order: 60,
+  },
+  {
+    subjectSlug: 'economics',
+    name: 'Real GDP Growth Rate',
+    description: 'Year-over-year real GDP growth',
+    latex: 'g = \\frac{GDP_{t} - GDP_{t-1}}{GDP_{t-1}} \\times 100\\%',
+    tags: ['macro', 'growth'],
+    order: 70,
+  },
+
+  // ─── Mathematics — Matrices ──────────────────────────────────────────────
+  {
+    subjectSlug: 'mathematics',
+    name: '2×2 Matrix',
+    description: 'Generic 2×2 matrix template',
+    latex: 'A = \\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}',
+    tags: ['matrix', 'linear-algebra'],
+    order: 300,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: '3×3 Matrix',
+    description: 'Generic 3×3 matrix template',
+    latex: 'A = \\begin{pmatrix} a_{11} & a_{12} & a_{13} \\\\ a_{21} & a_{22} & a_{23} \\\\ a_{31} & a_{32} & a_{33} \\end{pmatrix}',
+    tags: ['matrix', 'linear-algebra'],
+    order: 310,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Identity Matrix (3×3)',
+    latex: 'I = \\begin{pmatrix} 1 & 0 & 0 \\\\ 0 & 1 & 0 \\\\ 0 & 0 & 1 \\end{pmatrix}',
+    tags: ['matrix', 'linear-algebra', 'identity'],
+    order: 320,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Matrix Transpose',
+    description: 'Rows of A become columns of Aᵀ',
+    latex: '(A^{T})_{ij} = A_{ji}',
+    tags: ['matrix', 'linear-algebra', 'transpose'],
+    order: 330,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Determinant of a 2×2 Matrix',
+    latex: '\\det(A) = ad - bc',
+    tags: ['matrix', 'determinant'],
+    order: 340,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Determinant of a 3×3 Matrix',
+    description: 'Cofactor expansion along the first row',
+    latex: '\\det(A) = a_{11}(a_{22}a_{33} - a_{23}a_{32}) - a_{12}(a_{21}a_{33} - a_{23}a_{31}) + a_{13}(a_{21}a_{32} - a_{22}a_{31})',
+    tags: ['matrix', 'determinant'],
+    order: 350,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Inverse of a 2×2 Matrix',
+    description: 'Provided ad − bc ≠ 0',
+    latex: 'A^{-1} = \\frac{1}{ad - bc} \\begin{pmatrix} d & -b \\\\ -c & a \\end{pmatrix}',
+    tags: ['matrix', 'inverse'],
+    order: 360,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Matrix Multiplication (Element)',
+    description: 'Element (i,j) of AB',
+    latex: '(AB)_{ij} = \\sum_{k=1}^{n} A_{ik} B_{kj}',
+    tags: ['matrix', 'multiplication'],
+    order: 370,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Eigenvalue Equation',
+    description: 'Av = λv',
+    latex: 'A \\mathbf{v} = \\lambda \\mathbf{v}',
+    tags: ['matrix', 'eigenvalue', 'linear-algebra'],
+    order: 380,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: "Cramer's Rule (2 unknowns)",
+    description: 'Solve Ax = b when det(A) ≠ 0',
+    latex: 'x = \\frac{\\det(A_x)}{\\det(A)}, \\quad y = \\frac{\\det(A_y)}{\\det(A)}',
+    tags: ['matrix', 'linear-systems'],
+    order: 390,
+  },
+
+  // ─── Mathematics — Trigonometry & Logarithms ─────────────────────────────
+  {
+    subjectSlug: 'mathematics',
+    name: 'Pythagorean Identity',
+    latex: '\\sin^2 \\theta + \\cos^2 \\theta = 1',
+    tags: ['trigonometry', 'identity'],
+    order: 400,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Tangent Identity',
+    latex: '\\tan \\theta = \\frac{\\sin \\theta}{\\cos \\theta}',
+    tags: ['trigonometry', 'identity'],
+    order: 410,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Sum Formula (sin)',
+    latex: '\\sin(A + B) = \\sin A \\cos B + \\cos A \\sin B',
+    tags: ['trigonometry', 'identity'],
+    order: 420,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Sum Formula (cos)',
+    latex: '\\cos(A + B) = \\cos A \\cos B - \\sin A \\sin B',
+    tags: ['trigonometry', 'identity'],
+    order: 430,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Double-Angle (sin)',
+    latex: '\\sin 2\\theta = 2 \\sin \\theta \\cos \\theta',
+    tags: ['trigonometry', 'identity'],
+    order: 440,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Law of Sines',
+    description: 'For any triangle with sides a, b, c opposite angles A, B, C',
+    latex: '\\frac{a}{\\sin A} = \\frac{b}{\\sin B} = \\frac{c}{\\sin C}',
+    tags: ['trigonometry', 'triangle'],
+    order: 450,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Law of Cosines',
+    latex: 'c^2 = a^2 + b^2 - 2ab \\cos C',
+    tags: ['trigonometry', 'triangle'],
+    order: 460,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Logarithm Product Rule',
+    latex: '\\log(xy) = \\log x + \\log y',
+    tags: ['logarithm'],
+    order: 470,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Logarithm Quotient Rule',
+    latex: '\\log\\!\\left(\\frac{x}{y}\\right) = \\log x - \\log y',
+    tags: ['logarithm'],
+    order: 480,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Logarithm Power Rule',
+    latex: '\\log(x^n) = n \\log x',
+    tags: ['logarithm'],
+    order: 490,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Change of Base',
+    latex: '\\log_{a} b = \\frac{\\log b}{\\log a}',
+    tags: ['logarithm'],
+    order: 500,
+  },
+
+  // ─── Mathematics — Calculus extras ───────────────────────────────────────
+  {
+    subjectSlug: 'mathematics',
+    name: 'Limit Definition of Derivative',
+    latex: 'f\\,\'(x) = \\lim_{h \\to 0} \\frac{f(x + h) - f(x)}{h}',
+    tags: ['calculus', 'derivative'],
+    order: 510,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Product Rule (Derivative)',
+    latex: '(fg)\\,\' = f\\,\'g + fg\\,\'',
+    tags: ['calculus', 'derivative'],
+    order: 520,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Quotient Rule (Derivative)',
+    latex: '\\left(\\frac{f}{g}\\right)\\,\' = \\frac{f\\,\'g - fg\\,\'}{g^2}',
+    tags: ['calculus', 'derivative'],
+    order: 530,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Chain Rule',
+    latex: '\\frac{d}{dx} f(g(x)) = f\\,\'(g(x)) \\cdot g\\,\'(x)',
+    tags: ['calculus', 'derivative'],
+    order: 540,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Integral of x^n',
+    description: 'For n ≠ −1',
+    latex: '\\int x^{n}\\,dx = \\frac{x^{n+1}}{n+1} + C',
+    tags: ['calculus', 'integral'],
+    order: 550,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Integral of 1/x',
+    latex: '\\int \\frac{1}{x}\\,dx = \\ln |x| + C',
+    tags: ['calculus', 'integral'],
+    order: 560,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Integration by Parts',
+    latex: '\\int u\\,dv = uv - \\int v\\,du',
+    tags: ['calculus', 'integral'],
+    order: 570,
+  },
+
+  // ─── Mathematics — Probability & Combinatorics ───────────────────────────
+  {
+    subjectSlug: 'mathematics',
+    name: 'Permutations nPr',
+    latex: '{}^{n}P_{r} = \\frac{n!}{(n - r)!}',
+    tags: ['combinatorics', 'probability'],
+    order: 600,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Combinations nCr',
+    latex: '{}^{n}C_{r} = \\binom{n}{r} = \\frac{n!}{r!(n - r)!}',
+    tags: ['combinatorics', 'probability'],
+    order: 610,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Conditional Probability',
+    latex: 'P(A \\mid B) = \\frac{P(A \\cap B)}{P(B)}',
+    tags: ['probability'],
+    order: 620,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: "Bayes' Theorem",
+    latex: 'P(A \\mid B) = \\frac{P(B \\mid A)\\,P(A)}{P(B)}',
+    tags: ['probability'],
+    order: 630,
+  },
+  {
+    subjectSlug: 'mathematics',
+    name: 'Expected Value (Discrete)',
+    latex: 'E[X] = \\sum_{i} x_{i}\\,P(x_{i})',
+    tags: ['probability', 'statistics'],
+    order: 640,
+  },
+
+  // ─── Further Mathematics — Vectors & Complex ─────────────────────────────
+  {
+    subjectSlug: 'further-mathematics',
+    name: 'Vector Magnitude (3D)',
+    latex: '|\\mathbf{v}| = \\sqrt{v_x^{2} + v_y^{2} + v_z^{2}}',
+    tags: ['vector', 'geometry'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'further-mathematics',
+    name: 'Dot Product',
+    latex: '\\mathbf{a} \\cdot \\mathbf{b} = a_x b_x + a_y b_y + a_z b_z',
+    tags: ['vector'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'further-mathematics',
+    name: 'Cross Product Magnitude',
+    latex: '|\\mathbf{a} \\times \\mathbf{b}| = |\\mathbf{a}||\\mathbf{b}| \\sin \\theta',
+    tags: ['vector'],
+    order: 30,
+  },
+  {
+    subjectSlug: 'further-mathematics',
+    name: "Euler's Formula",
+    latex: 'e^{i\\theta} = \\cos \\theta + i \\sin \\theta',
+    tags: ['complex', 'identity'],
+    order: 40,
+  },
+  {
+    subjectSlug: 'further-mathematics',
+    name: 'Modulus of Complex Number',
+    latex: '|z| = \\sqrt{a^{2} + b^{2}}',
+    tags: ['complex'],
+    order: 50,
+  },
+  {
+    subjectSlug: 'further-mathematics',
+    name: 'De Moivre Theorem',
+    latex: '(\\cos \\theta + i \\sin \\theta)^{n} = \\cos n\\theta + i \\sin n\\theta',
+    tags: ['complex', 'identity'],
+    order: 60,
+  },
+
+  // ─── Physics — Electricity & Magnetism ───────────────────────────────────
+  {
+    subjectSlug: 'physics',
+    name: 'Electric Charge (Capacitor)',
+    description: 'Charge stored on a capacitor at voltage V',
+    latex: 'Q = CV',
+    tags: ['electricity', 'capacitance'],
+    order: 200,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Capacitor Energy',
+    latex: 'E = \\tfrac{1}{2} C V^{2}',
+    tags: ['electricity', 'capacitance', 'energy'],
+    order: 210,
+  },
+  {
+    subjectSlug: 'physics',
+    name: "Coulomb's Law",
+    description: 'Force between two point charges',
+    latex: 'F = k \\frac{q_{1} q_{2}}{r^{2}}',
+    tags: ['electricity', 'force'],
+    order: 220,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Electric Field',
+    latex: 'E = \\frac{F}{q}',
+    tags: ['electricity', 'field'],
+    order: 230,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Resistors in Series',
+    latex: 'R_{eq} = R_{1} + R_{2} + \\dots + R_{n}',
+    tags: ['electricity', 'resistors'],
+    order: 240,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Resistors in Parallel',
+    latex: '\\frac{1}{R_{eq}} = \\frac{1}{R_{1}} + \\frac{1}{R_{2}} + \\dots + \\frac{1}{R_{n}}',
+    tags: ['electricity', 'resistors'],
+    order: 250,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Magnetic Force on a Charge',
+    latex: 'F = qvB \\sin \\theta',
+    tags: ['magnetism', 'force'],
+    order: 260,
+  },
+
+  // ─── Physics — Thermodynamics & Modern ───────────────────────────────────
+  {
+    subjectSlug: 'physics',
+    name: 'First Law of Thermodynamics',
+    latex: '\\Delta U = Q - W',
+    tags: ['thermodynamics', 'energy'],
+    order: 300,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Heat Capacity',
+    latex: 'Q = mc \\Delta T',
+    tags: ['thermodynamics'],
+    order: 310,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Stefan–Boltzmann Law',
+    description: 'Total radiated power per unit area of a black body',
+    latex: 'P = \\sigma T^{4}',
+    tags: ['thermodynamics', 'radiation'],
+    order: 320,
+  },
+  {
+    subjectSlug: 'physics',
+    name: "Einstein's Mass-Energy Equivalence",
+    latex: 'E = mc^{2}',
+    tags: ['modern', 'relativity'],
+    order: 330,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Photon Energy',
+    latex: 'E = hf',
+    tags: ['quantum', 'photon'],
+    order: 340,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'de Broglie Wavelength',
+    latex: '\\lambda = \\frac{h}{p}',
+    tags: ['quantum', 'waves'],
+    order: 350,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Snell’s Law',
+    latex: 'n_{1} \\sin \\theta_{1} = n_{2} \\sin \\theta_{2}',
+    tags: ['optics', 'waves'],
+    order: 360,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Lens / Mirror Equation',
+    latex: '\\frac{1}{f} = \\frac{1}{u} + \\frac{1}{v}',
+    tags: ['optics'],
+    order: 370,
+  },
+  {
+    subjectSlug: 'physics',
+    name: 'Doppler Effect (Sound, observer)',
+    description: 'Frequency heard by stationary observer, source moving',
+    latex: "f' = f \\left( \\frac{v}{v - v_{s}} \\right)",
+    tags: ['waves', 'doppler'],
+    order: 380,
+  },
+
+  // ─── Chemistry — More ────────────────────────────────────────────────────
+  {
+    subjectSlug: 'chemistry',
+    name: 'Avogadro Constant',
+    description: 'Number of particles per mole',
+    latex: 'N_{A} = 6.022 \\times 10^{23}\\,\\mathrm{mol}^{-1}',
+    tags: ['stoichiometry', 'constants'],
+    order: 100,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Number of Particles',
+    latex: 'N = n \\cdot N_{A}',
+    tags: ['stoichiometry'],
+    order: 110,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'pOH',
+    latex: '\\mathrm{pOH} = -\\log_{10}[\\mathrm{OH}^{-}]',
+    tags: ['acid-base'],
+    order: 120,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'pH + pOH Relationship',
+    latex: '\\mathrm{pH} + \\mathrm{pOH} = 14',
+    tags: ['acid-base'],
+    order: 130,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Henderson–Hasselbalch',
+    description: 'pH of a buffer from pKa and ratio of conjugate base to acid',
+    latex: '\\mathrm{pH} = \\mathrm{p}K_{a} + \\log\\!\\left(\\frac{[\\mathrm{A}^{-}]}{[\\mathrm{HA}]}\\right)',
+    tags: ['acid-base', 'buffer'],
+    order: 140,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Arrhenius Equation',
+    description: 'Temperature dependence of reaction rate constants',
+    latex: 'k = A e^{-E_{a} / (RT)}',
+    tags: ['kinetics'],
+    order: 150,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Gibbs Free Energy',
+    latex: '\\Delta G = \\Delta H - T \\Delta S',
+    tags: ['thermodynamics'],
+    order: 160,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Equilibrium and ΔG°',
+    description: 'Standard Gibbs free energy and equilibrium constant',
+    latex: '\\Delta G^{\\circ} = -RT \\ln K',
+    tags: ['equilibrium', 'thermodynamics'],
+    order: 170,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Nernst Equation',
+    latex: 'E = E^{\\circ} - \\frac{RT}{nF} \\ln Q',
+    tags: ['electrochemistry'],
+    order: 180,
+  },
+  {
+    subjectSlug: 'chemistry',
+    name: 'Percentage Yield',
+    latex: '\\% \\text{ yield} = \\frac{\\text{actual}}{\\text{theoretical}} \\times 100\\%',
+    tags: ['stoichiometry'],
+    order: 190,
+  },
+
+  // ─── Biology (light) ─────────────────────────────────────────────────────
+  {
+    subjectSlug: 'biology',
+    name: 'Hardy–Weinberg Genotype Frequencies',
+    latex: 'p^{2} + 2pq + q^{2} = 1',
+    tags: ['genetics', 'population'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'biology',
+    name: 'Hardy–Weinberg Allele Frequencies',
+    latex: 'p + q = 1',
+    tags: ['genetics', 'population'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'biology',
+    name: 'Photosynthesis (overall)',
+    description: 'Glucose synthesis from CO₂ and water',
+    latex: '6\\,\\mathrm{CO}_{2} + 6\\,\\mathrm{H}_{2}\\mathrm{O} \\xrightarrow{\\text{light}} \\mathrm{C}_{6}\\mathrm{H}_{12}\\mathrm{O}_{6} + 6\\,\\mathrm{O}_{2}',
+    tags: ['photosynthesis'],
+    order: 30,
+  },
+  {
+    subjectSlug: 'biology',
+    name: 'Cellular Respiration (overall)',
+    latex: '\\mathrm{C}_{6}\\mathrm{H}_{12}\\mathrm{O}_{6} + 6\\,\\mathrm{O}_{2} \\rightarrow 6\\,\\mathrm{CO}_{2} + 6\\,\\mathrm{H}_{2}\\mathrm{O} + \\text{energy}',
+    tags: ['respiration'],
+    order: 40,
+  },
+
+  // ─── Financial Accounting ────────────────────────────────────────────────
+  {
+    subjectSlug: 'financial-accounting',
+    name: 'Accounting Equation',
+    latex: '\\text{Assets} = \\text{Liabilities} + \\text{Equity}',
+    tags: ['fundamentals'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'financial-accounting',
+    name: 'Gross Profit',
+    latex: '\\text{Gross Profit} = \\text{Revenue} - \\text{COGS}',
+    tags: ['profit'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'financial-accounting',
+    name: 'Net Profit',
+    latex: '\\text{Net Profit} = \\text{Gross Profit} - \\text{Operating Expenses}',
+    tags: ['profit'],
+    order: 30,
+  },
+  {
+    subjectSlug: 'financial-accounting',
+    name: 'Current Ratio',
+    latex: '\\text{Current Ratio} = \\frac{\\text{Current Assets}}{\\text{Current Liabilities}}',
+    tags: ['ratios', 'liquidity'],
+    order: 40,
+  },
+  {
+    subjectSlug: 'financial-accounting',
+    name: 'Straight-Line Depreciation',
+    latex: '\\text{Depreciation} = \\frac{\\text{Cost} - \\text{Salvage}}{\\text{Useful Life}}',
+    tags: ['depreciation'],
+    order: 50,
+  },
+
+  // ─── Computer Science ────────────────────────────────────────────────────
+  {
+    subjectSlug: 'computer-science',
+    name: 'Big-O Definition',
+    description: 'f(n) = O(g(n)) iff there exist c, n₀ > 0 such that f(n) ≤ c·g(n) for all n ≥ n₀',
+    latex: 'f(n) = O(g(n))',
+    tags: ['complexity', 'asymptotic'],
+    order: 10,
+  },
+  {
+    subjectSlug: 'computer-science',
+    name: 'Logarithm Bases (Big-O)',
+    description: 'Logarithm base is irrelevant in big-O notation',
+    latex: 'O(\\log_{a} n) = O(\\log_{b} n)',
+    tags: ['complexity'],
+    order: 20,
+  },
+  {
+    subjectSlug: 'computer-science',
+    name: 'Master Theorem (Case 2)',
+    description: 'For T(n) = aT(n/b) + Θ(n^d) with a = b^d',
+    latex: 'T(n) = \\Theta(n^{d} \\log n)',
+    tags: ['complexity', 'recurrence'],
+    order: 30,
+  },
+];
+
+export async function seedEquationLibrary(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+
+  const subjects = await prisma.canonicalSubject.findMany({
+    where: { slug: { in: Array.from(new Set(EQUATIONS.map((e) => e.subjectSlug))) } },
+    select: { id: true, slug: true },
+  });
+  const subjectIdBySlug = new Map(subjects.map((s) => [s.slug, s.id]));
+
+  let upserted = 0;
+  let skipped = 0;
+  const missingSubjectSlugs = new Set<string>();
+  for (const eq of EQUATIONS) {
+    const subjectId = subjectIdBySlug.get(eq.subjectSlug);
+    if (!subjectId) {
+      missingSubjectSlugs.add(eq.subjectSlug);
+      skipped += 1;
+      continue;
+    }
+    await prisma.equationLibraryItem.upsert({
+      where: {
+        canonicalSubjectId_name: {
+          canonicalSubjectId: subjectId,
+          name: eq.name,
+        },
+      },
+      update: {
+        description: eq.description ?? null,
+        latex: eq.latex,
+        tags: eq.tags,
+        order: eq.order,
+        isActive: true,
+      },
+      create: {
+        canonicalSubjectId: subjectId,
+        name: eq.name,
+        description: eq.description,
+        latex: eq.latex,
+        tags: eq.tags,
+        order: eq.order,
+      },
+    });
+    upserted += 1;
+  }
+
+  return {
+    upserted,
+    skipped,
+    durationMs: Date.now() - startedAt,
+    notes:
+      missingSubjectSlugs.size > 0
+        ? `Skipped equations for missing canonical subject(s): ${Array.from(missingSubjectSlugs).join(', ')}. Run canonical-subjects first.`
+        : undefined,
+  };
+}

--- a/prisma/seeds/popular-exams.ts
+++ b/prisma/seeds/popular-exams.ts
@@ -1,0 +1,50 @@
+import { PrismaClient } from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface PopularExamSeed {
+  code: string;
+  name: string;
+  country: string;
+  description: string;
+}
+
+const POPULAR_EXAMS: ReadonlyArray<PopularExamSeed> = [
+  { code: 'WAEC', name: 'West African Examinations Council', country: 'NG', description: 'Senior School Certificate Examination administered across West Africa.' },
+  { code: 'NECO', name: 'National Examinations Council', country: 'NG', description: 'Nigerian senior secondary certificate examination.' },
+  { code: 'JAMB', name: 'Joint Admissions and Matriculation Board', country: 'NG', description: 'Nigerian university matriculation examination (UTME).' },
+  { code: 'NABTEB', name: 'National Business and Technical Examinations Board', country: 'NG', description: 'Nigerian technical and business education certificate.' },
+  { code: 'BECE', name: 'Basic Education Certificate Examination', country: 'NG', description: 'Junior secondary school exit examination in Nigeria.' },
+  { code: 'COMMON_ENTRANCE', name: 'National Common Entrance Examination', country: 'NG', description: 'Entry examination for federal unity colleges.' },
+  { code: 'IGCSE', name: 'International General Certificate of Secondary Education', country: 'INTL', description: 'Cambridge international secondary qualification.' },
+  { code: 'CHECKPOINT', name: 'Cambridge Lower Secondary Checkpoint', country: 'INTL', description: 'Cambridge end-of-stage assessment for lower secondary.' },
+  { code: 'A_LEVELS', name: 'GCE Advanced Level', country: 'INTL', description: 'Cambridge / Edexcel pre-university qualification.' },
+  { code: 'O_LEVELS', name: 'GCE Ordinary Level', country: 'INTL', description: 'Cambridge / Edexcel ordinary-level qualification.' },
+  { code: 'SAT', name: 'Scholastic Assessment Test', country: 'INTL', description: 'College Board standardized university admissions test.' },
+  { code: 'TOEFL', name: 'Test of English as a Foreign Language', country: 'INTL', description: 'English-language proficiency test for non-native speakers.' },
+  { code: 'IELTS', name: 'International English Language Testing System', country: 'INTL', description: 'English-language proficiency test for study, work, migration.' },
+];
+
+export async function seedPopularExams(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+  let upserted = 0;
+  for (const exam of POPULAR_EXAMS) {
+    await prisma.popularExam.upsert({
+      where: { code: exam.code },
+      update: {
+        name: exam.name,
+        country: exam.country,
+        description: exam.description,
+      },
+      create: {
+        code: exam.code,
+        name: exam.name,
+        country: exam.country,
+        description: exam.description,
+        active: true,
+      },
+    });
+    upserted += 1;
+  }
+  return { upserted, skipped: 0, durationMs: Date.now() - startedAt };
+}

--- a/prisma/seeds/symbol-library.ts
+++ b/prisma/seeds/symbol-library.ts
@@ -1,0 +1,186 @@
+/**
+ * Curated symbol library — single-glyph LaTeX tokens that teachers drop into
+ * a math expression at the cursor (vs equations, which replace the whole
+ * draft). Categorised by `category` string so platform admins can add new
+ * categories via this seed without a migration.
+ *
+ * Categories used (kept stable; render order in the picker follows insertion
+ * order below):
+ *   - GREEK_LOWER     α β γ …
+ *   - GREEK_UPPER     Δ Σ Ω …
+ *   - OPERATORS       ± ÷ × ≠ ≤ ≥ ≈ ∞
+ *   - FUNCTIONS       \sin x, \log x, \lim, …
+ *   - CALCULUS        ∂ ∇ ∫ ∮ ∑ ∏
+ *   - SETS            ∈ ∉ ⊂ ⊆ ∪ ∩ ∅
+ *   - ARROWS          → ↔ ⇒ ⇔
+ *   - UNITS           Ω, °, ÅI etc. (when used as a unit, not a variable)
+ *
+ * Same LaTeX-escaping rule as equations: every backslash must be doubled in
+ * TS string literals (`\\theta`, not `\theta`).
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+import { SeedRunResult } from './types';
+
+interface SymbolSeed {
+  category: string;
+  name: string;
+  latex: string;
+  tags: string[];
+  order: number;
+}
+
+const SYMBOLS: SymbolSeed[] = [
+  // ─── Greek lower ──────────────────────────────────────────────────────────
+  { category: 'GREEK_LOWER', name: 'alpha',   latex: '\\alpha',   tags: ['greek'],          order: 10 },
+  { category: 'GREEK_LOWER', name: 'beta',    latex: '\\beta',    tags: ['greek'],          order: 20 },
+  { category: 'GREEK_LOWER', name: 'gamma',   latex: '\\gamma',   tags: ['greek'],          order: 30 },
+  { category: 'GREEK_LOWER', name: 'delta',   latex: '\\delta',   tags: ['greek'],          order: 40 },
+  { category: 'GREEK_LOWER', name: 'epsilon', latex: '\\varepsilon', tags: ['greek'],       order: 50 },
+  { category: 'GREEK_LOWER', name: 'zeta',    latex: '\\zeta',    tags: ['greek'],          order: 60 },
+  { category: 'GREEK_LOWER', name: 'eta',     latex: '\\eta',     tags: ['greek'],          order: 70 },
+  { category: 'GREEK_LOWER', name: 'theta',   latex: '\\theta',   tags: ['greek', 'angle'], order: 80 },
+  { category: 'GREEK_LOWER', name: 'kappa',   latex: '\\kappa',   tags: ['greek'],          order: 90 },
+  { category: 'GREEK_LOWER', name: 'lambda',  latex: '\\lambda',  tags: ['greek', 'wavelength'], order: 100 },
+  { category: 'GREEK_LOWER', name: 'mu',      latex: '\\mu',      tags: ['greek', 'mean'],  order: 110 },
+  { category: 'GREEK_LOWER', name: 'nu',      latex: '\\nu',      tags: ['greek'],          order: 120 },
+  { category: 'GREEK_LOWER', name: 'xi',      latex: '\\xi',      tags: ['greek'],          order: 130 },
+  { category: 'GREEK_LOWER', name: 'pi',      latex: '\\pi',      tags: ['greek'],          order: 140 },
+  { category: 'GREEK_LOWER', name: 'rho',     latex: '\\rho',     tags: ['greek', 'density'], order: 150 },
+  { category: 'GREEK_LOWER', name: 'sigma',   latex: '\\sigma',   tags: ['greek', 'std-dev'], order: 160 },
+  { category: 'GREEK_LOWER', name: 'tau',     latex: '\\tau',     tags: ['greek'],          order: 170 },
+  { category: 'GREEK_LOWER', name: 'phi',     latex: '\\phi',     tags: ['greek'],          order: 180 },
+  { category: 'GREEK_LOWER', name: 'chi',     latex: '\\chi',     tags: ['greek'],          order: 190 },
+  { category: 'GREEK_LOWER', name: 'psi',     latex: '\\psi',     tags: ['greek'],          order: 200 },
+  { category: 'GREEK_LOWER', name: 'omega',   latex: '\\omega',   tags: ['greek'],          order: 210 },
+
+  // ─── Greek upper ──────────────────────────────────────────────────────────
+  { category: 'GREEK_UPPER', name: 'Gamma',   latex: '\\Gamma',  tags: ['greek'],          order: 10 },
+  { category: 'GREEK_UPPER', name: 'Delta',   latex: '\\Delta',  tags: ['greek', 'change'], order: 20 },
+  { category: 'GREEK_UPPER', name: 'Theta',   latex: '\\Theta',  tags: ['greek'],          order: 30 },
+  { category: 'GREEK_UPPER', name: 'Lambda',  latex: '\\Lambda', tags: ['greek'],          order: 40 },
+  { category: 'GREEK_UPPER', name: 'Pi',      latex: '\\Pi',     tags: ['greek'],          order: 50 },
+  { category: 'GREEK_UPPER', name: 'Sigma',   latex: '\\Sigma',  tags: ['greek', 'sum'],   order: 60 },
+  { category: 'GREEK_UPPER', name: 'Phi',     latex: '\\Phi',    tags: ['greek'],          order: 70 },
+  { category: 'GREEK_UPPER', name: 'Psi',     latex: '\\Psi',    tags: ['greek'],          order: 80 },
+  { category: 'GREEK_UPPER', name: 'Omega',   latex: '\\Omega',  tags: ['greek', 'ohms'],  order: 90 },
+
+  // ─── Operators ────────────────────────────────────────────────────────────
+  { category: 'OPERATORS', name: 'plus-minus',    latex: '\\pm',     tags: ['operator', 'sign'],     order: 10 },
+  { category: 'OPERATORS', name: 'minus-plus',    latex: '\\mp',     tags: ['operator', 'sign'],     order: 20 },
+  { category: 'OPERATORS', name: 'times',         latex: '\\times',  tags: ['operator', 'multiply'], order: 30 },
+  { category: 'OPERATORS', name: 'divide',        latex: '\\div',    tags: ['operator', 'divide'],   order: 40 },
+  { category: 'OPERATORS', name: 'cdot',          latex: '\\cdot',   tags: ['operator', 'multiply', 'dot'], order: 50 },
+  { category: 'OPERATORS', name: 'not-equal',     latex: '\\neq',    tags: ['operator', 'compare'],  order: 60 },
+  { category: 'OPERATORS', name: 'less-or-equal', latex: '\\leq',    tags: ['operator', 'compare'],  order: 70 },
+  { category: 'OPERATORS', name: 'greater-or-equal', latex: '\\geq', tags: ['operator', 'compare'],  order: 80 },
+  { category: 'OPERATORS', name: 'approximately', latex: '\\approx', tags: ['operator', 'compare'],  order: 90 },
+  { category: 'OPERATORS', name: 'equivalent',    latex: '\\equiv',  tags: ['operator', 'compare'],  order: 100 },
+  { category: 'OPERATORS', name: 'proportional',  latex: '\\propto', tags: ['operator', 'compare'],  order: 110 },
+  { category: 'OPERATORS', name: 'infinity',      latex: '\\infty',  tags: ['operator', 'limits'],   order: 120 },
+  { category: 'OPERATORS', name: 'square-root',   latex: '\\sqrt{}',  tags: ['operator', 'root'],    order: 130 },
+  { category: 'OPERATORS', name: 'nth-root',      latex: '\\sqrt[n]{}', tags: ['operator', 'root'],  order: 140 },
+  { category: 'OPERATORS', name: 'fraction',      latex: '\\frac{}{}', tags: ['operator'],           order: 150 },
+  { category: 'OPERATORS', name: 'degree',        latex: '^{\\circ}', tags: ['operator', 'angle'],   order: 160 },
+  { category: 'OPERATORS', name: 'subscript',     latex: '_{}',      tags: ['operator'],             order: 170 },
+  { category: 'OPERATORS', name: 'superscript',   latex: '^{}',      tags: ['operator', 'power'],    order: 180 },
+
+  // ─── Functions ────────────────────────────────────────────────────────────
+  { category: 'FUNCTIONS', name: 'sin',     latex: '\\sin',    tags: ['trigonometry'],            order: 10 },
+  { category: 'FUNCTIONS', name: 'sin x',   latex: '\\sin x',  tags: ['trigonometry'],            order: 15 },
+  { category: 'FUNCTIONS', name: 'cos',     latex: '\\cos',    tags: ['trigonometry'],            order: 20 },
+  { category: 'FUNCTIONS', name: 'cos x',   latex: '\\cos x',  tags: ['trigonometry'],            order: 25 },
+  { category: 'FUNCTIONS', name: 'tan',     latex: '\\tan',    tags: ['trigonometry'],            order: 30 },
+  { category: 'FUNCTIONS', name: 'tan x',   latex: '\\tan x',  tags: ['trigonometry'],            order: 35 },
+  { category: 'FUNCTIONS', name: 'cot',     latex: '\\cot',    tags: ['trigonometry'],            order: 40 },
+  { category: 'FUNCTIONS', name: 'sec',     latex: '\\sec',    tags: ['trigonometry'],            order: 50 },
+  { category: 'FUNCTIONS', name: 'csc',     latex: '\\csc',    tags: ['trigonometry'],            order: 60 },
+  { category: 'FUNCTIONS', name: 'arcsin',  latex: '\\arcsin', tags: ['trigonometry', 'inverse'], order: 70 },
+  { category: 'FUNCTIONS', name: 'arccos',  latex: '\\arccos', tags: ['trigonometry', 'inverse'], order: 80 },
+  { category: 'FUNCTIONS', name: 'arctan',  latex: '\\arctan', tags: ['trigonometry', 'inverse'], order: 90 },
+  { category: 'FUNCTIONS', name: 'log',     latex: '\\log',    tags: ['logarithm'],               order: 100 },
+  { category: 'FUNCTIONS', name: 'log_b x', latex: '\\log_{b} x', tags: ['logarithm'],            order: 105 },
+  { category: 'FUNCTIONS', name: 'ln',      latex: '\\ln',     tags: ['logarithm', 'natural'],    order: 110 },
+  { category: 'FUNCTIONS', name: 'exp',     latex: '\\exp',    tags: ['exponential'],             order: 120 },
+  { category: 'FUNCTIONS', name: 'lim',     latex: '\\lim',    tags: ['limit', 'calculus'],       order: 130 },
+  { category: 'FUNCTIONS', name: 'lim x→a', latex: '\\lim_{x \\to a}', tags: ['limit', 'calculus'], order: 140 },
+  { category: 'FUNCTIONS', name: 'max',     latex: '\\max',    tags: ['optimization'],            order: 150 },
+  { category: 'FUNCTIONS', name: 'min',     latex: '\\min',    tags: ['optimization'],            order: 160 },
+  { category: 'FUNCTIONS', name: 'absolute value', latex: '\\lvert x \\rvert', tags: ['absolute', 'modulus'], order: 170 },
+
+  // ─── Calculus ─────────────────────────────────────────────────────────────
+  { category: 'CALCULUS', name: 'partial',     latex: '\\partial',  tags: ['derivative'],   order: 10 },
+  { category: 'CALCULUS', name: 'partial fraction', latex: '\\frac{\\partial}{\\partial x}', tags: ['derivative'], order: 15 },
+  { category: 'CALCULUS', name: 'derivative',  latex: '\\frac{d}{dx}', tags: ['derivative'], order: 20 },
+  { category: 'CALCULUS', name: 'second derivative', latex: '\\frac{d^2}{dx^2}', tags: ['derivative'], order: 25 },
+  { category: 'CALCULUS', name: 'nabla',       latex: '\\nabla',    tags: ['gradient', 'vector'], order: 30 },
+  { category: 'CALCULUS', name: 'integral',    latex: '\\int',      tags: ['integral'],     order: 40 },
+  { category: 'CALCULUS', name: 'definite integral', latex: '\\int_{a}^{b}', tags: ['integral'], order: 45 },
+  { category: 'CALCULUS', name: 'double integral', latex: '\\iint', tags: ['integral'],     order: 50 },
+  { category: 'CALCULUS', name: 'contour integral', latex: '\\oint', tags: ['integral'],    order: 60 },
+  { category: 'CALCULUS', name: 'sum',         latex: '\\sum',      tags: ['summation'],    order: 70 },
+  { category: 'CALCULUS', name: 'sum n=1 to N',latex: '\\sum_{n=1}^{N}', tags: ['summation'], order: 75 },
+  { category: 'CALCULUS', name: 'product',     latex: '\\prod',     tags: ['product'],      order: 80 },
+
+  // ─── Sets ─────────────────────────────────────────────────────────────────
+  { category: 'SETS', name: 'element-of',     latex: '\\in',         tags: ['set'], order: 10 },
+  { category: 'SETS', name: 'not-element-of', latex: '\\notin',      tags: ['set'], order: 20 },
+  { category: 'SETS', name: 'subset',         latex: '\\subset',     tags: ['set'], order: 30 },
+  { category: 'SETS', name: 'subset-or-equal',latex: '\\subseteq',   tags: ['set'], order: 40 },
+  { category: 'SETS', name: 'superset',       latex: '\\supset',     tags: ['set'], order: 50 },
+  { category: 'SETS', name: 'union',          latex: '\\cup',        tags: ['set'], order: 60 },
+  { category: 'SETS', name: 'intersection',   latex: '\\cap',        tags: ['set'], order: 70 },
+  { category: 'SETS', name: 'empty-set',      latex: '\\emptyset',   tags: ['set'], order: 80 },
+  { category: 'SETS', name: 'set-natural',    latex: '\\mathbb{N}',  tags: ['set', 'naturals'], order: 90 },
+  { category: 'SETS', name: 'set-integer',    latex: '\\mathbb{Z}',  tags: ['set', 'integers'], order: 100 },
+  { category: 'SETS', name: 'set-rational',   latex: '\\mathbb{Q}',  tags: ['set', 'rationals'], order: 110 },
+  { category: 'SETS', name: 'set-real',       latex: '\\mathbb{R}',  tags: ['set', 'reals'], order: 120 },
+  { category: 'SETS', name: 'set-complex',    latex: '\\mathbb{C}',  tags: ['set', 'complex'], order: 130 },
+
+  // ─── Arrows / logic ───────────────────────────────────────────────────────
+  { category: 'ARROWS', name: 'right-arrow',  latex: '\\rightarrow',     tags: ['arrow', 'logic'], order: 10 },
+  { category: 'ARROWS', name: 'left-arrow',   latex: '\\leftarrow',      tags: ['arrow'],          order: 20 },
+  { category: 'ARROWS', name: 'left-right-arrow', latex: '\\leftrightarrow', tags: ['arrow'],      order: 30 },
+  { category: 'ARROWS', name: 'implies',      latex: '\\Rightarrow',     tags: ['arrow', 'logic'], order: 40 },
+  { category: 'ARROWS', name: 'iff',          latex: '\\Leftrightarrow', tags: ['arrow', 'logic'], order: 50 },
+  { category: 'ARROWS', name: 'maps-to',      latex: '\\mapsto',         tags: ['arrow'],          order: 60 },
+  { category: 'ARROWS', name: 'logical-and',  latex: '\\land',           tags: ['logic'],          order: 70 },
+  { category: 'ARROWS', name: 'logical-or',   latex: '\\lor',            tags: ['logic'],          order: 80 },
+  { category: 'ARROWS', name: 'not',          latex: '\\neg',            tags: ['logic'],          order: 90 },
+  { category: 'ARROWS', name: 'for-all',      latex: '\\forall',         tags: ['logic'],          order: 100 },
+  { category: 'ARROWS', name: 'exists',       latex: '\\exists',         tags: ['logic'],          order: 110 },
+
+  // ─── Units (when used as a unit token, not a variable) ────────────────────
+  { category: 'UNITS', name: 'ohm-omega', latex: '\\,\\Omega', tags: ['unit', 'electricity'], order: 10 },
+  { category: 'UNITS', name: 'micro',     latex: '\\mu',       tags: ['unit', 'prefix'],      order: 20 },
+  { category: 'UNITS', name: 'angstrom',  latex: '\\text{\\AA}', tags: ['unit', 'length'],    order: 30 },
+  { category: 'UNITS', name: 'celsius',   latex: '^{\\circ}\\mathrm{C}', tags: ['unit', 'temperature'], order: 40 },
+  { category: 'UNITS', name: 'fahrenheit',latex: '^{\\circ}\\mathrm{F}', tags: ['unit', 'temperature'], order: 50 },
+  { category: 'UNITS', name: 'percent',   latex: '\\%',        tags: ['unit'],                order: 60 },
+];
+
+export async function seedSymbolLibrary(prisma: PrismaClient): Promise<SeedRunResult> {
+  const startedAt = Date.now();
+  let upserted = 0;
+  for (const sym of SYMBOLS) {
+    await prisma.symbolLibraryItem.upsert({
+      where: { category_name: { category: sym.category, name: sym.name } },
+      update: {
+        latex: sym.latex,
+        tags: sym.tags,
+        order: sym.order,
+        isActive: true,
+      },
+      create: {
+        category: sym.category,
+        name: sym.name,
+        latex: sym.latex,
+        tags: sym.tags,
+        order: sym.order,
+      },
+    });
+    upserted += 1;
+  }
+  return { upserted, skipped: 0, durationMs: Date.now() - startedAt };
+}

--- a/prisma/seeds/types.ts
+++ b/prisma/seeds/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared shape returned by every individual seed script. Used by the
+ * platform seed-runner BFF endpoint so the UI can show how many rows were
+ * touched, how long the run took, and whether anything was skipped because
+ * of missing prerequisites.
+ */
+export interface SeedRunResult {
+  upserted: number;
+  skipped: number;
+  durationMs: number;
+  notes?: string;
+}
+
+/**
+ * Stable identifier for a seed script. Used as a URL slug on the platform
+ * seed-runner endpoint and as the audit row's `seedSlug` value.
+ */
+export type SeedSlug =
+  | 'canonical-subjects'
+  | 'canonical-levels'
+  | 'canonical-terms'
+  | 'popular-exams'
+  | 'equation-library'
+  | 'symbol-library'
+  | 'curated-questions'
+  | 'curated-quizzes';

--- a/src/app-module.list.ts
+++ b/src/app-module.list.ts
@@ -16,7 +16,10 @@ import { TeacherModule } from './components/bff/teacher/teacher.module';
 import { CanonicalReferencesModule } from './components/canonical-references/canonical-references.module';
 import { CategoriesModule } from './components/categories/categories.module';
 import { DepartmentsModule } from './components/departments/departments.module';
+import { EquationLibraryModule } from './components/equation-library/equation-library.module';
 import { LevelsModule } from './components/levels/levels.module';
+import { SeedRunnerModule } from './components/seed-runner/seed-runner.module';
+import { SymbolLibraryModule } from './components/symbol-library/symbol-library.module';
 import { PaymentsModule } from './components/payments/payments.module';
 import { PlatformModule } from './components/platform/platform.module';
 import { PopularExamsModule } from './components/popular-exams/popular-exams.module';
@@ -87,6 +90,9 @@ export const AppModuleList = [
   PlatformModule,
   PopularExamsModule,
   QuestionsModule,
+  EquationLibraryModule,
+  SymbolLibraryModule,
+  SeedRunnerModule,
   QuizAggregationsModule,
   QuizAssignmentsModule,
   QuizAttemptsModule,

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -1,3 +1,4 @@
 export * from './super-admin.guard';
 export * from './system-admin.guard';
 export * from './assessments-feature.guard';
+export * from './platform-admin.guard';

--- a/src/common/guards/platform-admin.guard.ts
+++ b/src/common/guards/platform-admin.guard.ts
@@ -1,0 +1,32 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { UserTypes } from '../../components/users/constants';
+
+/**
+ * Hard gate for the highest-privilege internal role (`SystemAdmin.role =
+ * 'PLATFORM_ADMIN'`). Use ONLY for actions that should be reserved to the
+ * bootstrap super (e.g. running seed scripts on production, bootstrap
+ * tenant operations). Every other system-admin route should keep using
+ * `SystemAdminGuard` — see its file header for rationale.
+ */
+@Injectable()
+export class PlatformAdminGuard implements CanActivate {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request?.user;
+    if (user?.type !== UserTypes.SYSTEM_ADMIN) {
+      throw new ForbiddenException('Only platform admins can perform this action');
+    }
+    const systemAdmin = await this.prisma.systemAdmin.findFirst({
+      where: { userId: user.sub ?? user.id },
+      select: { role: true },
+    });
+    if (systemAdmin?.role !== 'PLATFORM_ADMIN') {
+      throw new ForbiddenException('Only platform admins can perform this action');
+    }
+    return true;
+  }
+}

--- a/src/components/equation-library/dto/list-equations.dto.ts
+++ b/src/components/equation-library/dto/list-equations.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ListEquationsDto {
+  @ApiPropertyOptional({
+    description: 'Filter by canonical subject slug, e.g. "mathematics" or "physics".',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  subjectSlug?: string;
+
+  @ApiPropertyOptional({
+    description: 'Free-text search against equation name and tags.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  q?: string;
+}

--- a/src/components/equation-library/equation-library.controller.ts
+++ b/src/components/equation-library/equation-library.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { ListEquationsDto } from './dto/list-equations.dto';
+import { EquationLibraryService } from './equation-library.service';
+import { EquationLibraryListResult } from './results/equation-library-list.result';
+
+@Controller('equation-library')
+@ApiTags('Equation Library')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class EquationLibraryController {
+  constructor(private readonly service: EquationLibraryService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List curated equations, optionally filtered by canonical subject and/or search term',
+  })
+  @ApiOkResponse({ type: EquationLibraryListResult })
+  async list(@Query() query: ListEquationsDto): Promise<EquationLibraryListResult> {
+    return this.service.list({ subjectSlug: query.subjectSlug, q: query.q });
+  }
+}

--- a/src/components/equation-library/equation-library.module.ts
+++ b/src/components/equation-library/equation-library.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { EquationLibraryController } from './equation-library.controller';
+import { EquationLibraryService } from './equation-library.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [EquationLibraryController],
+  providers: [EquationLibraryService, Encryptor],
+  exports: [EquationLibraryService],
+})
+export class EquationLibraryModule {}

--- a/src/components/equation-library/equation-library.service.ts
+++ b/src/components/equation-library/equation-library.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  EquationLibraryItemResult,
+  EquationLibraryListResult,
+  EquationLibrarySubjectFacetResult,
+} from './results/equation-library-list.result';
+
+@Injectable()
+export class EquationLibraryService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(opts: { subjectSlug?: string; q?: string }): Promise<EquationLibraryListResult> {
+    const where: Prisma.EquationLibraryItemWhereInput = { isActive: true };
+    if (opts.subjectSlug) {
+      where.canonicalSubject = { slug: opts.subjectSlug };
+    }
+    if (opts.q && opts.q.trim().length > 0) {
+      const term = opts.q.trim();
+      where.OR = [
+        { name: { contains: term, mode: 'insensitive' } },
+        { tags: { has: term.toLowerCase() } },
+      ];
+    }
+
+    const [rows, allSubjects] = await Promise.all([
+      this.prisma.equationLibraryItem.findMany({
+        where,
+        include: {
+          canonicalSubject: { select: { slug: true, name: true } },
+        },
+        orderBy: [{ canonicalSubject: { name: 'asc' } }, { order: 'asc' }, { name: 'asc' }],
+      }),
+      this.subjectFacets(opts.q),
+    ]);
+
+    const items: EquationLibraryItemResult[] = rows.map((r) => ({
+      id: r.id,
+      canonicalSubjectId: r.canonicalSubjectId,
+      canonicalSubjectSlug: r.canonicalSubject.slug,
+      canonicalSubjectName: r.canonicalSubject.name,
+      name: r.name,
+      description: r.description,
+      latex: r.latex,
+      tags: r.tags,
+    }));
+
+    return { items, subjects: allSubjects };
+  }
+
+  /**
+   * Counts of active equations grouped by canonical subject. When `q` is set,
+   * counts reflect rows matching the search term — so the dropdown badges
+   * stay in sync with what the user is filtering by. Subjects with zero
+   * matches are still included so the user can clear their search by
+   * picking another subject.
+   */
+  private async subjectFacets(q?: string): Promise<EquationLibrarySubjectFacetResult[]> {
+    const where: Prisma.EquationLibraryItemWhereInput = { isActive: true };
+    if (q && q.trim().length > 0) {
+      const term = q.trim();
+      where.OR = [
+        { name: { contains: term, mode: 'insensitive' } },
+        { tags: { has: term.toLowerCase() } },
+      ];
+    }
+    const grouped = await this.prisma.equationLibraryItem.groupBy({
+      by: ['canonicalSubjectId'],
+      where,
+      _count: { _all: true },
+    });
+    const subjectIds = grouped.map((g) => g.canonicalSubjectId);
+    const subjects = await this.prisma.canonicalSubject.findMany({
+      where: { id: { in: subjectIds } },
+      select: { id: true, slug: true, name: true },
+    });
+    const subjectsById = new Map(subjects.map((s) => [s.id, s]));
+    return grouped
+      .map((g) => {
+        const s = subjectsById.get(g.canonicalSubjectId);
+        if (!s) return null;
+        return { slug: s.slug, name: s.name, count: g._count._all };
+      })
+      .filter((x): x is EquationLibrarySubjectFacetResult => x !== null)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+}

--- a/src/components/equation-library/results/equation-library-list.result.ts
+++ b/src/components/equation-library/results/equation-library-list.result.ts
@@ -1,0 +1,49 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class EquationLibraryItemResult {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  canonicalSubjectId!: string;
+
+  @ApiProperty()
+  canonicalSubjectSlug!: string;
+
+  @ApiProperty()
+  canonicalSubjectName!: string;
+
+  @ApiProperty({ example: 'Quadratic Formula' })
+  name!: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  description!: string | null;
+
+  @ApiProperty({ example: 'x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}' })
+  latex!: string;
+
+  @ApiProperty({ type: [String] })
+  tags!: string[];
+}
+
+export class EquationLibrarySubjectFacetResult {
+  @ApiProperty()
+  slug!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ description: 'Number of active equations in this subject (after search filter)' })
+  count!: number;
+}
+
+export class EquationLibraryListResult {
+  @ApiProperty({ type: [EquationLibraryItemResult] })
+  items!: EquationLibraryItemResult[];
+
+  @ApiProperty({
+    type: [EquationLibrarySubjectFacetResult],
+    description: 'All canonical subjects with active equations, with counts. Use to build the subject filter dropdown.',
+  })
+  subjects!: EquationLibrarySubjectFacetResult[];
+}

--- a/src/components/seed-runner/results/seed-runner.result.ts
+++ b/src/components/seed-runner/results/seed-runner.result.ts
@@ -1,0 +1,79 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { SeedRunStatus } from '@prisma/client';
+
+export class SeedLastRunResult {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({ enum: SeedRunStatus })
+  status!: SeedRunStatus;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  startedAt!: Date;
+
+  @ApiPropertyOptional({ type: String, format: 'date-time', nullable: true })
+  finishedAt!: Date | null;
+
+  @ApiProperty()
+  upserted!: number;
+
+  @ApiProperty()
+  skipped!: number;
+
+  @ApiPropertyOptional({ nullable: true })
+  durationMs!: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  notes!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  errorMessage!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  triggeredByName!: string | null;
+}
+
+export class SeedDescriptorResult {
+  @ApiProperty()
+  slug!: string;
+
+  @ApiProperty()
+  title!: string;
+
+  @ApiProperty()
+  description!: string;
+
+  @ApiProperty({ type: [String] })
+  dependsOn!: string[];
+
+  @ApiProperty({ description: 'True iff a run is currently in flight on this server instance.' })
+  isRunning!: boolean;
+
+  @ApiPropertyOptional({ type: () => SeedLastRunResult, nullable: true })
+  lastRun!: SeedLastRunResult | null;
+}
+
+export class ListSeedsResult {
+  @ApiProperty({ type: [SeedDescriptorResult] })
+  seeds!: SeedDescriptorResult[];
+}
+
+export class RunSeedResult {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({ enum: SeedRunStatus })
+  status!: SeedRunStatus;
+
+  @ApiProperty()
+  upserted!: number;
+
+  @ApiProperty()
+  skipped!: number;
+
+  @ApiPropertyOptional({ nullable: true })
+  durationMs!: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  notes!: string | null;
+}

--- a/src/components/seed-runner/seed-runner.controller.ts
+++ b/src/components/seed-runner/seed-runner.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import { GetCurrentUserId } from '../../common/decorators';
+import { PlatformAdminGuard } from '../../common/guards';
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import {
+  ListSeedsResult,
+  RunSeedResult,
+  SeedDescriptorResult,
+} from './results/seed-runner.result';
+import { SeedRunnerService } from './seed-runner.service';
+
+@Controller('platform/seeds')
+@ApiTags('Platform Seeds')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard, PlatformAdminGuard)
+export class SeedRunnerController {
+  constructor(private readonly service: SeedRunnerService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List available platform seed scripts with metadata about their last run',
+  })
+  @ApiOkResponse({ type: ListSeedsResult })
+  async list(): Promise<ListSeedsResult> {
+    const seeds = (await this.service.list()) as SeedDescriptorResult[];
+    return { seeds };
+  }
+
+  @Post(':slug/run')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({
+    name: 'slug',
+    description: 'Seed identifier (e.g. canonical-subjects, equation-library)',
+  })
+  @ApiOperation({
+    summary:
+      'Run a single platform seed script. Idempotent: each script upserts only and never deletes existing rows.',
+  })
+  @ApiOkResponse({ type: RunSeedResult })
+  async run(
+    @Param('slug') slug: string,
+    @GetCurrentUserId() userId: string,
+  ): Promise<RunSeedResult> {
+    const audit = await this.service.run(slug, userId);
+    return {
+      id: audit.id,
+      status: audit.status,
+      upserted: audit.upserted,
+      skipped: audit.skipped,
+      durationMs: audit.durationMs,
+      notes: audit.notes,
+    };
+  }
+}

--- a/src/components/seed-runner/seed-runner.module.ts
+++ b/src/components/seed-runner/seed-runner.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+
+import { PlatformAdminGuard } from '../../common/guards';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { SeedRunnerController } from './seed-runner.controller';
+import { SeedRunnerService } from './seed-runner.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [SeedRunnerController],
+  providers: [SeedRunnerService, Encryptor, PlatformAdminGuard],
+  exports: [SeedRunnerService],
+})
+export class SeedRunnerModule {}

--- a/src/components/seed-runner/seed-runner.service.ts
+++ b/src/components/seed-runner/seed-runner.service.ts
@@ -1,0 +1,195 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaClient, SeedRunStatus } from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import { seedCanonicalLevels } from '../../../prisma/seeds/canonical-levels';
+import { seedCanonicalSubjects } from '../../../prisma/seeds/canonical-subjects';
+import { seedCanonicalTerms } from '../../../prisma/seeds/canonical-terms';
+import { seedCuratedQuestions } from '../../../prisma/seeds/curated-questions';
+import { seedCuratedQuizzes } from '../../../prisma/seeds/curated-quizzes';
+import { seedEquationLibrary } from '../../../prisma/seeds/equation-library';
+import { seedPopularExams } from '../../../prisma/seeds/popular-exams';
+import { seedSymbolLibrary } from '../../../prisma/seeds/symbol-library';
+import type { SeedRunResult, SeedSlug } from '../../../prisma/seeds/types';
+
+interface SeedDescriptor {
+  slug: SeedSlug;
+  title: string;
+  description: string;
+  /**
+   * Slugs whose seeds should be run first because this seed depends on rows
+   * they create. Used purely for documentation in the UI; the seed runner
+   * never auto-chains, so the platform admin can see the order at a glance.
+   */
+  dependsOn: SeedSlug[];
+  run: (prisma: PrismaClient) => Promise<SeedRunResult>;
+}
+
+/**
+ * The full set of seeds the platform-portal seed-runner exposes. Order
+ * here is the recommended execution order; UI renders cards top-to-bottom.
+ *
+ * Adding a new seed: add a line here AND a `'new-slug'` entry to the
+ * `SeedSlug` union in prisma/seeds/types.ts.
+ */
+const SEEDS: SeedDescriptor[] = [
+  {
+    slug: 'canonical-subjects',
+    title: 'Canonical Subjects',
+    description:
+      'Platform-wide subject reference list (Mathematics, Physics, etc). Curated questions, equations and symbols are keyed by subject slug.',
+    dependsOn: [],
+    run: seedCanonicalSubjects,
+  },
+  {
+    slug: 'canonical-levels',
+    title: 'Canonical Levels',
+    description:
+      'Platform-wide level / grade codes (PRY1-PRY6, JSS1-SSS3, GRADE_1-12, A_LEVEL, O_LEVEL).',
+    dependsOn: [],
+    run: seedCanonicalLevels,
+  },
+  {
+    slug: 'canonical-terms',
+    title: 'Canonical Terms',
+    description: 'Platform-wide term names (First Term, Second Term, Third Term).',
+    dependsOn: [],
+    run: seedCanonicalTerms,
+  },
+  {
+    slug: 'popular-exams',
+    title: 'Popular Exams',
+    description:
+      'Reference list of standardized exams (WAEC, NECO, JAMB, IGCSE, etc) teachers tag past-paper questions with.',
+    dependsOn: [],
+    run: seedPopularExams,
+  },
+  {
+    slug: 'equation-library',
+    title: 'Equation Library',
+    description:
+      'Curated equations teachers pick from in the Insert math dialog. Subject-keyed; requires Canonical Subjects to be seeded first.',
+    dependsOn: ['canonical-subjects'],
+    run: seedEquationLibrary,
+  },
+  {
+    slug: 'symbol-library',
+    title: 'Symbol Library',
+    description:
+      'Curated math symbols (Greek letters, operators, calculus, sets, arrows). Inserted at the cursor in the math dialog.',
+    dependsOn: [],
+    run: seedSymbolLibrary,
+  },
+  {
+    slug: 'curated-questions',
+    title: 'Curated Sample Questions',
+    description:
+      'Starter SCHOS_CURATED questions across subjects, seeded as DRAFT for review. Requires the platform admin user to exist.',
+    dependsOn: ['canonical-subjects', 'canonical-levels'],
+    run: seedCuratedQuestions,
+  },
+  {
+    slug: 'curated-quizzes',
+    title: 'Curated Sample Quizzes',
+    description:
+      'Bundles curated questions into ready-to-publish quizzes (e.g. the generic English Language quiz). Seeded as DRAFT — review and publish before they appear in the curated quiz library.',
+    dependsOn: ['canonical-subjects', 'canonical-levels', 'curated-questions'],
+    run: seedCuratedQuizzes,
+  },
+];
+
+const SEEDS_BY_SLUG = new Map(SEEDS.map((s) => [s.slug, s]));
+
+@Injectable()
+export class SeedRunnerService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** In-memory mutex set: prevents concurrent runs of the same seed. */
+  private readonly inFlight = new Set<SeedSlug>();
+
+  list() {
+    return Promise.all(
+      SEEDS.map(async (s) => {
+        const lastRun = await this.prisma.seedRun.findFirst({
+          where: { seedSlug: s.slug },
+          orderBy: { startedAt: 'desc' },
+          include: {
+            triggeredBy: { select: { firstName: true, lastName: true } },
+          },
+        });
+        return {
+          slug: s.slug,
+          title: s.title,
+          description: s.description,
+          dependsOn: s.dependsOn,
+          isRunning: this.inFlight.has(s.slug),
+          lastRun: lastRun
+            ? {
+                id: lastRun.id,
+                status: lastRun.status,
+                startedAt: lastRun.startedAt,
+                finishedAt: lastRun.finishedAt,
+                upserted: lastRun.upserted,
+                skipped: lastRun.skipped,
+                durationMs: lastRun.durationMs,
+                notes: lastRun.notes,
+                errorMessage: lastRun.errorMessage,
+                triggeredByName: lastRun.triggeredBy
+                  ? `${lastRun.triggeredBy.firstName} ${lastRun.triggeredBy.lastName}`.trim()
+                  : null,
+              }
+            : null,
+        };
+      }),
+    );
+  }
+
+  async run(slug: string, triggeredById: string) {
+    const seed = SEEDS_BY_SLUG.get(slug as SeedSlug);
+    if (!seed) {
+      throw new NotFoundException(`Unknown seed: ${slug}`);
+    }
+    if (this.inFlight.has(seed.slug)) {
+      throw new ConflictException(`Seed "${seed.slug}" is already running.`);
+    }
+
+    this.inFlight.add(seed.slug);
+    const audit = await this.prisma.seedRun.create({
+      data: {
+        seedSlug: seed.slug,
+        status: SeedRunStatus.RUNNING,
+        triggeredById,
+      },
+    });
+
+    try {
+      const result = await seed.run(this.prisma);
+      const finishedAt = new Date();
+      const updated = await this.prisma.seedRun.update({
+        where: { id: audit.id },
+        data: {
+          status: SeedRunStatus.SUCCEEDED,
+          finishedAt,
+          upserted: result.upserted,
+          skipped: result.skipped,
+          durationMs: result.durationMs,
+          notes: result.notes ?? null,
+        },
+      });
+      return updated;
+    } catch (err) {
+      const finishedAt = new Date();
+      await this.prisma.seedRun.update({
+        where: { id: audit.id },
+        data: {
+          status: SeedRunStatus.FAILED,
+          finishedAt,
+          errorMessage: err instanceof Error ? err.message : String(err),
+        },
+      });
+      throw err;
+    } finally {
+      this.inFlight.delete(seed.slug);
+    }
+  }
+}

--- a/src/components/symbol-library/dto/list-symbols.dto.ts
+++ b/src/components/symbol-library/dto/list-symbols.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ListSymbolsDto {
+  @ApiPropertyOptional({ description: 'Filter by category, e.g. GREEK_LOWER, OPERATORS, FUNCTIONS' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  category?: string;
+
+  @ApiPropertyOptional({ description: 'Free-text search across symbol name and tags' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  q?: string;
+}

--- a/src/components/symbol-library/results/symbol-library-list.result.ts
+++ b/src/components/symbol-library/results/symbol-library-list.result.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SymbolLibraryItemResult {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({ example: 'GREEK_LOWER' })
+  category!: string;
+
+  @ApiProperty({ example: 'theta' })
+  name!: string;
+
+  @ApiProperty({ example: '\\theta' })
+  latex!: string;
+
+  @ApiProperty({ type: [String] })
+  tags!: string[];
+}
+
+export class SymbolCategoryFacetResult {
+  @ApiProperty({ example: 'GREEK_LOWER' })
+  category!: string;
+
+  @ApiProperty()
+  count!: number;
+}
+
+export class SymbolLibraryListResult {
+  @ApiProperty({ type: [SymbolLibraryItemResult] })
+  items!: SymbolLibraryItemResult[];
+
+  @ApiProperty({
+    type: [SymbolCategoryFacetResult],
+    description: 'Active symbol categories with counts (after the search filter is applied).',
+  })
+  categories!: SymbolCategoryFacetResult[];
+}

--- a/src/components/symbol-library/symbol-library.controller.ts
+++ b/src/components/symbol-library/symbol-library.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { StrategyEnum } from '../auth/strategies';
+import { AccessTokenGuard } from '../auth/strategies/jwt/guards';
+import { ListSymbolsDto } from './dto/list-symbols.dto';
+import { SymbolLibraryListResult } from './results/symbol-library-list.result';
+import { SymbolLibraryService } from './symbol-library.service';
+
+@Controller('symbol-library')
+@ApiTags('Symbol Library')
+@ApiBearerAuth(StrategyEnum.JWT)
+@UseGuards(AccessTokenGuard)
+export class SymbolLibraryController {
+  constructor(private readonly service: SymbolLibraryService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List curated math symbols, optionally filtered by category and/or search term',
+  })
+  @ApiOkResponse({ type: SymbolLibraryListResult })
+  async list(@Query() query: ListSymbolsDto): Promise<SymbolLibraryListResult> {
+    return this.service.list({ category: query.category, q: query.q });
+  }
+}

--- a/src/components/symbol-library/symbol-library.module.ts
+++ b/src/components/symbol-library/symbol-library.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../../prisma/prisma.module';
+import { Encryptor } from '../../utils/encryptor';
+import { AuthModule } from '../auth/auth.module';
+import { SymbolLibraryController } from './symbol-library.controller';
+import { SymbolLibraryService } from './symbol-library.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [SymbolLibraryController],
+  providers: [SymbolLibraryService, Encryptor],
+  exports: [SymbolLibraryService],
+})
+export class SymbolLibraryModule {}

--- a/src/components/symbol-library/symbol-library.service.ts
+++ b/src/components/symbol-library/symbol-library.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  SymbolCategoryFacetResult,
+  SymbolLibraryItemResult,
+  SymbolLibraryListResult,
+} from './results/symbol-library-list.result';
+
+@Injectable()
+export class SymbolLibraryService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(opts: { category?: string; q?: string }): Promise<SymbolLibraryListResult> {
+    const where: Prisma.SymbolLibraryItemWhereInput = { isActive: true };
+    if (opts.category) where.category = opts.category;
+    if (opts.q && opts.q.trim().length > 0) {
+      const term = opts.q.trim();
+      where.OR = [
+        { name: { contains: term, mode: 'insensitive' } },
+        { tags: { has: term.toLowerCase() } },
+      ];
+    }
+
+    const [rows, categoryFacets] = await Promise.all([
+      this.prisma.symbolLibraryItem.findMany({
+        where,
+        orderBy: [{ category: 'asc' }, { order: 'asc' }, { name: 'asc' }],
+      }),
+      this.categoryFacets(opts.q),
+    ]);
+
+    const items: SymbolLibraryItemResult[] = rows.map((r) => ({
+      id: r.id,
+      category: r.category,
+      name: r.name,
+      latex: r.latex,
+      tags: r.tags,
+    }));
+
+    return { items, categories: categoryFacets };
+  }
+
+  private async categoryFacets(q?: string): Promise<SymbolCategoryFacetResult[]> {
+    const where: Prisma.SymbolLibraryItemWhereInput = { isActive: true };
+    if (q && q.trim().length > 0) {
+      const term = q.trim();
+      where.OR = [
+        { name: { contains: term, mode: 'insensitive' } },
+        { tags: { has: term.toLowerCase() } },
+      ];
+    }
+    const grouped = await this.prisma.symbolLibraryItem.groupBy({
+      by: ['category'],
+      where,
+      _count: { _all: true },
+    });
+    return grouped
+      .map((g) => ({ category: g.category, count: g._count._all }))
+      .sort((a, b) => a.category.localeCompare(b.category));
+  }
+}


### PR DESCRIPTION
Builds out the platform-curated content pipeline that supports the new math-authoring UX in the question editor and gives schos staff a safe way to land seed content in production without SSH.

Schema:
- EquationLibraryItem (subject-keyed LaTeX equations) + migration
- SymbolLibraryItem (category-keyed glyph palette) + migration
- SeedRun audit table for the runner

Backend modules:
- /equation-library — list curated equations with subject + search filters
- /symbol-library — list curated symbols with category + search filters
- /platform/seeds — list and run individual seed scripts. PLATFORM_ADMIN only via new PlatformAdminGuard. Each run is mutex-locked, audited (who/when/upserted/skipped/duration/notes/errors), and upsert-only — no script ever deletes existing rows.

Seeds (split from monolithic seed.ts into prisma/seeds/* with a shared SeedRunResult shape so the runner UI can show metrics):
- canonical-subjects: 49 entries — adds General Knowledge, Computer Studies, Data Processing, Technical Drawing, Tie and Dye, Auto Mechanics, Building Construction, Electrical Installation, Animal Husbandry, Book Keeping, Catering Craft Practice, Garment Making alongside the existing 37 academic subjects
- canonical-levels, canonical-terms, popular-exams (extracted)
- equation-library: 122 entries — quadratic formula, full matrices set, trig/log/calculus/probability, vectors, complex, electricity, thermo, modern physics, chemistry kinetics+equilibrium, biology, finance ratios, complexity notation
- symbol-library: 111 glyphs across Greek, operators, functions, calculus, sets, arrows/logic, units
- curated-questions: 38 SCHOS_CURATED starter questions including 20 WAEC-style English Language items (vocabulary, grammar, concord, voice, tense, idiom, figurative language). Idempotent via seedKey anchor in promptPlainText.
- curated-quizzes: 1 starter "Generic English Language Quiz" bundling the 20 English questions in order; depends on curated-questions.

All seeds upsert by stable keys so re-running is safe and updates content in place.