### PR TITLE
fix(activities): clean up descriptions and drop page-view noise

### DIFF
--- a/src/common/services/activity-log.service.ts
+++ b/src/common/services/activity-log.service.ts
@@ -425,34 +425,30 @@ export class ActivityLogService extends BaseService {
   }
 
   /**
-   * Helper method to generate descriptive notification messages
+   * Build a clean human-readable description for the activity feed.
+   * Frontend renders the user's name as a separate "by ${user}" line, so
+   * we deliberately don't suffix it here. Raw enum tokens (action /
+   * entityType) are also kept out — those are system-level and surface
+   * elsewhere as filter badges, not as prose.
    */
   private generateNotificationMessage(
     action: string,
     entityType: string,
     details?: any,
-    userName?: string,
+    _userName?: string,
   ): string {
-    let message = `${action} ${entityType}`;
-
-    if (details) {
-      if (details.changes && Object.keys(details.changes).length > 0) {
-        message += ` with changes: ${JSON.stringify(details.changes)}`;
-      } else if (details.description) {
-        message += `: ${details.description}`;
-      } else if (details.reason) {
-        message += `: ${details.reason}`;
-      } else if (details.message) {
-        message += `: ${details.message}`;
-      } else {
-        message += `: ${JSON.stringify(details)}`;
-      }
+    if (details?.message) return details.message;
+    if (details?.description) return details.description;
+    if (details?.reason) return details.reason;
+    if (details?.changes && Object.keys(details.changes).length > 0) {
+      return `Updated ${this.toFriendly(entityType).toLowerCase()}`;
     }
+    return this.toFriendly(action);
+  }
 
-    if (userName && !details?.skipUserName) {
-      message += ` by ${userName}`;
-    }
-
-    return message;
+  private toFriendly(token: string): string {
+    if (!token) return '';
+    const lower = token.toLowerCase().replace(/_/g, ' ');
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
   }
 }

--- a/src/components/bff/student/student.controller.ts
+++ b/src/components/bff/student/student.controller.ts
@@ -36,13 +36,6 @@ export class StudentController {
     description: 'Student dashboard data retrieved successfully',
     type: StudentDashboardResult,
   })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_DASHBOARD',
-    entityType: 'STUDENT_DASHBOARD',
-    description: 'Student viewed dashboard',
-    category: 'STUDENT',
-  })
   async getStudentDashboard(@GetCurrentUserId() userId: string) {
     const data = await this.studentService.getStudentDashboardData(userId);
     return new StudentDashboardResult(data);
@@ -75,13 +68,6 @@ export class StudentController {
     description: 'Student results retrieved successfully',
     type: StudentResultsResult,
   })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_RESULTS',
-    entityType: 'STUDENT_RESULTS',
-    description: 'Student viewed academic results',
-    category: 'STUDENT',
-  })
   async getStudentResults(
     @GetCurrentUserId() userId: string,
     @Query('academicSessionId') academicSessionId?: string,
@@ -102,13 +88,6 @@ export class StudentController {
   @ApiResponse({
     status: 200,
     description: 'Student profile retrieved successfully',
-  })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_PROFILE',
-    entityType: 'STUDENT_PROFILE',
-    description: 'Student viewed profile',
-    category: 'STUDENT',
   })
   async getStudentProfile(@GetCurrentUserId() userId: string) {
     const profile = await this.studentService.getStudentProfile(userId);
@@ -153,13 +132,6 @@ export class StudentController {
   @ApiResponse({
     status: 200,
     description: 'Student academic sessions with terms retrieved successfully',
-  })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_ACADEMIC_SESSIONS',
-    entityType: 'STUDENT_ACADEMIC_SESSIONS',
-    description: 'Student viewed enrolled academic sessions with terms',
-    category: 'STUDENT',
   })
   async getStudentAcademicSessions(@GetCurrentUserId() userId: string) {
     const sessions = await this.studentService.getStudentAcademicSessions(userId);
@@ -271,13 +243,6 @@ export class StudentController {
     description: 'Student payments retrieved successfully',
     type: [StudentPaymentResponseDto],
   })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_PAYMENTS',
-    entityType: 'STUDENT_PAYMENTS',
-    description: 'Student viewed payments',
-    category: 'STUDENT',
-  })
   async getStudentPayments(@GetCurrentUserId() userId: string) {
     const payments = await this.studentService.getStudentPayments(userId);
     return {
@@ -293,13 +258,6 @@ export class StudentController {
     status: 200,
     description: 'Student payment summary retrieved successfully',
     type: StudentPaymentSummaryDto,
-  })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_PAYMENT_SUMMARY',
-    entityType: 'STUDENT_PAYMENT_SUMMARY',
-    description: 'Student viewed payment summary',
-    category: 'STUDENT',
   })
   async getStudentPaymentSummary(@GetCurrentUserId() userId: string) {
     const summary = await this.studentService.getStudentPaymentSummary(userId);
@@ -317,13 +275,6 @@ export class StudentController {
     description: 'Student outstanding payments retrieved successfully',
     type: [StudentPaymentResponseDto],
   })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_OUTSTANDING_PAYMENTS',
-    entityType: 'STUDENT_OUTSTANDING_PAYMENTS',
-    description: 'Student viewed outstanding payments',
-    category: 'STUDENT',
-  })
   async getOutstandingPayments(@GetCurrentUserId() userId: string) {
     const payments = await this.studentService.getOutstandingPayments(userId);
     return {
@@ -339,13 +290,6 @@ export class StudentController {
     status: 200,
     description: 'Student payment history retrieved successfully',
     type: [StudentPaymentHistoryDto],
-  })
-  @UseInterceptors(ActivityLogInterceptor)
-  @LogActivity({
-    action: 'VIEW_STUDENT_PAYMENT_HISTORY',
-    entityType: 'STUDENT_PAYMENT_HISTORY',
-    description: 'Student viewed payment history',
-    category: 'STUDENT',
   })
   async getStudentPaymentHistory(@GetCurrentUserId() userId: string) {
     const history = await this.studentService.getStudentPaymentHistory(userId);

--- a/src/components/payments/services/paystack-webhook.service.ts
+++ b/src/components/payments/services/paystack-webhook.service.ts
@@ -121,13 +121,30 @@ export class PaystackWebhookService {
           });
         }
 
-        await this.logPaymentActivity(studentPayment.student.userId, 'PAYMENT_COMPLETED', {
-          paymentId: studentPayment.id,
-          amount: amountToCredit,
-          reference,
-          status: newStatus,
-          platformCommission: platformTx ? Number(platformTx.platformCommission) : 0,
-        });
+        const studentName = `${studentPayment.student.user.firstName} ${studentPayment.student.user.lastName}`;
+        const formattedAmount = this.formatNaira(amountToCredit);
+        const studentDescription =
+          newStatus === 'PAID'
+            ? `Payment of ${formattedAmount} completed (Ref: ${reference})`
+            : `Partial payment of ${formattedAmount} received (Ref: ${reference})`;
+        const adminDescription =
+          newStatus === 'PAID'
+            ? `${studentName} paid ${formattedAmount} (Ref: ${reference})`
+            : `${studentName} made partial payment of ${formattedAmount} (Ref: ${reference})`;
+
+        await this.logPaymentActivity(
+          studentPayment.student.userId,
+          'PAYMENT_COMPLETED',
+          {
+            paymentId: studentPayment.id,
+            amount: amountToCredit,
+            reference,
+            status: newStatus,
+            platformCommission: platformTx ? Number(platformTx.platformCommission) : 0,
+          },
+          studentDescription,
+          adminDescription,
+        );
 
         return { success: true, message: 'Student payment processed successfully' };
       }
@@ -153,12 +170,22 @@ export class PaystackWebhookService {
           },
         });
 
-        await this.logPaymentActivity(colorSchemePayment.userId, 'COLOR_SCHEME_PAYMENT_COMPLETED', {
-          paymentId: colorSchemePayment.id,
-          amount: Number(colorSchemePayment.amount),
-          reference,
-          status: 'PAID',
-        });
+        const csAmount = Number(colorSchemePayment.amount);
+        const csUserName = `${colorSchemePayment.user.firstName} ${colorSchemePayment.user.lastName}`;
+        const csFormatted = this.formatNaira(csAmount);
+
+        await this.logPaymentActivity(
+          colorSchemePayment.userId,
+          'COLOR_SCHEME_PAYMENT_COMPLETED',
+          {
+            paymentId: colorSchemePayment.id,
+            amount: csAmount,
+            reference,
+            status: 'PAID',
+          },
+          `Color scheme payment of ${csFormatted} completed (Ref: ${reference})`,
+          `${csUserName} paid ${csFormatted} for color scheme (Ref: ${reference})`,
+        );
 
         return { success: true, message: 'Color scheme payment processed successfully' };
       }
@@ -213,11 +240,20 @@ export class PaystackWebhookService {
           });
         }
 
-        await this.logPaymentActivity(studentPayment.student.userId, 'PAYMENT_FAILED', {
-          paymentId: studentPayment.id,
-          reference,
-          reason: gateway_response,
-        });
+        const failedStudentName = `${studentPayment.student.user.firstName} ${studentPayment.student.user.lastName}`;
+        const failureReason = gateway_response || 'unknown reason';
+
+        await this.logPaymentActivity(
+          studentPayment.student.userId,
+          'PAYMENT_FAILED',
+          {
+            paymentId: studentPayment.id,
+            reference,
+            reason: gateway_response,
+          },
+          `Payment failed: ${failureReason} (Ref: ${reference})`,
+          `${failedStudentName}'s payment failed: ${failureReason} (Ref: ${reference})`,
+        );
 
         return { success: true, message: 'Student payment failure logged' };
       }
@@ -235,11 +271,20 @@ export class PaystackWebhookService {
 
       if (colorSchemePayment) {
         // Mark color scheme payment as failed (we could add a FAILED status or just log it)
-        await this.logPaymentActivity(colorSchemePayment.userId, 'COLOR_SCHEME_PAYMENT_FAILED', {
-          paymentId: colorSchemePayment.id,
-          reference,
-          reason: gateway_response,
-        });
+        const failedCsUserName = `${colorSchemePayment.user.firstName} ${colorSchemePayment.user.lastName}`;
+        const csFailureReason = gateway_response || 'unknown reason';
+
+        await this.logPaymentActivity(
+          colorSchemePayment.userId,
+          'COLOR_SCHEME_PAYMENT_FAILED',
+          {
+            paymentId: colorSchemePayment.id,
+            reference,
+            reason: gateway_response,
+          },
+          `Color scheme payment failed: ${csFailureReason} (Ref: ${reference})`,
+          `${failedCsUserName}'s color scheme payment failed: ${csFailureReason} (Ref: ${reference})`,
+        );
 
         return { success: true, message: 'Color scheme payment failure logged' };
       }
@@ -294,6 +339,8 @@ export class PaystackWebhookService {
     userId: string | null,
     action: string,
     details: Record<string, any>,
+    description?: string,
+    adminDescription?: string,
   ): Promise<void> {
     try {
       if (userId) {
@@ -309,7 +356,7 @@ export class PaystackWebhookService {
               schoolId: user.schoolId,
               action,
               entityType: 'PAYMENT',
-              description: `Payment activity: ${action}`,
+              description: description ?? this.toFriendlyAction(action),
               details: details,
               ipAddress: 'webhook',
               userAgent: 'paystack-webhook',
@@ -317,7 +364,12 @@ export class PaystackWebhookService {
             },
           });
 
-          await this.logActivityForSchoolAdmins(user.schoolId, action, details);
+          await this.logActivityForSchoolAdmins(
+            user.schoolId,
+            action,
+            details,
+            adminDescription ?? description,
+          );
         }
       }
     } catch (error) {
@@ -329,6 +381,7 @@ export class PaystackWebhookService {
     schoolId: string,
     action: string,
     details: Record<string, any>,
+    description?: string,
   ): Promise<void> {
     try {
       const schoolAdmins = await this.prisma.user.findMany({
@@ -348,7 +401,7 @@ export class PaystackWebhookService {
             schoolId: schoolId,
             action,
             entityType: 'PAYMENT',
-            description: `Student payment activity: ${action}`,
+            description: description ?? this.toFriendlyAction(action),
             details: {
               ...details,
               loggedFor: 'school_admin',
@@ -362,6 +415,15 @@ export class PaystackWebhookService {
     } catch (error) {
       this.logger.error(`Error logging activity for school admins: ${error.message}`, error.stack);
     }
+  }
+
+  private formatNaira(amount: number): string {
+    return `₦${amount.toLocaleString('en-NG')}`;
+  }
+
+  private toFriendlyAction(action: string): string {
+    const lower = action.toLowerCase().replace(/_/g, ' ');
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
   }
 
   async getWebhookEvents(limit: number = 50): Promise<any[]> {


### PR DESCRIPTION
Recent Activities feed showed raw enum tokens like "MARK_CLASS_ATTENDANCE STUDENT_ATTENDANCE: ..." prepended to every description, plus a duplicate "by <user>" suffix the dashboard already renders separately.

- Rewrite generateNotificationMessage in ActivityLogService: return the clean human string from details.message / description / reason when present, otherwise a title-cased action label. Drop the user-name suffix.
- Remove 8 VIEW_STUDENT_* @LogActivity decorators (dashboard, results, profile, academic sessions, payments, summary, outstanding, history)
  - page loads have no audit value and just spam the feed.
- Enrich Paystack webhook descriptions with amount, student name, and payment reference. "Student payment activity: PAYMENT_COMPLETED" is now "John Doe paid ₦5,000 (Ref: ABC123)" for admins and "Payment of ₦5,000 completed (Ref: ABC123)" for the student. Same treatment for partial payments, failures, and color scheme payments.