### PR TITLE
Feat/student admin improvement (#140) (#141)

### DIFF
--- a/src/components/bff/student/student.controller.ts
+++ b/src/components/bff/student/student.controller.ts
@@ -243,6 +243,26 @@ export class StudentController {
     }
   }
 
+  @Get('attendance-history')
+  @ApiOperation({
+    summary: "Get the logged-in student's class attendance history over the last N days",
+  })
+  @ApiQuery({ name: 'days', required: false, type: Number, description: 'Defaults to 28' })
+  @ApiResponse({ status: 200, description: 'Attendance history retrieved successfully' })
+  async getMyAttendanceHistory(
+    @GetCurrentUserId() userId: string,
+    @Query('days') daysParam?: string,
+  ) {
+    const parsed = daysParam ? Number.parseInt(daysParam, 10) : 28;
+    const days = Math.min(Math.max(Number.isFinite(parsed) ? parsed : 28, 1), 90);
+    const result = await this.studentService.getMyAttendanceHistory(userId, days);
+    return {
+      success: true,
+      message: 'Attendance history retrieved successfully',
+      data: result,
+    };
+  }
+
   // Payment endpoints
   @Get('payments')
   @ApiOperation({ summary: 'Get student payments' })

--- a/src/components/bff/student/student.service.ts
+++ b/src/components/bff/student/student.service.ts
@@ -825,6 +825,112 @@ export class StudentService extends BaseService {
     };
   }
 
+  /**
+   * Returns the logged-in student's per-day class attendance over the last
+   * `days` days (oldest first). Days with no record yield `status: null`,
+   * rendered as a neutral cell in the pastoral heat-strip on mobile.
+   * Mirrors the teacher-side getStudentAttendanceHistory but keyed off the
+   * authenticated user instead of an arbitrary studentId.
+   */
+  async getMyAttendanceHistory(userId: string, days: number) {
+    const student = await this.prisma.student.findFirst({
+      where: { userId },
+    });
+    if (!student) {
+      throw new Error('Student not found');
+    }
+
+    // A student can be enrolled in more than one class arm over time — the
+    // active enrollment is what we want for daily attendance.
+    const classArmStudent = await this.prisma.classArmStudent.findFirst({
+      where: { studentId: student.id, isActive: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!classArmStudent) {
+      // No active class enrollment — return an empty history so the screen
+      // can still render the section with all-neutral cells.
+      return {
+        studentId: student.id,
+        classArmId: null,
+        days,
+        history: [],
+        statistics: {
+          presentDays: 0,
+          absentDays: 0,
+          lateDays: 0,
+          excusedDays: 0,
+          recordedDays: 0,
+          attendanceRate: 0,
+        },
+      };
+    }
+
+    const today = new Date();
+    const endOfToday = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      23,
+      59,
+      59,
+      999,
+    );
+    const startBoundary = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (days - 1),
+      0,
+      0,
+      0,
+      0,
+    );
+
+    const records = await this.prisma.studentAttendance.findMany({
+      where: {
+        classArmStudentId: classArmStudent.id,
+        date: { gte: startBoundary, lte: endOfToday },
+        deletedAt: null,
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    const byDate = new Map<string, (typeof records)[number]>();
+    for (const r of records) {
+      const d = r.date;
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      byDate.set(key, r);
+    }
+
+    const history: Array<{ date: string; status: string | null }> = [];
+    for (let offset = days - 1; offset >= 0; offset--) {
+      const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() - offset);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      history.push({ date: key, status: byDate.get(key)?.status ?? null });
+    }
+
+    const presentDays = history.filter((h) => h.status === 'PRESENT').length;
+    const absentDays = history.filter((h) => h.status === 'ABSENT').length;
+    const lateDays = history.filter((h) => h.status === 'LATE').length;
+    const excusedDays = history.filter((h) => h.status === 'EXCUSED').length;
+    const recordedDays = presentDays + absentDays + lateDays + excusedDays;
+
+    return {
+      studentId: student.id,
+      classArmId: classArmStudent.classArmId,
+      days,
+      history,
+      statistics: {
+        presentDays,
+        absentDays,
+        lateDays,
+        excusedDays,
+        recordedDays,
+        attendanceRate:
+          recordedDays > 0 ? Math.round(((presentDays + lateDays) / recordedDays) * 10000) / 100 : 0,
+      },
+    };
+  }
+
   async getStudentAcademicSessions(userId: string) {
     const student = await this.prisma.student.findFirst({
       where: { userId },

--- a/src/components/bff/teacher/teacher.controller.ts
+++ b/src/components/bff/teacher/teacher.controller.ts
@@ -641,6 +641,37 @@ export class TeacherController {
     };
   }
 
+  @Get('student/:studentId/attendance-history')
+  @ApiOperation({
+    summary: "Get one student's class attendance history over the last N days (pastoral view)",
+  })
+  @ApiQuery({ name: 'classArmId', required: true, type: String })
+  @ApiQuery({ name: 'days', required: false, type: Number, description: 'Defaults to 28' })
+  @ApiResponse({ status: 200, description: 'Student attendance history retrieved successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden - not authorized for this class' })
+  @ApiResponse({ status: 404, description: 'Teacher or student not found in class' })
+  async getStudentAttendanceHistory(
+    @GetCurrentUserId() userId: string,
+    @Param('studentId') studentId: string,
+    @Query('classArmId') classArmId: string,
+    @Query('days') daysParam?: string,
+  ) {
+    const parsed = daysParam ? Number.parseInt(daysParam, 10) : 28;
+    // Cap to a sane range so a typo can't yank a year of records.
+    const days = Math.min(Math.max(Number.isFinite(parsed) ? parsed : 28, 1), 90);
+    const result = await this.teacherService.getStudentAttendanceHistory(
+      userId,
+      studentId,
+      classArmId,
+      days,
+    );
+    return {
+      success: true,
+      message: 'Student attendance history retrieved successfully',
+      data: result,
+    };
+  }
+
   // Classroom Broadsheet Endpoints
   @Get('classroom-broadsheet')
   @ApiOperation({ summary: 'Get broadsheet data (class teacher only)' })

--- a/src/components/bff/teacher/teacher.service.ts
+++ b/src/components/bff/teacher/teacher.service.ts
@@ -3024,6 +3024,109 @@ export class TeacherService {
     };
   }
 
+  /**
+   * Returns one student's per-day class attendance over the last `days`
+   * calendar days (oldest first). Days with no record yield `status: null`.
+   * Authorization: same as getClassAttendanceData — class teacher OR subject
+   * teacher of the classArm. Powers the pastoral student detail heat-strip.
+   */
+  async getStudentAttendanceHistory(
+    userId: string,
+    studentId: string,
+    classArmId: string,
+    days: number,
+  ) {
+    const teacher = await this.prisma.teacher.findFirst({
+      where: { userId, deletedAt: null },
+    });
+    if (!teacher) throw new NotFoundException('Teacher not found');
+
+    const classArmTeacher = await this.prisma.classArmTeacher.findFirst({
+      where: { teacherId: teacher.id, classArmId, deletedAt: null },
+    });
+    const subjectTeacher = await this.prisma.classArmSubjectTeacher.findFirst({
+      where: { teacherId: teacher.id, deletedAt: null, classArmSubject: { classArmId } },
+    });
+    if (!classArmTeacher && !subjectTeacher) {
+      throw new ForbiddenException('You are not authorized to view attendance for this class');
+    }
+
+    const classArmStudent = await this.prisma.classArmStudent.findFirst({
+      where: { classArmId, studentId, isActive: true },
+    });
+    if (!classArmStudent) {
+      throw new NotFoundException('Student is not enrolled in this class');
+    }
+
+    // Date range — last N days inclusive of today, midnight-aligned.
+    const today = new Date();
+    const endOfToday = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      23,
+      59,
+      59,
+      999,
+    );
+    const startBoundary = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (days - 1),
+      0,
+      0,
+      0,
+      0,
+    );
+
+    const records = await this.prisma.studentAttendance.findMany({
+      where: {
+        classArmStudentId: classArmStudent.id,
+        date: { gte: startBoundary, lte: endOfToday },
+        deletedAt: null,
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    // Bucket records by YYYY-MM-DD for fast lookup.
+    const byDate = new Map<string, (typeof records)[number]>();
+    for (const r of records) {
+      const d = r.date;
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      byDate.set(key, r);
+    }
+
+    // Walk every day in range and emit a result entry (oldest first).
+    const history: Array<{ date: string; status: string | null }> = [];
+    for (let offset = days - 1; offset >= 0; offset--) {
+      const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() - offset);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      history.push({ date: key, status: byDate.get(key)?.status ?? null });
+    }
+
+    const presentDays = history.filter((h) => h.status === 'PRESENT').length;
+    const absentDays = history.filter((h) => h.status === 'ABSENT').length;
+    const lateDays = history.filter((h) => h.status === 'LATE').length;
+    const excusedDays = history.filter((h) => h.status === 'EXCUSED').length;
+    const recordedDays = presentDays + absentDays + lateDays + excusedDays;
+
+    return {
+      studentId,
+      classArmId,
+      days,
+      history,
+      statistics: {
+        presentDays,
+        absentDays,
+        lateDays,
+        excusedDays,
+        recordedDays,
+        attendanceRate:
+          recordedDays > 0 ? Math.round(((presentDays + lateDays) / recordedDays) * 10000) / 100 : 0,
+      },
+    };
+  }
+
   // Classroom Broadsheet methods
   async getClassroomBroadsheet(userId: string, classArmId: string) {
     const { schoolId } = await this.verifyClassTeacher(userId, classArmId);

--- a/src/components/questions/questions.service.ts
+++ b/src/components/questions/questions.service.ts
@@ -56,6 +56,13 @@ export class QuestionsService {
       where.ownerType = QuestionOwnerType.SCHOS_CURATED;
     }
 
+    // Teachers only ever see PUBLISHED curated content; ignore any user-supplied status filter
+    // when scoped to the library. System admins keep full visibility for library management.
+    const teacherLibraryView = scope === 'library' && caller.type === UserTypes.TEACHER;
+    if (teacherLibraryView) {
+      where.status = QuestionStatus.PUBLISHED;
+    }
+
     if (query.subjectId) where.subjectId = query.subjectId;
     if (query.levelId) where.levelId = query.levelId;
     if (query.canonicalSubjectName) {
@@ -69,7 +76,7 @@ export class QuestionsService {
     }
     if (query.type) where.type = query.type;
     if (query.difficulty) where.difficulty = query.difficulty;
-    if (query.status) where.status = query.status;
+    if (query.status && !teacherLibraryView) where.status = query.status;
     if (query.search) {
       where.promptPlainText = { contains: query.search, mode: 'insensitive' };
     }
@@ -114,6 +121,14 @@ export class QuestionsService {
       question.authorUserId === callerUserId &&
       question.schoolId === caller.schoolId;
     if (!isCurated && !isOwn) {
+      throw new NotFoundException('Question not found');
+    }
+    // Teachers must not see DRAFT/ARCHIVED curated questions — only system admins can preview those.
+    if (
+      isCurated &&
+      caller.type === UserTypes.TEACHER &&
+      question.status !== QuestionStatus.PUBLISHED
+    ) {
       throw new NotFoundException('Question not found');
     }
 
@@ -308,11 +323,14 @@ export class QuestionsService {
         id,
         deletedAt: null,
         ownerType: QuestionOwnerType.SCHOS_CURATED,
+        status: QuestionStatus.PUBLISHED,
       },
       include: QUESTION_INCLUDE,
     });
     if (!source) {
-      throw new NotFoundException('Curated question not found (only SCHOS_CURATED questions can be cloned)');
+      throw new NotFoundException(
+        'Curated question not found (only PUBLISHED curated questions can be cloned)',
+      );
     }
 
     const cloned = await this.prisma.$transaction(async (tx) => {

--- a/src/components/quizzes/quizzes.service.ts
+++ b/src/components/quizzes/quizzes.service.ts
@@ -8,6 +8,7 @@ import {
 import {
   Prisma,
   QuestionOwnerType,
+  QuestionStatus,
   QuizAssignmentStatus,
   QuizOwnerType,
   QuizStatus,
@@ -76,6 +77,13 @@ export class QuizzesService {
       where.ownerType = QuizOwnerType.SCHOS_CURATED;
     }
 
+    // Teachers only ever see PUBLISHED curated content; ignore any user-supplied status filter
+    // when scoped to the library. System admins keep full visibility for library management.
+    const teacherLibraryView = scope === 'library' && caller.type === UserTypes.TEACHER;
+    if (teacherLibraryView) {
+      where.status = QuizStatus.PUBLISHED;
+    }
+
     if (query.subjectId) where.subjectId = query.subjectId;
     if (query.levelId) where.levelId = query.levelId;
     if (query.canonicalSubjectName) {
@@ -88,7 +96,7 @@ export class QuizzesService {
       where.canonicalTermName = { equals: query.canonicalTermName, mode: 'insensitive' };
     }
     if (query.difficulty) where.difficulty = query.difficulty;
-    if (query.status) where.status = query.status;
+    if (query.status && !teacherLibraryView) where.status = query.status;
     if (query.search) where.title = { contains: query.search, mode: 'insensitive' };
     if (query.topicIds?.length) {
       where.topics = { some: { topicId: { in: query.topicIds } } };
@@ -125,6 +133,14 @@ export class QuizzesService {
       quiz.authorUserId === callerUserId &&
       quiz.schoolId === caller.schoolId;
     if (!isCurated && !isOwn) {
+      throw new NotFoundException('Quiz not found');
+    }
+    // Teachers must not see DRAFT/ARCHIVED curated quizzes — only system admins can preview those.
+    if (
+      isCurated &&
+      caller.type === UserTypes.TEACHER &&
+      quiz.status !== QuizStatus.PUBLISHED
+    ) {
       throw new NotFoundException('Quiz not found');
     }
 
@@ -276,7 +292,12 @@ export class QuizzesService {
     }
 
     const source = await this.prisma.quiz.findFirst({
-      where: { id, deletedAt: null, ownerType: QuizOwnerType.SCHOS_CURATED },
+      where: {
+        id,
+        deletedAt: null,
+        ownerType: QuizOwnerType.SCHOS_CURATED,
+        status: QuizStatus.PUBLISHED,
+      },
       include: {
         questions: { orderBy: { order: 'asc' } },
         topics: true,
@@ -284,7 +305,7 @@ export class QuizzesService {
     });
     if (!source) {
       throw new NotFoundException(
-        'Curated quiz not found (only SCHOS_CURATED quizzes can be cloned)',
+        'Curated quiz not found (only PUBLISHED curated quizzes can be cloned)',
       );
     }
 
@@ -355,7 +376,13 @@ export class QuizzesService {
 
     const questions = await this.prisma.question.findMany({
       where: { id: { in: questionIds }, deletedAt: null },
-      select: { id: true, ownerType: true, schoolId: true, authorUserId: true },
+      select: {
+        id: true,
+        ownerType: true,
+        schoolId: true,
+        authorUserId: true,
+        status: true,
+      },
     });
     if (questions.length !== questionIds.length) {
       const found = new Set(questions.map((q) => q.id));
@@ -373,6 +400,15 @@ export class QuizzesService {
         throw new ForbiddenException(
           `Cannot attach question ${q.id}: not curated and not owned by you`,
         );
+      }
+      // Teachers can only pull PUBLISHED curated questions from the library; DRAFT/ARCHIVED
+      // curated content is invisible to them. System admins composing curated quizzes are unrestricted.
+      if (
+        isCurated &&
+        caller.type === UserTypes.TEACHER &&
+        q.status !== QuestionStatus.PUBLISHED
+      ) {
+        throw new NotFoundException(`Question ${q.id} not found`);
       }
       if (quiz.ownerType === QuizOwnerType.SCHOS_CURATED && !isCurated) {
         throw new BadRequestException(

--- a/src/components/students/bulk-upload/dto/student-record.dto.ts
+++ b/src/components/students/bulk-upload/dto/student-record.dto.ts
@@ -145,4 +145,82 @@ export class StudentRecordDto {
   @IsOptional()
   @IsString()
   guardianRelationship?: string;
+
+  // --- Address (optional) ---
+  @ApiProperty({ description: 'Address line 1', example: '12 Marina Road', required: false })
+  @IsOptional()
+  @IsString()
+  addressStreet1?: string;
+
+  @ApiProperty({ description: 'Address line 2', example: 'Apt 4B', required: false })
+  @IsOptional()
+  @IsString()
+  addressStreet2?: string;
+
+  @ApiProperty({ description: 'City', example: 'Lagos', required: false })
+  @IsOptional()
+  @IsString()
+  addressCity?: string;
+
+  @ApiProperty({ description: 'State / region', example: 'Lagos', required: false })
+  @IsOptional()
+  @IsString()
+  addressState?: string;
+
+  @ApiProperty({ description: 'Country', example: 'Nigeria', required: false })
+  @IsOptional()
+  @IsString()
+  addressCountry?: string;
+
+  @ApiProperty({ description: 'Postal / ZIP code', example: '101241', required: false })
+  @IsOptional()
+  @IsString()
+  addressPostalCode?: string;
+
+  // --- Medical (optional) ---
+  @ApiProperty({ description: 'Blood group', example: 'O+', required: false })
+  @IsOptional()
+  @IsString()
+  bloodGroup?: string;
+
+  @ApiProperty({
+    description: 'Allergies, semicolon-separated',
+    example: 'peanuts;penicillin',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  allergies?: string;
+
+  @ApiProperty({
+    description: 'Medical conditions, semicolon-separated',
+    example: 'asthma;eczema',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  medicalConditions?: string;
+
+  @ApiProperty({ description: 'Emergency contact name', example: 'Jane Doe', required: false })
+  @IsOptional()
+  @IsString()
+  emergencyContactName?: string;
+
+  @ApiProperty({
+    description: 'Emergency contact phone',
+    example: '+234-XXX-XXX-XXXX',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  emergencyContactPhone?: string;
+
+  @ApiProperty({
+    description: 'Emergency contact relationship to student',
+    example: 'Mother',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  emergencyContactRelationship?: string;
 }

--- a/src/components/students/bulk-upload/processors/student-import.processor.ts
+++ b/src/components/students/bulk-upload/processors/student-import.processor.ts
@@ -409,13 +409,27 @@ export class StudentImportProcessor extends WorkerHost {
   }
 
   private transformRecordToCreateStudentDto(record: any): any {
-    // Extract guardian fields and className (used only for mapping) and group them into guardianInformation
+    // Extract guardian fields, address fields, medical fields, and className (used only for mapping)
+    // so they don't leak into the User create call. Only fields on the User model should remain in studentFields.
     const {
       guardianFirstName,
       guardianLastName,
       guardianEmail,
       guardianPhone,
       guardianRelationship,
+      className: _className,
+      addressStreet1,
+      addressStreet2,
+      addressCity,
+      addressState,
+      addressCountry,
+      addressPostalCode,
+      bloodGroup,
+      allergies,
+      medicalConditions,
+      emergencyContactName,
+      emergencyContactPhone,
+      emergencyContactRelationship,
       ...studentFields
     } = record;
 
@@ -444,6 +458,72 @@ export class StudentImportProcessor extends WorkerHost {
       });
     }
 
+    // Build address object if any address fields are provided
+    let address = undefined;
+    if (
+      addressStreet1 ||
+      addressStreet2 ||
+      addressCity ||
+      addressState ||
+      addressCountry ||
+      addressPostalCode
+    ) {
+      address = {
+        street1: addressStreet1,
+        street2: addressStreet2,
+        city: addressCity,
+        state: addressState,
+        country: addressCountry,
+        postalCode: addressPostalCode,
+      };
+      Object.keys(address).forEach((key) => {
+        if (address[key] === undefined || address[key] === '') {
+          delete address[key];
+        }
+      });
+    }
+
+    // Build medicalInformation object if any medical fields are provided
+    const splitList = (value: unknown): string[] | undefined => {
+      if (typeof value !== 'string') return undefined;
+      const parts = value
+        .split(';')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      return parts.length > 0 ? parts : undefined;
+    };
+
+    const allergiesList = splitList(allergies);
+    const medicalConditionsList = splitList(medicalConditions);
+    let emergencyContact: any = undefined;
+    if (emergencyContactName || emergencyContactPhone) {
+      emergencyContact = {
+        name: emergencyContactName,
+        phone: emergencyContactPhone,
+        relationship: emergencyContactRelationship,
+      };
+      Object.keys(emergencyContact).forEach((key) => {
+        if (emergencyContact[key] === undefined || emergencyContact[key] === '') {
+          delete emergencyContact[key];
+        }
+      });
+    }
+
+    let medicalInformation: any = undefined;
+    if (bloodGroup || allergiesList || medicalConditionsList || emergencyContact) {
+      medicalInformation = {
+        bloodGroup: bloodGroup || undefined,
+        allergies: allergiesList,
+        medicalConditions: medicalConditionsList,
+        emergencyContact,
+      };
+      Object.keys(medicalInformation).forEach((key) => {
+        if (medicalInformation[key] === undefined) {
+          delete medicalInformation[key];
+        }
+      });
+    }
+
     // Convert date strings to Date objects, handling DD-MM-YYYY format
     let admissionDate = undefined;
     if (studentFields.admissionDate) {
@@ -460,6 +540,8 @@ export class StudentImportProcessor extends WorkerHost {
       dateOfBirth,
       guardianInformation,
       admissionDate,
+      address,
+      medicalInformation,
     };
   }
 

--- a/src/components/students/bulk-upload/services/bulk-upload.service.ts
+++ b/src/components/students/bulk-upload/services/bulk-upload.service.ts
@@ -306,6 +306,32 @@ export class BulkUploadService extends BaseService {
       )?.toString(),
       guardianRelationship:
         row.guardianRelationship || row['Guardian Relationship'] || row['guardian_relationship'],
+      // Address (optional)
+      addressStreet1: row.addressStreet1 || row['Address Street 1'] || row['address_street1'],
+      addressStreet2: row.addressStreet2 || row['Address Street 2'] || row['address_street2'],
+      addressCity: row.addressCity || row['Address City'] || row['address_city'],
+      addressState: row.addressState || row['Address State'] || row['address_state'],
+      addressCountry: row.addressCountry || row['Address Country'] || row['address_country'],
+      addressPostalCode:
+        row.addressPostalCode || row['Address Postal Code'] || row['address_postal_code'],
+      // Medical (optional)
+      bloodGroup: row.bloodGroup || row['Blood Group'] || row['blood_group'],
+      allergies: row.allergies || row['Allergies'] || row['allergies'],
+      medicalConditions:
+        row.medicalConditions || row['Medical Conditions'] || row['medical_conditions'],
+      emergencyContactName:
+        row.emergencyContactName ||
+        row['Emergency Contact Name'] ||
+        row['emergency_contact_name'],
+      emergencyContactPhone: (
+        row.emergencyContactPhone ||
+        row['Emergency Contact Phone'] ||
+        row['emergency_contact_phone']
+      )?.toString(),
+      emergencyContactRelationship:
+        row.emergencyContactRelationship ||
+        row['Emergency Contact Relationship'] ||
+        row['emergency_contact_relationship'],
     };
 
     // Validate required fields with detailed error messages
@@ -350,7 +376,12 @@ export class BulkUploadService extends BaseService {
   }
 
   private transformExcelRowToStudentRecord(row: any[], rowNumber: number): StudentRecordDto | null {
-    // Column order: firstName, lastName, gender, className, dateOfBirth, email, phone, stateOfOrigin, admissionDate, guardianFirstName, guardianLastName, guardianEmail, guardianPhone, guardianRelationship
+    // Column order: firstName, lastName, gender, className, dateOfBirth, email, phone,
+    //   stateOfOrigin, admissionDate, guardianFirstName, guardianLastName, guardianEmail,
+    //   guardianPhone, guardianRelationship,
+    //   addressStreet1, addressStreet2, addressCity, addressState, addressCountry, addressPostalCode,
+    //   bloodGroup, allergies, medicalConditions,
+    //   emergencyContactName, emergencyContactPhone, emergencyContactRelationship
     const record: StudentRecordDto = {
       firstName: row[0],
       lastName: row[1],
@@ -367,6 +398,20 @@ export class BulkUploadService extends BaseService {
       guardianEmail: row[11],
       guardianPhone: row[12]?.toString(),
       guardianRelationship: row[13],
+      // Address (optional)
+      addressStreet1: row[14],
+      addressStreet2: row[15],
+      addressCity: row[16],
+      addressState: row[17],
+      addressCountry: row[18],
+      addressPostalCode: row[19]?.toString(),
+      // Medical (optional)
+      bloodGroup: row[20],
+      allergies: row[21],
+      medicalConditions: row[22],
+      emergencyContactName: row[23],
+      emergencyContactPhone: row[24]?.toString(),
+      emergencyContactRelationship: row[25],
     };
 
     // Validate required fields with detailed error messages

--- a/src/components/students/bulk-upload/services/template.service.ts
+++ b/src/components/students/bulk-upload/services/template.service.ts
@@ -42,6 +42,18 @@ export class TemplateService extends BaseService {
         'guardianEmail',
         'guardianPhone',
         'guardianRelationship',
+        'addressStreet1',
+        'addressStreet2',
+        'addressCity',
+        'addressState',
+        'addressCountry',
+        'addressPostalCode',
+        'bloodGroup',
+        'allergies',
+        'medicalConditions',
+        'emergencyContactName',
+        'emergencyContactPhone',
+        'emergencyContactRelationship',
       ];
 
       // Create sample data
@@ -62,6 +74,18 @@ export class TemplateService extends BaseService {
           'jane.doe@email.com',
           '+234-XXX-XXX-XXXX',
           'Mother',
+          '12 Marina Road',
+          'Apt 4B',
+          'Lagos',
+          'Lagos',
+          'Nigeria',
+          '101241',
+          'O+',
+          'peanuts;penicillin',
+          'asthma',
+          'Jane Doe',
+          '+234-XXX-XXX-XXXX',
+          'Mother',
         ],
         [
           'Alice',
@@ -79,6 +103,18 @@ export class TemplateService extends BaseService {
           'robert.smith@email.com',
           '+234-XXX-XXX-XXXX',
           'Father',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
         ],
       ];
 
@@ -176,37 +212,73 @@ export class TemplateService extends BaseService {
         },
       ],
       requiredFields: [
-        { field: 'firstName', description: 'Student first name', example: 'John' },
-        { field: 'lastName', description: 'Student last name', example: 'Doe' },
-        { field: 'gender', description: 'Student gender', example: 'MALE or FEMALE' },
+        { field: 'First Name', description: "Student's first name", example: 'John' },
+        { field: 'Last Name', description: "Student's last name", example: 'Doe' },
+        { field: 'Gender', description: "Student's gender", example: 'MALE or FEMALE' },
         {
-          field: 'classArmId',
-          description: 'Class arm UUID',
-          example: '123e4567-e89b-12d3-a456-426614174000',
+          field: 'Class',
+          description: 'Class the student belongs to (pick from the dropdown in the template)',
+          example: 'JSS 1 A',
         },
       ],
       optionalFields: [
-        { field: 'dateOfBirth', description: 'Student date of birth', example: '15-05-2012' },
-        { field: 'email', description: 'Student email address', example: 'john.doe@school.com' },
-        { field: 'phone', description: 'Student phone number', example: '+234-XXX-XXX-XXXX' },
-        { field: 'stateOfOrigin', description: 'Student state of origin', example: 'Lagos' },
-        { field: 'admissionNo', description: 'Custom admission number', example: 'ADM001' },
-        { field: 'admissionDate', description: 'Admission date', example: '01-09-2025' },
-        { field: 'guardianFirstName', description: 'Guardian first name', example: 'Jane' },
-        { field: 'guardianLastName', description: 'Guardian last name', example: 'Doe' },
+        { field: 'Date of Birth', description: "Student's date of birth", example: '15-05-2012' },
+        { field: 'Email Address', description: "Student's email address", example: 'john.doe@school.com' },
+        { field: 'Phone Number', description: "Student's phone number", example: '+234-XXX-XXX-XXXX' },
+        { field: 'State of Origin', description: "Student's state of origin", example: 'Lagos' },
         {
-          field: 'guardianEmail',
-          description: 'Guardian email address',
+          field: 'Admission Number',
+          description: 'Custom admission number (auto-generated if left blank)',
+          example: 'ADM001',
+        },
+        { field: 'Admission Date', description: 'Date the student was admitted', example: '01-09-2025' },
+        { field: 'Guardian First Name', description: "Guardian's first name", example: 'Jane' },
+        { field: 'Guardian Last Name', description: "Guardian's last name", example: 'Doe' },
+        {
+          field: 'Guardian Email',
+          description: "Guardian's email address",
           example: 'jane.doe@email.com',
         },
         {
-          field: 'guardianPhone',
-          description: 'Guardian phone number',
+          field: 'Guardian Phone',
+          description: "Guardian's phone number",
           example: '+234-XXX-XXX-XXXX',
         },
         {
-          field: 'guardianRelationship',
-          description: 'Relationship to student',
+          field: 'Guardian Relationship',
+          description: "Guardian's relationship to the student",
+          example: 'Mother',
+        },
+        { field: 'Address Line 1', description: 'Street address line 1', example: '12 Marina Road' },
+        { field: 'Address Line 2', description: 'Street address line 2', example: 'Apt 4B' },
+        { field: 'City', description: 'City', example: 'Lagos' },
+        { field: 'State / Region', description: 'State or region', example: 'Lagos' },
+        { field: 'Country', description: 'Country', example: 'Nigeria' },
+        { field: 'Postal / ZIP Code', description: 'Postal or ZIP code', example: '101241' },
+        { field: 'Blood Group', description: 'Blood group', example: 'O+' },
+        {
+          field: 'Allergies',
+          description: 'List of allergies, separated by semicolons',
+          example: 'peanuts;penicillin',
+        },
+        {
+          field: 'Medical Conditions',
+          description: 'List of medical conditions, separated by semicolons',
+          example: 'asthma;eczema',
+        },
+        {
+          field: 'Emergency Contact Name',
+          description: "Emergency contact's full name",
+          example: 'Jane Doe',
+        },
+        {
+          field: 'Emergency Contact Phone',
+          description: "Emergency contact's phone number",
+          example: '+234-XXX-XXX-XXXX',
+        },
+        {
+          field: 'Emergency Contact Relationship',
+          description: "Emergency contact's relationship to the student",
           example: 'Mother',
         },
       ],
@@ -251,6 +323,18 @@ export class TemplateService extends BaseService {
         'guardianEmail',
         'guardianPhone',
         'guardianRelationship',
+        'addressStreet1',
+        'addressStreet2',
+        'addressCity',
+        'addressState',
+        'addressCountry',
+        'addressPostalCode',
+        'bloodGroup',
+        'allergies',
+        'medicalConditions',
+        'emergencyContactName',
+        'emergencyContactPhone',
+        'emergencyContactRelationship',
       ];
 
       // Create sample data
@@ -271,6 +355,18 @@ export class TemplateService extends BaseService {
           'jane.doe@email.com',
           '+234-XXX-XXX-XXXX',
           'Mother',
+          '12 Marina Road',
+          'Apt 4B',
+          'Lagos',
+          'Lagos',
+          'Nigeria',
+          '101241',
+          'O+',
+          'peanuts;penicillin',
+          'asthma',
+          'Jane Doe',
+          '+234-XXX-XXX-XXXX',
+          'Mother',
         ],
         [
           'Alice',
@@ -288,6 +384,18 @@ export class TemplateService extends BaseService {
           'robert.smith@email.com',
           '+234-XXX-XXX-XXXX',
           'Father',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
         ],
       ];
 
@@ -314,11 +422,23 @@ export class TemplateService extends BaseService {
         { wch: 25 }, // guardianEmail
         { wch: 18 }, // guardianPhone
         { wch: 15 }, // guardianRelationship
+        { wch: 22 }, // addressStreet1
+        { wch: 18 }, // addressStreet2
+        { wch: 15 }, // addressCity
+        { wch: 15 }, // addressState
+        { wch: 15 }, // addressCountry
+        { wch: 12 }, // addressPostalCode
+        { wch: 10 }, // bloodGroup
+        { wch: 25 }, // allergies
+        { wch: 25 }, // medicalConditions
+        { wch: 20 }, // emergencyContactName
+        { wch: 18 }, // emergencyContactPhone
+        { wch: 18 }, // emergencyContactRelationship
       ];
       worksheet['!cols'] = colWidths;
 
-      // Set phone columns (G=phone, N=guardianPhone) to text format to preserve leading zeros
-      const phoneColLetters = ['G', 'N'];
+      // Set phone columns (G=phone, N=guardianPhone, Z=emergencyContactPhone) to text format to preserve leading zeros
+      const phoneColLetters = ['G', 'N', 'Z'];
       for (const col of phoneColLetters) {
         for (let row = 1; row <= 1000; row++) {
           const cellRef = `${col}${row}`;
@@ -400,6 +520,22 @@ export class TemplateService extends BaseService {
         ["• guardianPhone - Guardian's phone number"],
         ['• guardianRelationship - Relationship to student (e.g., Mother, Father)'],
         [''],
+        ['Address (Optional):'],
+        ['• addressStreet1 - Address line 1 (e.g., 12 Marina Road)'],
+        ['• addressStreet2 - Address line 2 (e.g., Apt 4B)'],
+        ['• addressCity - City (e.g., Lagos)'],
+        ['• addressState - State / region (e.g., Lagos)'],
+        ['• addressCountry - Country (e.g., Nigeria)'],
+        ['• addressPostalCode - Postal / ZIP code'],
+        [''],
+        ['Medical (Optional):'],
+        ['• bloodGroup - Blood group (e.g., O+, A-)'],
+        ['• allergies - Semicolon-separated list (e.g., peanuts;penicillin)'],
+        ['• medicalConditions - Semicolon-separated list (e.g., asthma;eczema)'],
+        ["• emergencyContactName - Emergency contact's full name"],
+        ["• emergencyContactPhone - Emergency contact's phone number"],
+        ['• emergencyContactRelationship - Relationship to student (e.g., Mother)'],
+        [''],
         ['Available Classes:'],
         ...classOptions.map((className) => [`• ${className}`]),
         [''],
@@ -480,6 +616,18 @@ export class TemplateService extends BaseService {
         'guardianEmail',
         'guardianPhone',
         'guardianRelationship',
+        'addressStreet1',
+        'addressStreet2',
+        'addressCity',
+        'addressState',
+        'addressCountry',
+        'addressPostalCode',
+        'bloodGroup',
+        'allergies',
+        'medicalConditions',
+        'emergencyContactName',
+        'emergencyContactPhone',
+        'emergencyContactRelationship',
       ];
 
       // Create sample data with actual class names
@@ -500,6 +648,18 @@ export class TemplateService extends BaseService {
           'jane.doe@email.com',
           '+234-XXX-XXX-XXXX',
           'Mother',
+          '12 Marina Road',
+          'Apt 4B',
+          'Lagos',
+          'Lagos',
+          'Nigeria',
+          '101241',
+          'O+',
+          'peanuts;penicillin',
+          'asthma',
+          'Jane Doe',
+          '+234-XXX-XXX-XXXX',
+          'Mother',
         ],
         [
           'Alice',
@@ -517,6 +677,18 @@ export class TemplateService extends BaseService {
           'robert.smith@email.com',
           '+234-XXX-XXX-XXXX',
           'Father',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
         ],
       ];
 
@@ -540,6 +712,10 @@ export class TemplateService extends BaseService {
         '# ',
         '# REQUIRED FIELDS: firstName, lastName, gender, className',
         '# OPTIONAL FIELDS: All others',
+        '# ',
+        '# ADDRESS COLUMNS (all optional): addressStreet1, addressStreet2, addressCity, addressState, addressCountry, addressPostalCode',
+        '# MEDICAL COLUMNS (all optional): bloodGroup, allergies, medicalConditions, emergencyContactName, emergencyContactPhone, emergencyContactRelationship',
+        '# • allergies and medicalConditions accept multiple values separated by semicolons (e.g., peanuts;penicillin)',
         '# ',
         '',
         csvContent,
@@ -600,6 +776,18 @@ export class TemplateService extends BaseService {
         'guardianEmail',
         'guardianPhone',
         'guardianRelationship',
+        'addressStreet1',
+        'addressStreet2',
+        'addressCity',
+        'addressState',
+        'addressCountry',
+        'addressPostalCode',
+        'bloodGroup',
+        'allergies',
+        'medicalConditions',
+        'emergencyContactName',
+        'emergencyContactPhone',
+        'emergencyContactRelationship',
       ];
 
       // Add headers to the worksheet
@@ -630,6 +818,18 @@ export class TemplateService extends BaseService {
         { width: 25 }, // guardianEmail
         { width: 18, style: { numFmt: '@' } }, // guardianPhone — text format
         { width: 15 }, // guardianRelationship
+        { width: 22 }, // addressStreet1
+        { width: 18 }, // addressStreet2
+        { width: 15 }, // addressCity
+        { width: 15 }, // addressState
+        { width: 15 }, // addressCountry
+        { width: 14, style: { numFmt: '@' } }, // addressPostalCode — text format to preserve leading zeros
+        { width: 10 }, // bloodGroup
+        { width: 25 }, // allergies
+        { width: 25 }, // medicalConditions
+        { width: 20 }, // emergencyContactName
+        { width: 18, style: { numFmt: '@' } }, // emergencyContactPhone — text format
+        { width: 18 }, // emergencyContactRelationship
       ];
 
       // Add sample data
@@ -649,6 +849,18 @@ export class TemplateService extends BaseService {
           'jane.doe@email.com',
           '+234-XXX-XXX-XXXX',
           'Mother',
+          '12 Marina Road',
+          'Apt 4B',
+          'Lagos',
+          'Lagos',
+          'Nigeria',
+          '101241',
+          'O+',
+          'peanuts;penicillin',
+          'asthma',
+          'Jane Doe',
+          '+234-XXX-XXX-XXXX',
+          'Mother',
         ],
         [
           'Alice',
@@ -665,6 +877,18 @@ export class TemplateService extends BaseService {
           'robert.smith@email.com',
           '+234-XXX-XXX-XXXX',
           'Father',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
         ],
       ];
 
@@ -674,8 +898,9 @@ export class TemplateService extends BaseService {
       });
 
       // Add empty rows to ensure the column range exists for validation
+      const emptyRow = new Array(headers.length).fill('');
       for (let i = 0; i < 50; i++) {
-        worksheet.addRow(['', '', '', '', '', '', '', '', '', '', '', '', '', '']);
+        worksheet.addRow([...emptyRow]);
       }
 
       // Add data validation for dropdowns using ExcelJS
@@ -738,6 +963,22 @@ export class TemplateService extends BaseService {
         ["• guardianEmail - Guardian's email address"],
         ["• guardianPhone - Guardian's phone number"],
         ['• guardianRelationship - Relationship to student (e.g., Mother, Father)'],
+        [''],
+        ['Address (Optional):'],
+        ['• addressStreet1 - Address line 1 (e.g., 12 Marina Road)'],
+        ['• addressStreet2 - Address line 2 (e.g., Apt 4B)'],
+        ['• addressCity - City (e.g., Lagos)'],
+        ['• addressState - State / region (e.g., Lagos)'],
+        ['• addressCountry - Country (e.g., Nigeria)'],
+        ['• addressPostalCode - Postal / ZIP code'],
+        [''],
+        ['Medical (Optional):'],
+        ['• bloodGroup - Blood group (e.g., O+, A-)'],
+        ['• allergies - Semicolon-separated list (e.g., peanuts;penicillin)'],
+        ['• medicalConditions - Semicolon-separated list (e.g., asthma;eczema)'],
+        ["• emergencyContactName - Emergency contact's full name"],
+        ["• emergencyContactPhone - Emergency contact's phone number"],
+        ['• emergencyContactRelationship - Relationship to student (e.g., Mother)'],
         [''],
         ['Available Classes:'],
         ...classOptions.map((className) => [`• ${className}`]),

--- a/src/components/students/students.controller.ts
+++ b/src/components/students/students.controller.ts
@@ -350,6 +350,23 @@ export class StudentsController {
     });
   }
 
+  @Get(':id/attendance-history')
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Student's class attendance history over the last N days",
+  })
+  @CheckPolicies(new ReadStudentPolicyHandler())
+  async getAttendanceHistory(@Param('id') id: string, @Query('days') daysParam?: string) {
+    const parsed = daysParam ? Number.parseInt(daysParam, 10) : 28;
+    const days = Math.min(Math.max(Number.isFinite(parsed) ? parsed : 28, 1), 90);
+    const result = await this.studentsService.getStudentAttendanceHistoryById(id, days);
+    return {
+      success: true,
+      message: 'Attendance history retrieved successfully',
+      data: result,
+    };
+  }
+
   @Get(':id')
   @ApiResponse({
     status: HttpStatus.OK,

--- a/src/components/students/students.service.ts
+++ b/src/components/students/students.service.ts
@@ -405,6 +405,101 @@ export class StudentsService extends BaseService {
     });
   }
 
+  /**
+   * Returns one student's per-day class attendance over the last `days`
+   * days (oldest first). Days with no record yield `status: null`.
+   * Powers the pastoral heat-strip on the admin student detail screen.
+   * Mirrors the teacher and student endpoints; admin auth is enforced
+   * by the controller's policy guard.
+   */
+  async getStudentAttendanceHistoryById(studentId: string, days: number) {
+    const classArmStudent = await this.prisma.classArmStudent.findFirst({
+      where: { studentId, isActive: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!classArmStudent) {
+      return {
+        studentId,
+        classArmId: null,
+        days,
+        history: [] as Array<{ date: string; status: string | null }>,
+        statistics: {
+          presentDays: 0,
+          absentDays: 0,
+          lateDays: 0,
+          excusedDays: 0,
+          recordedDays: 0,
+          attendanceRate: 0,
+        },
+      };
+    }
+
+    const today = new Date();
+    const endOfToday = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate(),
+      23,
+      59,
+      59,
+      999,
+    );
+    const startBoundary = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - (days - 1),
+      0,
+      0,
+      0,
+      0,
+    );
+
+    const records = await this.prisma.studentAttendance.findMany({
+      where: {
+        classArmStudentId: classArmStudent.id,
+        date: { gte: startBoundary, lte: endOfToday },
+        deletedAt: null,
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    const byDate = new Map<string, (typeof records)[number]>();
+    for (const r of records) {
+      const d = r.date;
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      byDate.set(key, r);
+    }
+
+    const history: Array<{ date: string; status: string | null }> = [];
+    for (let offset = days - 1; offset >= 0; offset--) {
+      const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() - offset);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      history.push({ date: key, status: byDate.get(key)?.status ?? null });
+    }
+
+    const presentDays = history.filter((h) => h.status === 'PRESENT').length;
+    const absentDays = history.filter((h) => h.status === 'ABSENT').length;
+    const lateDays = history.filter((h) => h.status === 'LATE').length;
+    const excusedDays = history.filter((h) => h.status === 'EXCUSED').length;
+    const recordedDays = presentDays + absentDays + lateDays + excusedDays;
+
+    return {
+      studentId,
+      classArmId: classArmStudent.classArmId,
+      days,
+      history,
+      statistics: {
+        presentDays,
+        absentDays,
+        lateDays,
+        excusedDays,
+        recordedDays,
+        attendanceRate:
+          recordedDays > 0 ? Math.round(((presentDays + lateDays) / recordedDays) * 10000) / 100 : 0,
+      },
+    };
+  }
+
   async update(id: string, updateStudentDto: UpdateStudentDto) {
     // Check if student exists
     const existingStudent = await this.findOne(id);


### PR DESCRIPTION
* feat(attendance): add per-student class attendance history endpoint

Adds three sibling endpoints that return the last N days of a student's class attendance (oldest first; days with no record yield status: null), powering the pastoral heat-strip:

- GET /bff/student/attendance-history       (logged-in student)
- GET /bff/teacher/student/:id/attendance-history (class/subject teacher)
- GET /students/:id/attendance-history      (admin, policy-gated)

Days param defaults to 28 and is clamped to [1, 90]. Teacher route authorizes against class-teacher OR subject-teacher of the classArm.

* feat(content): hide non-PUBLISHED curated questions/quizzes from teachers

In the library scope teachers now only ever see PUBLISHED curated rows; any user-supplied status filter is ignored for that view. findOne also 404s for teachers viewing DRAFT/ARCHIVED curated rows. System admins keep full visibility for library management.

Cloning is restricted further: cloneCurated requires status=PUBLISHED on the source, with a clearer error message.

* feat(students-bulk): add address & medical fields, fix className leak

- Address (Line 1/2, City, State, Country, Postal Code) and medical (Blood Group, Allergies, Medical Conditions, Emergency Contact name/phone/relationship) are now optional columns in the bulk-upload template. Allergies and medical conditions accept multiple values separated by semicolons.
- Processor assembles flat columns back into address and medicalInformation objects matching the existing CreateStudentDto shape; flat fields are stripped before forwarding to userService.save so they no longer leak into prisma.user.create.
- Same className strip extends the prior fix that prevented 'Unknown argument className' Prisma errors on bulk imports.
- Instructions endpoint now returns readable labels ('First Name', 'Class') instead of database field names ('firstName', 'classArmId'), and the required 'Class' example shows a class name rather than a UUID.