### PR TITLE
feat(admin): personal profile endpoints and surface User on every log…

### DIFF
--- a/src/components/auth/results/auth.result.ts
+++ b/src/components/auth/results/auth.result.ts
@@ -53,12 +53,17 @@ export class AuthResult extends BaseResultWithData {
       throw new Error('User, student, or teacher must be provided');
     }
     const data: AuthResultData = { tokens, preferences };
+    // Always surface the User entity at `data.user` so clients have one
+    // canonical place to read identity fields (firstName, avatarUrl, …)
+    // regardless of role. The role-specific student/teacher entities still
+    // ride alongside for callers that need their domain fields.
+    if (user) {
+      data.user = UserEntity.from(user);
+    }
     if (student) {
       data.student = StudentEntity.fromStudent(student);
     } else if (teacher) {
       data.teacher = TeacherEntity.fromTeacher(teacher);
-    } else {
-      data.user = UserEntity.from(user);
     }
 
     if (admin) {

--- a/src/components/bff/admin/bff-admin.controller.ts
+++ b/src/components/bff/admin/bff-admin.controller.ts
@@ -24,10 +24,12 @@ import { StrategyEnum } from '../../auth/strategies';
 import { AccessTokenGuard } from '../../auth/strategies/jwt/guards';
 import { CheckPolicies, PoliciesGuard } from '../../roles-manager';
 import { ManageStudentPolicyHandler } from '../../students/policies';
+import { UsersService } from '../../users/users.service';
 import { BffAdminService } from './bff-admin.service';
 import { ResultCommentsService } from '../../result-comments/result-comments.service';
 import { QuizBillingService } from '../../quiz-billing/quiz-billing.service';
 import { ToggleAssessmentsDto } from './dto/toggle-assessments.dto';
+import { UpdateMyProfileDto } from './dto/update-my-profile.dto';
 import { AssessmentsSettingsResult } from './results/assessments-settings.result';
 import { AssessmentsUsageResult } from './results/assessments-usage.result';
 import {
@@ -93,7 +95,67 @@ export class BffAdminController {
     private readonly bffAdminService: BffAdminService,
     private readonly resultCommentsService: ResultCommentsService,
     private readonly quizBillingService: QuizBillingService,
+    private readonly usersService: UsersService,
   ) {}
+
+  // ─── Personal Profile ──────────────────────────────────
+
+  @Get('me/profile')
+  @ApiOperation({ summary: "Get the logged-in admin's own user profile" })
+  @ApiResponse({ status: 200, description: 'Profile retrieved successfully' })
+  async getMyProfile(@GetCurrentUserId() userId: string) {
+    const user = await this.usersService.findById(userId);
+    if (!user) {
+      return { success: false, message: 'User not found', data: null };
+    }
+    return {
+      success: true,
+      message: 'Profile retrieved successfully',
+      data: {
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        phone: user.phone,
+        gender: user.gender,
+        dateOfBirth: user.dateOfBirth,
+        stateOfOrigin: user.stateOfOrigin,
+        avatarUrl: user.avatarUrl,
+      },
+    };
+  }
+
+  @Patch('me/profile')
+  @ApiOperation({ summary: "Update the logged-in admin's own user profile" })
+  @ApiResponse({ status: 200, description: 'Profile updated successfully' })
+  @UseInterceptors(ActivityLogInterceptor)
+  @LogActivity({
+    action: 'UPDATE_MY_PROFILE',
+    entityType: 'USER',
+    description: 'Admin updated their own profile',
+    category: 'ACCOUNT',
+  })
+  async updateMyProfile(
+    @GetCurrentUserId() userId: string,
+    @Body() dto: UpdateMyProfileDto,
+  ) {
+    const updated = await this.usersService.update(userId, dto);
+    return {
+      success: true,
+      message: 'Profile updated successfully',
+      data: {
+        id: updated.id,
+        firstName: updated.firstName,
+        lastName: updated.lastName,
+        email: updated.email,
+        phone: updated.phone,
+        gender: updated.gender,
+        dateOfBirth: updated.dateOfBirth,
+        stateOfOrigin: updated.stateOfOrigin,
+        avatarUrl: updated.avatarUrl,
+      },
+    };
+  }
 
   @Get('assessments-settings')
   @CheckPolicies(new ManageStudentPolicyHandler())

--- a/src/components/bff/admin/dto/update-my-profile.dto.ts
+++ b/src/components/bff/admin/dto/update-my-profile.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsMobilePhone,
+  IsDateString,
+  IsUrl,
+} from 'class-validator';
+
+enum Gender {
+  MALE = 'MALE',
+  FEMALE = 'FEMALE',
+}
+
+/**
+ * Self-edit DTO for the logged-in admin's own profile. Email is intentionally
+ * omitted — changing the login email needs an OTP verification flow we don't
+ * have yet. Password and role/system fields are also off-limits here so this
+ * endpoint can never be used to escalate or hijack an account.
+ */
+export class UpdateMyProfileDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @ApiProperty({ required: false, enum: Gender })
+  @IsOptional()
+  @IsEnum(Gender, { message: 'Gender must be either MALE or FEMALE' })
+  gender?: Gender;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsMobilePhone()
+  phone?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsDateString()
+  dateOfBirth?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  stateOfOrigin?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUrl()
+  avatarUrl?: string;
+}


### PR DESCRIPTION
…in (#151)

Lets the admin app edit the logged-in admin's own user record, and makes the User entity reachable at a single canonical path on every login response regardless of role.

- bff/admin/me/profile GET + PATCH on the admin BFF, gated by AccessTokenGuard. UpdateMyProfileDto is a slimmed UpdateUserDto without email/password/role fields so the endpoint can never escalate or hijack an account; email changes still need an OTP flow that hasn't shipped. Reuses UsersService.update for password/dateOfBirth normalization and emits an UPDATE_MY_PROFILE activity log.
- AuthResult.from now always populates data.user from the User row, in addition to the role-specific data.student / data.teacher entities. Previously data.user was only set on admin logins, so student/teacher clients had no canonical place to read firstName/avatarUrl/etc. — the mobile app's avatar caching depended on this.